### PR TITLE
feat (contrib/actions): Add proveOptions parameter to CDS_PerlTest

### DIFF
--- a/contrib/actions/cds-perl-test.hcl
+++ b/contrib/actions/cds-perl-test.hcl
@@ -22,8 +22,13 @@ requirements = {
 parameters = {
 	 "testDirectory" = {
 		type = "string"
-		description = "Directory where is Perl Source Code"
+		description = "Directory in which prove will be launched"
 		value = "./src"
+	}
+	 "proveOptions" = {
+		type = "string"
+		description = "Options passed to prove"
+		value = "-r --timer"
 	}
 }
 
@@ -36,7 +41,7 @@ set -e
 
 cd {{.testDirectory}}
 mkdir -p results
-prove -r --timer --formatter=TAP::Formatter::JUnit > results/resultsUnitsTests.xml
+prove --formatter=TAP::Formatter::JUnit {{.proveOptions}} > results/resultsUnitsTests.xml
 
 EOF
 	}, {


### PR DESCRIPTION
Allow to execute prove outside the tests directory, and so test
several ones at once. In case of classic hierarchy lib/, t/, xt/
proveOptions could be set to:
   --timer -lr t xt
while testDirectory is the root directory of the module.