### PR TITLE
fix (api): goroutine on sanity

### DIFF
--- a/engine/api/application.go
+++ b/engine/api/application.go
@@ -651,15 +651,16 @@ func updateApplicationHandler(w http.ResponseWriter, r *http.Request, db *gorp.D
 		return err
 	}
 
-	if err := sanity.CheckApplication(tx, p, app); err != nil {
-		log.Warning("updateApplicationHandler: Cannot check application sanity: %s\n", err)
-		return err
-	}
-
 	if err := tx.Commit(); err != nil {
 		log.Warning("updateApplicationHandler> Cannot commit transaction: %s\n", err)
 		return err
 	}
+
+	go func() {
+		if err := sanity.CheckApplication(db, p, app); err != nil {
+			log.Warning("updateApplicationHandler: Cannot check application sanity: %s", err)
+		}
+	}()
 
 	cache.DeleteAll(cache.Key("application", projectKey, "*"))
 	cache.DeleteAll(cache.Key("pipeline", projectKey, "*"))

--- a/engine/api/application_variable.go
+++ b/engine/api/application_variable.go
@@ -103,10 +103,11 @@ func restoreAuditHandler(w http.ResponseWriter, r *http.Request, db *gorp.DbMap,
 		return err
 	}
 
-	if err := sanity.CheckApplication(tx, p, app); err != nil {
-		log.Warning("restoreAuditHandler: Cannot check application sanity: %s\n", err)
-		return err
-	}
+	go func() {
+		if err := sanity.CheckApplication(tx, p, app); err != nil {
+			log.Warning("restoreAuditHandler: Cannot check application sanity: %s")
+		}
+	}()
 
 	cache.DeleteAll(cache.Key("application", key, "*"+appName+"*"))
 	return nil
@@ -204,9 +205,11 @@ func deleteVariableFromApplicationHandler(w http.ResponseWriter, r *http.Request
 		return sdk.WrapError(err, "deleteVariableFromApplicationHandler: Cannot delete %s", varName)
 	}
 
-	if err := sanity.CheckApplication(tx, p, app); err != nil {
-		return sdk.WrapError(err, "restoreAuditHandler: Cannot check application sanity")
-	}
+	go func() {
+		if err := sanity.CheckApplication(tx, p, app); err != nil {
+			log.Warning("restoreAuditHandler: Cannot check application sanity: %s", err)
+		}
+	}()
 
 	if err := tx.Commit(); err != nil {
 		return sdk.WrapError(err, "deleteVariableFromApplicationHandler: Cannot commit transaction")
@@ -317,10 +320,11 @@ func updateVariablesInApplicationHandler(w http.ResponseWriter, r *http.Request,
 		return err
 	}
 
-	if err := sanity.CheckApplication(db, p, app); err != nil {
-		log.Warning("updateVariableInApplicationHandler: Cannot check application sanity: %s\n", err)
-		return err
-	}
+	go func() {
+		if err := sanity.CheckApplication(db, p, app); err != nil {
+			log.Warning("updateVariableInApplicationHandler: Cannot check application sanity: %s", err)
+		}
+	}()
 
 	cache.DeleteAll(cache.Key("application", key, "*"+appName+"*"))
 	return nil
@@ -373,9 +377,11 @@ func updateVariableInApplicationHandler(w http.ResponseWriter, r *http.Request, 
 		return sdk.WrapError(err, "updateVariableInApplicationHandler: Cannot load variables")
 	}
 
-	if err := sanity.CheckApplication(db, p, app); err != nil {
-		return sdk.WrapError(err, "updateVariableInApplicationHandler: Cannot check application sanity")
-	}
+	go func() {
+		if err := sanity.CheckApplication(db, p, app); err != nil {
+			log.Warning("updateVariableInApplicationHandler: Cannot check application sanity: %s", err)
+		}
+	}()
 
 	cache.DeleteAll(cache.Key("application", key, "*"+appName+"*"))
 
@@ -445,10 +451,11 @@ func addVariableInApplicationHandler(w http.ResponseWriter, r *http.Request, db 
 		return err
 	}
 
-	if err := sanity.CheckApplication(db, p, app); err != nil {
-		log.Warning("addVariableInApplicationHandler: Cannot check application sanity: %s\n", err)
-		return err
-	}
+	go func() {
+		if err := sanity.CheckApplication(db, p, app); err != nil {
+			log.Warning("addVariableInApplicationHandler: Cannot check application sanity: %s", err)
+		}
+	}()
 
 	cache.DeleteAll(cache.Key("application", key, "*"+appName+"*"))
 

--- a/engine/api/environment.go
+++ b/engine/api/environment.go
@@ -211,10 +211,11 @@ func updateEnvironmentsHandler(w http.ResponseWriter, r *http.Request, db *gorp.
 		return err
 	}
 
-	if err := sanity.CheckProjectPipelines(db, proj); err != nil {
-		log.Warning("updateVariablesInApplicationHandler: Cannot check warnings: %s\n", err)
-		return err
-	}
+	go func() {
+		if err := sanity.CheckProjectPipelines(db, proj); err != nil {
+			log.Warning("updateVariablesInApplicationHandler: Cannot check warnings: %s", err)
+		}
+	}()
 
 	return WriteJSON(w, r, proj, http.StatusOK)
 }

--- a/engine/api/project_variable.go
+++ b/engine/api/project_variable.go
@@ -95,10 +95,11 @@ func restoreProjectVariableAuditHandler(w http.ResponseWriter, r *http.Request, 
 		return err
 	}
 
-	if err := sanity.CheckProjectPipelines(db, p); err != nil {
-		log.Warning("restoreProjectVariableAuditHandler: Cannot check warnings: %s\n", err)
-		return err
-	}
+	go func() {
+		if err := sanity.CheckProjectPipelines(db, p); err != nil {
+			log.Warning("restoreProjectVariableAuditHandler: Cannot check warnings: %s", err)
+		}
+	}()
 
 	return nil
 }
@@ -261,11 +262,11 @@ func updateVariablesInProjectHandler(w http.ResponseWriter, r *http.Request, db 
 
 	}
 
-	if err := sanity.CheckProjectPipelines(db, p); err != nil {
-		log.Warning("updateVariablesInApplicationHandler: Cannot check warnings: %s\n", err)
-		return err
-
-	}
+	go func() {
+		if err := sanity.CheckProjectPipelines(db, p); err != nil {
+			log.Warning("updateVariablesInApplicationHandler: Cannot check warnings: %s")
+		}
+	}()
 
 	return nil
 }
@@ -316,11 +317,12 @@ func updateVariableInProjectHandler(w http.ResponseWriter, r *http.Request, db *
 
 	}
 
-	if err := sanity.CheckProjectPipelines(db, p); err != nil {
-		log.Warning("updateVariableInProject: Cannot check warnings: %s\n", err)
-		return err
+	go func() {
+		if err := sanity.CheckProjectPipelines(db, p); err != nil {
+			log.Warning("updateVariableInProject: Cannot check warnings: %s", err)
+		}
+	}()
 
-	}
 	return WriteJSON(w, r, newVar, http.StatusOK)
 }
 
@@ -410,12 +412,11 @@ func addVariableInProjectHandler(w http.ResponseWriter, r *http.Request, db *gor
 		return err
 	}
 
-	err = sanity.CheckProjectPipelines(db, p)
-	if err != nil {
-		log.Warning("AddVariableInProject: Cannot check warnings: %s\n", err)
-		return err
-
-	}
+	go func() {
+		if err := sanity.CheckProjectPipelines(db, p); err != nil {
+			log.Warning("AddVariableInProject: Cannot check warnings: %s", err)
+		}
+	}()
 
 	p.Variable, err = project.GetAllVariableInProject(db, p.ID)
 	if err != nil {


### PR DESCRIPTION
Sanity are too slow, really too slow on project with many apps / env.
Compute Warnings need to be refacto to be more precise, fastest without force user (with > 30 apps) to wait more dans 30" en each action on UI.
This commit in only to make UI faster, especially since the new UI get warnings async now.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>