### PR TITLE
test: it tests on all branches

### DIFF
--- a/cli/cds/login/login.go
+++ b/cli/cds/login/login.go
@@ -45,7 +45,8 @@ var CmdSignup = &cobra.Command{
 	},
 }
 
-type config struct {
+// Config contains config file structure
+type Config struct {
 	User     string `json:"user"`
 	Password string `json:"password,omitempty"`
 	Token    string `json:"token,omitempty"`
@@ -53,7 +54,7 @@ type config struct {
 }
 
 func runSignup() {
-	conf := config{}
+	conf := Config{}
 
 	//Take the endpoint from flags or ask for on command line
 	if defaultEndPoint == "" {
@@ -83,6 +84,9 @@ func runSignup() {
 	fmt.Println("Please check your email to activate your account...")
 	fmt.Printf("And type your verification code: ")
 	b, err := gopass.GetPasswd()
+	if err != nil {
+		sdk.Exit("%v", err)
+	}
 	token := string(b)
 
 	u, err := sdk.VerifyUser(conf.User, token)
@@ -94,7 +98,7 @@ func runSignup() {
 	runLogin(&conf)
 }
 
-func runLogin(conf *config) {
+func runLogin(conf *Config) {
 	if conf == nil {
 		//Check if file exists
 		if _, err := os.Stat(sdk.CDSConfigFile); err == nil {
@@ -106,7 +110,7 @@ func runLogin(conf *config) {
 			}
 		}
 
-		conf = &config{}
+		conf = &Config{}
 
 		//Take the endpoint from flags or ask for on command line
 		if defaultEndPoint == "" {

--- a/cli/cds/user/verify.go
+++ b/cli/cds/user/verify.go
@@ -7,22 +7,16 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ovh/cds/cli/cds/login"
 	"github.com/ovh/cds/sdk"
 	"os"
 	"path"
 )
 
-type configFile struct {
-	User     string `json:"user"`
-	Password string `json:"password"`
-	Host     string `json:"host"`
-}
-
 func cmdUserVerify() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "cds user verify <username> <token>",
-		Long:  ``,
 		Run:   verifyUser,
 	}
 
@@ -36,27 +30,27 @@ func verifyUser(cmd *cobra.Command, args []string) {
 	name := args[0]
 	token := args[1]
 
-	userData, err := sdk.VerifyUser(name, token)
-	if err != nil {
-		sdk.Exit("%s\n", err)
+	userData, errv := sdk.VerifyUser(name, token)
+	if errv != nil {
+		sdk.Exit("%s\n", errv)
 	}
 
-	userDataString, err := json.MarshalIndent(userData, " ", " ")
-	if err != nil {
-		fmt.Printf("VerifyUser: Cannot marshal userData: %s\n", err)
-		sdk.Exit("%s\n", err)
+	userDataString, errm := json.MarshalIndent(userData, " ", " ")
+	if errm != nil {
+		fmt.Printf("VerifyUser: Cannot marshal userData: %s\n", errm)
+		sdk.Exit("%s\n", errm)
 	}
 	fmt.Printf("Account informations : %s\n", userDataString)
 
-	fileContent := &configFile{
-		User:     userData.User.Username,
-		Password: userData.Password,
-		Host:     sdk.Host,
+	fileContent := &login.Config{
+		User:  userData.User.Username,
+		Token: userData.Token,
+		Host:  sdk.Host,
 	}
 
-	jsonStr, err := json.MarshalIndent(fileContent, "", "  ")
-	if err != nil {
-		sdk.Exit("%s\n", err)
+	jsonStr, errm := json.MarshalIndent(fileContent, "", "  ")
+	if errm != nil {
+		sdk.Exit("%s\n", errm)
 	}
 	jsonStr = append(jsonStr, '\n')
 
@@ -67,8 +61,8 @@ func verifyUser(cmd *cobra.Command, args []string) {
 			sdk.Exit("%s\n", err)
 		}
 	}
-	err = ioutil.WriteFile(sdk.CDSConfigFile, jsonStr, 0600)
-	if err != nil {
+
+	if err := ioutil.WriteFile(sdk.CDSConfigFile, jsonStr, 0600); err != nil {
 		sdk.Exit("%s\n", err)
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     environment:
       CDS_TOKEN: changeitchangeitchangeitchangeitchangeitchangeitchangeitchangeit
       CDS_API: http://cds-api:8081
+      CDS_PROVISION: 1
     links:
        - cds-api
 

--- a/tests/sc_join_action.yml
+++ b/tests/sc_join_action.yml
@@ -6,23 +6,23 @@ testcases:
   - script: {{.cds.build.cds}} project add ITSCJA ITSCJA ITSCJA
   - script: {{.cds.build.cds}} application add ITSCJA TestApp
   - script: {{.cds.build.cds}} action remove ITSCJA_GitClone --force
-  - script: {{.cds.build.cds}} action remove ITSCJA_GoGet --force
-  - script: {{.cds.build.cds}} action remove ITSCJA_GoTest --force
+  - script: {{.cds.build.cds}} action remove ITSCJA_EchoA --force
+  - script: {{.cds.build.cds}} action remove ITSCJA_EchoB --force
 
 - name : test joined action
   steps:
   - script: {{.cds.build.cds}} pipeline add ITSCJA JA_Pipeline
   - script: {{.cds.build.cds}} action add ITSCJA_GitClone -r git -p gitURL -p gitTarget
   - script: {{.cds.build.cds}} action add step ITSCJA_GitClone Script -p script="git --version; echo Cloning {{.gitURL}} in {{.gitTarget}}; echo toto={{.toto}}"
-  - script: {{.cds.build.cds}} action add ITSCJA_GoGet -r go -p goGetTarget
-  - script: {{.cds.build.cds}} action add step ITSCJA_GoGet Script -p script="go version; echo {{.goGetTarget}}; echo toto={{.toto}}"
-  - script: {{.cds.build.cds}} action add ITSCJA_GoTest -r go -p goTestTarget
-  - script: {{.cds.build.cds}} action add step ITSCJA_GoTest Script -p script="go version; echo {{.goTestTarget}}; echo toto={{.toto}}"
+  - script: {{.cds.build.cds}} action add ITSCJA_EchoA -p goGetTarget
+  - script: {{.cds.build.cds}} action add step ITSCJA_EchoA Script -p script="echo {{.goGetTarget}}; echo toto={{.toto}}"
+  - script: {{.cds.build.cds}} action add ITSCJA_EchoB -p goTestTarget
+  - script: {{.cds.build.cds}} action add step ITSCJA_EchoB Script -p script="echo {{.goTestTarget}}; echo toto={{.toto}}"
 
   - script: {{.cds.build.cds}} pipeline job add ITSCJA JA_Pipeline TestFoo
   - script: {{.cds.build.cds}} pipeline job append ITSCJA JA_Pipeline TestFoo ITSCJA_GitClone -p gitURL="ssh://foo@bar.com" -p gitTarget="./src/foo@bar.com/test"
-  - script: {{.cds.build.cds}} pipeline job append ITSCJA JA_Pipeline TestFoo ITSCJA_GoGet -p goGetTarget="./..."
-  - script: {{.cds.build.cds}} pipeline job append ITSCJA JA_Pipeline TestFoo ITSCJA_GoTest -p goTestTarget="./..."
+  - script: {{.cds.build.cds}} pipeline job append ITSCJA JA_Pipeline TestFoo ITSCJA_EchoA -p goGetTarget="./..."
+  - script: {{.cds.build.cds}} pipeline job append ITSCJA JA_Pipeline TestFoo ITSCJA_EchoB -p goTestTarget="./..."
   - script: {{.cds.build.cds}} pipeline show ITSCJA JA_Pipeline
 
 - name : joined action run
@@ -36,6 +36,6 @@ testcases:
   - script: {{.cds.build.cds}} pipeline delete ITSCJA JA_Pipeline
   - script: {{.cds.build.cds}} project remove --force ITSCJA
   - script: {{.cds.build.cds}} action remove ITSCJA_GitClone
-  - script: {{.cds.build.cds}} action remove ITSCJA_GoGet
-  - script: {{.cds.build.cds}} action remove ITSCJA_GoTest
+  - script: {{.cds.build.cds}} action remove ITSCJA_EchoA
+  - script: {{.cds.build.cds}} action remove ITSCJA_EchoB
   - script: {{.cds.build.cds}} group remove ITSCJA


### PR DESCRIPTION
This PR:
- fix cds user verify to use same config file as cds signup (and use token instead of password). #796  to allow session mode only.
- Remove a go pre-requisite for a test -> no need to put go inside docker image hatchery-local to run test (go was not usefull for the test too)
- set default Provision to 1 on hatchery local
