### PR TITLE
fix (migration): avoid panic, display error when unwanted record present

### DIFF
--- a/engine/api/database/cli.go
+++ b/engine/api/database/cli.go
@@ -130,6 +130,10 @@ func statusCmdFunc(cmd *cobra.Command, args []string) {
 	}
 
 	for _, r := range records {
+		if _, ok := rows[r.Id]; !ok {
+			fmt.Printf("Record '%s' not in migration list, manual migration needed\n", r.Id)
+			continue
+		}
 		rows[r.Id].Migrated = true
 		rows[r.Id].AppliedAt = r.AppliedAt
 	}


### PR DESCRIPTION
Sample output:

```
$ api database status --db-password cds
Record '001_gorp_migrations_lock.sql' not in migration list, manual migration needed
Record '002_template.sql' not in migration list, manual migration needed
Record '003_worker_model-permissions.sql' not in migration list, manual migration needed
Record '004_clean_worker_model.sql' not in migration list, manual migration needed
|              MIGRATION              | APPLIED |
|-------------------------------------|---------|
| 000_create_all.sql                  | no      |
| 001_event.sql                       | no      |
| 002_pipeline_build.sql              | no      |
| 003_build_log.sql                   | no      |
| 004_scheduler_timezone.sql          | no      |
| 005_pollers.sql                     | no      |
| 006_worker.sql                      | no      |
| 007_project_metadata.sql            | no      |
| 008_pipeline_build_unique_index.sql | no      |
| 009_application_metadata.sql        | no      |
| 010_audit.sql                       | no      |
| 011_spawninfos.sql                  | no      |
| 012_pipelinebuild_commits.sql       | no      |
| 013_fix_detach_pipeline.sql         | no      |
| 014_workflows.sql                   | no      |
| 015_workflows_join.sql              | no      |
| 016_workflows_context.sql           | no      |
| 017_worker_hatchery.sql             | no      |
| 018_worker_model.sql                | no      |
| 019_worker_model.sql                | no      |
| 020_workflow_constraint.sql         | no      |
| 021_workflow_constraint.sql         | no      |
| 022_workflows_run.sql               | no      |
| 023_workflows_artifacts.sql         | no      |
| 024_workflows_artifacts.sql         | no      |
| 025_workflows_run.sql               | no      |
| 026_workflows_runs.sql              | no      |
```