### PR TITLE
doc: fix go get command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -5,7 +5,7 @@
 ### From sources
 
 ```bash
- $ go get github.com/ovh/cds
+ $ go get github.com/ovh/cds/cli
  $ go install github.com/ovh/cds/cli/cds
 ```
 


### PR DESCRIPTION
We cannot run `go get` with the root cds project URL.

```
go get github.com/ovh/cds
can't load package: package github.com/ovh/cds: no buildable Go source files in /Users/user/work/dev/go/src/github.com/ovh/cds
```

This is fixed with running `go get github.com/ovh/cds/cli` instead.