### PR TITLE
feat (plugin): allow using cds.build.var in a plugin

### DIFF
--- a/contrib/plugins/plugin-venom/venom.go
+++ b/contrib/plugins/plugin-venom/venom.go
@@ -51,6 +51,15 @@ func (s VenomPlugin) Parameters() plugin.Parameters {
 	return params
 }
 
+type venomWriter struct {
+	plugin.IJob
+}
+
+func (w venomWriter) Write(buf []byte) (int, error) {
+	err := plugin.SendLog(w, "VENOM %s", buf)
+	return 0, err
+}
+
 // Run execute the action
 func (s VenomPlugin) Run(a plugin.IJob) plugin.Result {
 	// Parse parameters
@@ -66,7 +75,7 @@ func (s VenomPlugin) Run(a plugin.IJob) plugin.Result {
 	}
 	p, err := strconv.Atoi(parallel)
 	if err != nil {
-		plugin.SendLog(a, "PLUGIN", "parallel arg must be an integer.")
+		plugin.SendLog(a, "VENOM - parallel arg must be an integer\n")
 		return plugin.Fail
 	}
 
@@ -87,9 +96,10 @@ func (s VenomPlugin) Run(a plugin.IJob) plugin.Result {
 	}
 
 	start := time.Now()
-	tests, err := venom.Process([]string{path}, a.Arguments().Data, []string{exclude}, p, loglevel, details)
+	w := venomWriter{a}
+	tests, err := venom.Process([]string{path}, a.Arguments().Data, []string{exclude}, p, loglevel, details, w)
 	if err != nil {
-		plugin.SendLog(a, "PLUGIN", "Fail on venom: %s", err)
+		plugin.SendLog(a, "VENOM - Fail on venom: %s\n", err)
 		return plugin.Fail
 	}
 

--- a/engine/worker/builtin.go
+++ b/engine/worker/builtin.go
@@ -76,6 +76,9 @@ func (w *currentWorker) runPlugin(ctx context.Context, a *sdk.Action, pbJob sdk.
 		for _, p := range pbJob.Parameters {
 			pluginArgs.Data[p.Name] = p.Value
 		}
+		for _, v := range w.currentJob.buildVariables {
+			pluginArgs.Data["cds.build."+v.Name] = v.Value
+		}
 
 		//Call the Run function on the plugin interface
 		pluginAction := plugin.Job{


### PR DESCRIPTION
This is used by plugin-venom
+ use io.writer on plugin-venom to see venom output on cds logs

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>