### PR TITLE
feat(hatchery): add -k for insecure SSL

### DIFF
--- a/engine/hatchery/docker/cmd.go
+++ b/engine/hatchery/docker/cmd.go
@@ -39,6 +39,6 @@ $ hatchery docker --api=https://<api.domain> --token=<token>
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		hatcheryDocker.addhost = viper.GetString("docker-add-host")
-		hatchery.Born(hatcheryDocker, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"))
+		hatchery.Born(hatcheryDocker, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"), viper.GetBool("insecure"))
 	},
 }

--- a/engine/hatchery/local/cmd.go
+++ b/engine/hatchery/local/cmd.go
@@ -27,7 +27,7 @@ $ hatchery docker --api=https://<api.domain> --token=<token> --basedir=/tmp
 
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		hatchery.Born(hatcheryLocal, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"))
+		hatchery.Born(hatcheryLocal, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"), viper.GetBool("insecure"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if hatcheryLocal.basedir == "" {

--- a/engine/hatchery/main.go
+++ b/engine/hatchery/main.go
@@ -90,4 +90,8 @@ func addFlags() {
 
 	rootCmd.PersistentFlags().Int("max-worker", 10, "Maximum allowed simultaenous workers")
 	viper.BindPFlag("max-worker", rootCmd.PersistentFlags().Lookup("max-worker"))
+
+	rootCmd.PersistentFlags().BoolP("insecure", "k", false, `(SSL) This option explicitly allows hatchery to perform "insecure" SSL connections on CDS API.`)
+	viper.BindPFlag("insecure", rootCmd.PersistentFlags().Lookup("insecure"))
+
 }

--- a/engine/hatchery/mesos/cmd.go
+++ b/engine/hatchery/mesos/cmd.go
@@ -50,7 +50,7 @@ $ hatchery mesos --api=https://<api.domain> --token=<token>
 
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		hatchery.Born(hatcheryMesos, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"))
+		hatchery.Born(hatcheryMesos, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"), viper.GetBool("insecure"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		hatcheryMesos.token = viper.GetString("token")

--- a/engine/hatchery/openstack/cmd.go
+++ b/engine/hatchery/openstack/cmd.go
@@ -54,7 +54,7 @@ $ CDS_OPENSTACK_USER=<user> CDS_OPENSTACK_TENANT=<tenant> CDS_OPENSTACK_AUTH_END
 
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		hatchery.Born(hatcheryOpenStack, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"))
+		hatchery.Born(hatcheryOpenStack, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"), viper.GetBool("insecure"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		hatcheryOpenStack.tenant = viper.GetString("openstack-tenant")

--- a/engine/hatchery/swarm/cmd.go
+++ b/engine/hatchery/swarm/cmd.go
@@ -42,7 +42,7 @@ $ DOCKER_HOST="tcp://localhost:2375" hatchery swarm --api=https://<api.domain> -
 
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		hatchery.Born(hatcherySwarm, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"))
+		hatchery.Born(hatcherySwarm, viper.GetString("api"), viper.GetString("token"), viper.GetInt("provision"), viper.GetInt("request-api-timeout"), viper.GetBool("insecure"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		hatcherySwarm.onlyWithServiceReq = viper.GetBool("only-with-service-req")

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -1,6 +1,7 @@
 package hatchery
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,13 +31,15 @@ var (
 )
 
 // Born creates hatchery
-func Born(h Interface, api, token string, provision int, requestSecondsTimeout int) {
+func Born(h Interface, api, token string, provision int, requestSecondsTimeout int, insecureSkipVerifyTLS bool) {
 	Client = &http.Client{
 		Transport: &httpcontrol.Transport{
-			RequestTimeout: time.Duration(requestSecondsTimeout) * time.Second,
-			MaxTries:       5,
+			RequestTimeout:  time.Duration(requestSecondsTimeout) * time.Second,
+			MaxTries:        5,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerifyTLS},
 		},
 	}
+
 	sdk.SetHTTPClient(Client)
 	// No user / password, only token used for auth hatchery
 	sdk.Options(api, "", "", token)


### PR DESCRIPTION
This option explicitly allows hatchery to perform "insecure" SSL connections on CDS API.