### PR TITLE
fix (api): cds pipeline import existing stages

### DIFF
--- a/engine/api/pipeline/pipeline_importer.go
+++ b/engine/api/pipeline/pipeline_importer.go
@@ -149,7 +149,7 @@ func ImportUpdate(db gorp.SqlExecutor, proj *sdk.Project, pip *sdk.Pipeline, msg
 				//Insert the job
 				j.PipelineStageID = oldStage.ID
 				j.Action.Type = sdk.JoinedAction
-				log.Debug(">> Creating job %s on stage %s on pipeline %s stageID:", j.Action.Name, s.Name, pip.Name, oldStage.ID)
+				log.Debug(">> Creating job %s on stage %s on pipeline %s stageID: %d", j.Action.Name, s.Name, pip.Name, oldStage.ID)
 				if err := InsertJob(db, j, oldStage.ID, pip); err != nil {
 					return sdk.WrapError(err, "ImportUpdate> Unable to insert job %s in %s", j.Action.Name, pip.Name)
 				}

--- a/engine/api/pipeline_import.go
+++ b/engine/api/pipeline_import.go
@@ -58,8 +58,7 @@ func importPipelineHandler(w http.ResponseWriter, r *http.Request, db *gorp.DbMa
 	}
 
 	if errorParse != nil {
-		log.Warning("importNewEnvironmentHandler> Cannot parsing: %s\n", errorParse)
-		return sdk.ErrWrongRequest
+		return sdk.WrapError(sdk.ErrWrongRequest, "importNewEnvironmentHandler> Cannot parsing: %s", errorParse)
 	}
 
 	// Check if pipeline exists
@@ -101,7 +100,6 @@ func importPipelineHandler(w http.ResponseWriter, r *http.Request, db *gorp.DbMa
 
 	tx, errBegin := db.Begin()
 	if errBegin != nil {
-		log.Warning("importPipelineHandler: Cannot start transaction: %s\n", errBegin)
 		return sdk.WrapError(errBegin, "importPipelineHandler: Cannot start transaction")
 	}
 

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -206,7 +206,7 @@ var errorsAmericanEnglish = map[int]string{
 	ErrEnvironmentCannotBeDeleted.ID:            "Environment cannot be deleted. It is still in used",
 	ErrInvalidPipeline.ID:                       "Invalid pipeline",
 	ErrKeyNotFound.ID:                           "Key not found",
-	ErrPipelineAlreadyExists.ID:                 "Pipeline already exist",
+	ErrPipelineAlreadyExists.ID:                 "Pipeline already exists",
 	ErrJobAlreadyBooked.ID:                      "Job already booked",
 	ErrPipelineBuildNotFound.ID:                 "Pipeline build not found",
 	ErrAlreadyTaken.ID:                          "This job is already taken by another worker",

--- a/sdk/messages.go
+++ b/sdk/messages.go
@@ -45,6 +45,9 @@ var (
 	MsgPipelineGroupAdded                  = &Message{"MsgPipelineGroupAdded", trad{FR: "Les permissions du groupe %s sur le pipeline %s on été ajoutées", EN: "Permission for group %s on pipeline %s has been added"}, nil}
 	MsgPipelineGroupDeleted                = &Message{"MsgPipelineGroupDeleted", trad{FR: "Les permissions du groupe %s sur le pipeline %s on été supprimées", EN: "Permission for group %s on pipeline %s has been deleted"}, nil}
 	MsgPipelineStageUpdated                = &Message{"MsgPipelineStageUpdated", trad{FR: "Le stage %s a été mis à jour", EN: "Stage %s updated"}, nil}
+	MsgPipelineStageUpdating               = &Message{"MsgPipelineStageUpdating", trad{FR: "Mise à jour du stage %s en cours...", EN: "Updating stage %s ..."}, nil}
+	MsgPipelineStageDeletingOldJobs        = &Message{"MsgPipelineStageDeletingOldJobs", trad{FR: "Suppression des anciens jobs du stage %s en cours...", EN: "Deleting old jobs in stage %s ..."}, nil}
+	MsgPipelineStageInsertingNewJobs       = &Message{"MsgPipelineStageInsertingNewJobs", trad{FR: "Insertion des nouveaux jobs dans le stage %s en cours...", EN: "Inserting new jobs in stage %s ..."}, nil}
 	MsgPipelineStageAdded                  = &Message{"MsgPipelineStageAdded", trad{FR: "Le stage %s a été ajouté", EN: "Stage %s added"}, nil}
 	MsgPipelineStageDeleted                = &Message{"MsgPipelineStageDeleted", trad{FR: "Le stage %s a été supprimé", EN: "Stage %s deleted"}, nil}
 	MsgPipelineJobUpdated                  = &Message{"MsgPipelineJobUpdated", trad{FR: "Le job %s du stage %s a été mis à jour", EN: "Job %s in stage %s updated"}, nil}


### PR DESCRIPTION
remove all job before insert job from yml (if stage already exist)
use oldStage.ID to insertJob, this avoid create a new stage if the current stage already exists

close #923

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>