### PR TITLE
fix (api): panic cache local

### DIFF
--- a/engine/api/cache/local.go
+++ b/engine/api/cache/local.go
@@ -148,8 +148,10 @@ func (s *LocalStore) DequeueWithContext(c context.Context, queueName string, val
 	log.Debug("[%p] DequeueWithContext from %s", s, queueName)
 	l := s.Queues[queueName]
 	if l == nil {
+		s.mutex.Lock()
 		s.Queues[queueName] = &list.List{}
 		l = s.Queues[queueName]
+		s.mutex.Unlock()
 	}
 
 	elemChan := make(chan *list.Element)


### PR DESCRIPTION
This avoid:

fatal error: concurrent map writes

goroutine 20 [running]:
runtime.throw(0x2419962, 0x15)
/.../go/src/runtime/panic.go:605 +0x95 fp=0xc420101828 sp=0xc420101808 pc=0x102d1a5
runtime.mapassign_faststr(0x2111e80, 0xc42019a330, 0x24000f4, 0x6, 0x3087120)
/.../go/src/runtime/hashmap_fast.go:607 +0x4f5 fp=0xc4201018a8 sp=0xc420101828 pc=0x100eb35
github.com/ovh/cds/engine/api/cache.(*LocalStore).Enqueue(0xc4201a0800, 0x24000f4, 0x6, 0x2316e40, 0xc420358a20)
/.../src/github.com/ovh/cds/engine/api/cache/local.go:92 +0x366 fp=0xc420101958 sp=0xc4201018a8 pc=0x1743766
github.com/ovh/cds/engine/api/event.Publish(0x2192180, 0xc4201ac150)
/.../src/github.com/ovh/cds/engine/api/event/publish.go:28 +0x23e fp=0xc420101ae8 sp=0xc420101958 pc=0x17dcb8e
github.com/ovh/cds/engine/api.(*API).Serve(0xc42037c700, 0x2ffeb00, 0xc4203d7a80, 0x0, 0x0)
/.../src/github.com/ovh/cds/engine/api/api.go:531 +0x1913 fp=0xc420101f58 sp=0xc420101ae8 pc=0x19b16a3
main.start(0x2ffeb00, 0xc4203d7a80, 0x2ffc580, 0xc42037c700, 0x23ba140, 0xc42037ca80)
/.../src/github.com/ovh/cds/engine/main.go:293 +0xda fp=0xc420101fb0 sp=0xc420101f58 pc=0x1ee058a
runtime.goexit()
/.../go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc420101fb8 sp=0xc420101fb0 pc=0x105b371
created by main.glob..func4
/.../src/github.com/ovh/cds/engine/main.go:271 +0x3b4

goroutine 51 [runnable]:
github.com/ovh/cds/engine/api/cache.(*LocalStore).DequeueWithContext(0xc4201a0800, 0x2ffeb00, 0xc4203d7a80, 0x24000f4, 0x6, 0x1fedca0, 0xc4204ee1e0)
/.../src/github.com/ovh/cds/engine/api/cache/local.go:152 +0x373
github.com/ovh/cds/engine/api/event.DequeueEvent(0x2ffeb00, 0xc4203d7a80)
/.../src/github.com/ovh/cds/engine/api/event/event.go:60 +0x194
created by github.com/ovh/cds/engine/api.(*API).Serve
/.../src/github.com/ovh/cds/engine/api/api.go:482 +0x1ec9

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>