### PR TITLE
feat (api): gops

### DIFF
--- a/engine/api/main.go
+++ b/engine/api/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/gops/agent"
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/spf13/cobra"
@@ -79,6 +80,10 @@ var mainCmd = &cobra.Command{
 
 		if err := mail.CheckMailConfiguration(); err != nil {
 			log.Fatalf("SMTP configuration error: %s\n", err)
+		}
+
+		if err := agent.Listen(nil); err != nil {
+			log.Critical("Cannot initialize agent listener for gops: %s\n", err)
 		}
 
 		var objectstoreKind objectstore.Kind

--- a/vendor/github.com/google/gops/LICENSE
+++ b/vendor/github.com/google/gops/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/gops/agent/agent.go
+++ b/vendor/github.com/google/gops/agent/agent.go
@@ -1,0 +1,237 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package agent provides hooks programs can register to retrieve
+// diagnostics data by using gops.
+package agent
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	gosignal "os/signal"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strconv"
+	"sync"
+	"time"
+
+	"bufio"
+
+	"github.com/google/gops/internal"
+	"github.com/google/gops/signal"
+	"github.com/kardianos/osext"
+)
+
+const defaultAddr = "127.0.0.1:0"
+
+var (
+	mu       sync.Mutex
+	portfile string
+	listener net.Listener
+
+	units = []string{" bytes", "KB", "MB", "GB", "TB", "PB"}
+)
+
+// Options allows configuring the started agent.
+type Options struct {
+	// Addr is the host:port the agent will be listening at.
+	// Optional.
+	Addr string
+
+	// NoShutdownCleanup tells the agent not to automatically cleanup
+	// resources if the running process recieves an interrupt.
+	// Optional.
+	NoShutdownCleanup bool
+}
+
+// Listen starts the gops agent on a host process. Once agent started, users
+// can use the advanced gops features. The agent will listen to Interrupt
+// signals and exit the process, if you need to perform further work on the
+// Interrupt signal use the options parameter to configure the agent
+// accordingly.
+//
+// Note: The agent exposes an endpoint via a TCP connection that can be used by
+// any program on the system. Review your security requirements before starting
+// the agent.
+func Listen(opts *Options) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if opts == nil {
+		opts = &Options{}
+	}
+	if portfile != "" {
+		return fmt.Errorf("gops: agent already listening at: %v", listener.Addr())
+	}
+
+	gopsdir, err := internal.ConfigDir()
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(gopsdir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	if !opts.NoShutdownCleanup {
+		gracefulShutdown()
+	}
+
+	addr := opts.Addr
+	if addr == "" {
+		addr = defaultAddr
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	listener = ln
+	port := listener.Addr().(*net.TCPAddr).Port
+	portfile = fmt.Sprintf("%s/%d", gopsdir, os.Getpid())
+	err = ioutil.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	go listen()
+	return nil
+}
+
+func listen() {
+	buf := make([]byte, 1)
+	for {
+		fd, err := listener.Accept()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			if netErr, ok := err.(net.Error); ok && !netErr.Temporary() {
+				break
+			}
+			continue
+		}
+		if _, err := fd.Read(buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		if err := handle(fd, buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		fd.Close()
+	}
+}
+
+func gracefulShutdown() {
+	c := make(chan os.Signal, 1)
+	gosignal.Notify(c, os.Interrupt)
+	go func() {
+		// cleanup the socket on shutdown.
+		<-c
+		Close()
+		os.Exit(1)
+	}()
+}
+
+// Close closes the agent, removing temporary files and closing the TCP listener.
+// If no agent is listening, Close does nothing.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile != "" {
+		os.Remove(portfile)
+		portfile = ""
+	}
+	if listener != nil {
+		listener.Close()
+	}
+}
+
+func formatBytes(val uint64) string {
+	var i int
+	var target uint64
+	for i = range units {
+		target = 1 << uint(10*(i+1))
+		if val < target {
+			break
+		}
+	}
+	if i > 0 {
+		return fmt.Sprintf("%0.2f%s (%d bytes)", float64(val)/(float64(target)/1024), units[i], val)
+	}
+	return fmt.Sprintf("%d bytes", val)
+}
+
+func handle(conn io.Writer, msg []byte) error {
+	switch msg[0] {
+	case signal.StackTrace:
+		return pprof.Lookup("goroutine").WriteTo(conn, 2)
+	case signal.GC:
+		runtime.GC()
+		_, err := conn.Write([]byte("ok"))
+		return err
+	case signal.MemStats:
+		var s runtime.MemStats
+		runtime.ReadMemStats(&s)
+		fmt.Fprintf(conn, "alloc: %v\n", formatBytes(s.Alloc))
+		fmt.Fprintf(conn, "total-alloc: %v\n", formatBytes(s.TotalAlloc))
+		fmt.Fprintf(conn, "sys: %v\n", formatBytes(s.Sys))
+		fmt.Fprintf(conn, "lookups: %v\n", s.Lookups)
+		fmt.Fprintf(conn, "mallocs: %v\n", s.Mallocs)
+		fmt.Fprintf(conn, "frees: %v\n", s.Frees)
+		fmt.Fprintf(conn, "heap-alloc: %v\n", formatBytes(s.HeapAlloc))
+		fmt.Fprintf(conn, "heap-sys: %v\n", formatBytes(s.HeapSys))
+		fmt.Fprintf(conn, "heap-idle: %v\n", formatBytes(s.HeapIdle))
+		fmt.Fprintf(conn, "heap-in-use: %v\n", formatBytes(s.HeapInuse))
+		fmt.Fprintf(conn, "heap-released: %v\n", formatBytes(s.HeapReleased))
+		fmt.Fprintf(conn, "heap-objects: %v\n", s.HeapObjects)
+		fmt.Fprintf(conn, "stack-in-use: %v\n", formatBytes(s.StackInuse))
+		fmt.Fprintf(conn, "stack-sys: %v\n", formatBytes(s.StackSys))
+		fmt.Fprintf(conn, "next-gc: when heap-alloc >= %v\n", formatBytes(s.NextGC))
+		lastGC := "-"
+		if s.LastGC != 0 {
+			lastGC = fmt.Sprint(time.Unix(0, int64(s.LastGC)))
+		}
+		fmt.Fprintf(conn, "last-gc: %v\n", lastGC)
+		fmt.Fprintf(conn, "gc-pause: %v\n", time.Duration(s.PauseTotalNs))
+		fmt.Fprintf(conn, "num-gc: %v\n", s.NumGC)
+		fmt.Fprintf(conn, "enable-gc: %v\n", s.EnableGC)
+		fmt.Fprintf(conn, "debug-gc: %v\n", s.DebugGC)
+	case signal.Version:
+		fmt.Fprintf(conn, "%v\n", runtime.Version())
+	case signal.HeapProfile:
+		pprof.WriteHeapProfile(conn)
+	case signal.CPUProfile:
+		if err := pprof.StartCPUProfile(conn); err != nil {
+			return err
+		}
+		time.Sleep(30 * time.Second)
+		pprof.StopCPUProfile()
+	case signal.Stats:
+		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
+		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
+		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
+		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
+	case signal.BinaryDump:
+		path, err := osext.Executable()
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = bufio.NewReader(f).WriteTo(conn)
+		return err
+	case signal.Trace:
+		trace.Start(conn)
+		time.Sleep(5 * time.Second)
+		trace.Stop()
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -337,6 +337,12 @@
 			"revisionTime": "2017-01-11T10:11:55Z"
 		},
 		{
+			"checksumSHA1": "VMPjzdEjS4TvwM41fcWr5dnb4Eo=",
+			"path": "github.com/google/gops/agent",
+			"revision": "e1d23454034a34648ae16bce17e428ae38ddc1d8",
+			"revisionTime": "2017-03-02T19:52:43Z"
+		},
+		{
 			"checksumSHA1": "5DBIm/bJOKLR3CbQH6wIELQDLlQ=",
 			"path": "github.com/gorhill/cronexpr",
 			"revision": "d520615e531a6bf3fb69406b9eba718261285ec8",


### PR DESCRIPTION
```bash
➜  cds git:(gops) gops stats 73347
goroutines: 170
OS threads: 11
GOMAXPROCS: 4
num CPU: 4
```

```bash
➜  cds git:(gops) gops memstats 73347
alloc: 9.91MB (10396256 bytes)
total-alloc: 548.46MB (575098264 bytes)
sys: 18.36MB (19249400 bytes)
lookups: 1287
mallocs: 748961
frees: 707521
heap-alloc: 9.91MB (10396256 bytes)
heap-sys: 13.88MB (14548992 bytes)
heap-idle: 2.09MB (2195456 bytes)
heap-in-use: 11.78MB (12353536 bytes)
heap-released: 0 bytes
heap-objects: 41440
stack-in-use: 1.12MB (1179648 bytes)
stack-sys: 1.12MB (1179648 bytes)
next-gc: when heap-alloc >= 11.48MB (12042672 bytes)
last-gc: 2017-03-04 14:45:27.63627105 +0100 CET
gc-pause: 8.761893ms
num-gc: 127
enable-gc: true
debug-gc: false
```

```bash
➜  cds git:(gops) gops -h
gops: missing PID or address
Usage: gops is a tool to list and diagnose Go processes.


Commands:
    stack       Prints the stack trace.
    gc          Runs the garbage collector and blocks until successful.
    memstats    Prints the allocation and garbage collection stats.
    version     Prints the Go version used to build the program.
    stats       Prints the vital runtime stats.
    help        Prints this help text.

Profiling commands:
    trace       Runs the runtime tracer for 5 secs and launches "go tool trace".
    pprof-heap  Reads the heap profile and launches "go tool pprof".
    pprof-cpu   Reads the CPU profile and launches "go tool pprof".
```
could be usefull ?

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>