### PR TITLE
fix (hatchery/openstack): force get worker

### DIFF
--- a/engine/hatchery/openstack/spawn.go
+++ b/engine/hatchery/openstack/spawn.go
@@ -82,6 +82,7 @@ func (h *HatcheryCloud) SpawnWorker(model *sdk.Model, job *sdk.PipelineBuildJob,
 	udataEnd := `
 cd $HOME
 # Download and start worker with curl
+rm -f worker
 curl  "{{.API}}/download/worker/$(uname -m)" -o worker --retry 10 --retry-max-time 120 -C - >> /tmp/user_data 2>&1
 chmod +x worker
 export CDS_SINGLE_USE=1


### PR DESCRIPTION
usefull with -C - on spawn with snapshot

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>