### PR TITLE
fix (worker): do not hang on close

### DIFF
--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/gops/agent"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -96,6 +97,13 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 		w.alive = true
 		initViper(w)
+
+		if viper.GetString("log_level") == "debug" {
+			if err := agent.Listen(nil); err != nil {
+				sdk.Exit("Error on starting gops agent", err)
+			}
+		}
+
 		hostname, errh := os.Hostname() // no check of err here
 		if errh != nil {
 			hostname = fmt.Sprintf("error compute hostname: %s", errh)
@@ -167,6 +175,15 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 				log.Error("Queues polling stopped: %v", err)
 			}
 		}(ctx)
+
+		go func(errs chan error) {
+			for {
+				select {
+				case err := <-errs:
+					log.Error("%v", err)
+				}
+			}
+		}(errs)
 
 		// main loop
 		for {
@@ -292,12 +309,10 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 					log.Warning("takeJob> could not unregister: %s", err)
 				}
 
-			case err := <-errs:
-				log.Error("%v", err)
-
 			case <-registerTick.C:
 				w.doRegister()
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
this avoid this deadlock (with chan) on worker shutdown:
```
goroutine 10 [running]:
runtime/pprof.writeGoroutineStacks(0x4b02480, 0xc4201ba020, 0x0, 0x0)
    /Users/yesnault/go/src/runtime/pprof/pprof.go:608 +0xa7
runtime/pprof.writeGoroutine(0x4b02480, 0xc4201ba020, 0x2, 0x0, 0x0)
    /Users/yesnault/go/src/runtime/pprof/pprof.go:597 +0x44
runtime/pprof.(*Profile).WriteTo(0x4b54060, 0x4b02480, 0xc4201ba020, 0x2, 0x0, 0x0)
    /Users/yesnault/go/src/runtime/pprof/pprof.go:310 +0x3ab
github.com/ovh/cds/vendor/github.com/google/gops/agent.handle(0x4b02480, 0xc4201ba020, 0xc4201be02d, 0x1, 0x1, 0x0, 0x0)
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/google/gops/agent/agent.go:171 +0x1a3
github.com/ovh/cds/vendor/github.com/google/gops/agent.listen()
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/google/gops/agent/agent.go:119 +0x2c5
created by github.com/ovh/cds/vendor/github.com/google/gops/agent.Listen
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/google/gops/agent/agent.go:100 +0x457

goroutine 1 [chan send]:
main.mainCommandRun.func1(0xc42020c240, 0xc4201c62c0, 0x0, 0x4)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:271 +0x1655
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).execute(0xc42020c240, 0xc420010150, 0x4, 0x4, 0xc42020c240, 0xc420010150)
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:572 +0x234
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42020c240, 0xc42020cb40, 0xc42020c390, 0xc42015ff50)
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:658 +0x2fe
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42020c240, 0xc42015ff50, 0x1)
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:617 +0x2b
main.main()
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/main.go:66 +0x250

goroutine 5 [syscall]:
os/signal.signal_recv(0x0)
    /Users/yesnault/go/src/runtime/sigqueue.go:131 +0xa7
os/signal.loop()
    /Users/yesnault/go/src/os/signal/signal_unix.go:22 +0x22
created by os/signal.init.0
    /Users/yesnault/go/src/os/signal/signal_unix.go:28 +0x41

goroutine 8 [select, locked to thread]:
runtime.gopark(0x47b9130, 0x0, 0x4783d54, 0x6, 0x18, 0x1)
    /Users/yesnault/go/src/runtime/proc.go:277 +0x12c
runtime.selectgo(0xc42003af50, 0xc420020540)
    /Users/yesnault/go/src/runtime/select.go:395 +0x1138
runtime.ensureSigM.func1()
    /Users/yesnault/go/src/runtime/signal_unix.go:511 +0x1fe
runtime.goexit()
    /Users/yesnault/go/src/runtime/asm_amd64.s:2337 +0x1

goroutine 9 [chan receive]:
github.com/ovh/cds/vendor/github.com/google/gops/agent.gracefulShutdown.func1(0xc420060960)
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/google/gops/agent/agent.go:132 +0x34
created by github.com/ovh/cds/vendor/github.com/google/gops/agent.gracefulShutdown
    /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/google/gops/agent/agent.go:130 +0xb5

goroutine 11 [IO wait]:
internal/poll.runtime_pollWait(0x4f54eb0, 0x72, 0xffffffffffffffff)
    /Users/yesnault/go/src/runtime/netpoll.go:173 +0x57
internal/poll.(*pollDesc).wait(0xc420106598, 0x72, 0x0, 0x0, 0x0)
    /Users/yesnault/go/src/internal/poll/fd_poll_runtime.go:85 +0xae
internal/poll.(*pollDesc).waitRead(0xc420106598, 0xffffffffffffff00, 0x0, 0x0)
    /Users/yesnault/go/src/internal/poll/fd_poll_runtime.go:90 +0x3d
internal/poll.(*FD).Accept(0xc420106580, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /Users/yesnault/go/src/internal/poll/fd_unix.go:334 +0x1e2
net.(*netFD).accept(0xc420106580, 0xc42003be80, 0x4002d57, 0xc420294260)
    /Users/yesnault/go/src/net/fd_unix.go:238 +0x42
net.(*TCPListener).accept(0xc42000e990, 0x429d218, 0x405b080, 0xc42003bec8)
    /Users/yesnault/go/src/net/tcpsock_posix.go:136 +0x2e
net.(*TCPListener).Accept(0xc42000e990, 0x47b8ac8, 0xc4202941e0, 0x4b0a780, 0xc4201b2390)
    /Users/yesnault/go/src/net/tcpsock.go:247 +0x49
net/http.(*Server).Serve(0xc4202204e0, 0x4b09940, 0xc42000e990, 0x0, 0x0)
    /Users/yesnault/go/src/net/http/server.go:2695 +0x1b2
main.(*currentWorker).serve.func1(0xc4202204e0, 0x4b09940, 0xc42000e990)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_server.go:48 +0x43
created by main.(*currentWorker).serve
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_server.go:47 +0x44b

goroutine 12 [chan receive]:
main.(*currentWorker).serve.func2(0x4b0a6c0, 0xc4201c6300, 0xc4202204e0)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_server.go:55 +0x48
created by main.(*currentWorker).serve
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_server.go:54 +0x487

goroutine 13 [select]:
main.mainCommandRun.func1.2(0xc420060d20, 0xc420193070, 0x4b0a6c0, 0xc4201c6300)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:115 +0xf2
created by main.mainCommandRun.func1
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:114 +0x3e7

goroutine 27 [select]:
main.(*currentWorker).logProcessor(0xc420203000, 0x4b0a6c0, 0xc4201c6300, 0x4b634a0, 0x4b63400)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/logger.go:53 +0x1d2
created by main.mainCommandRun.func1
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:150 +0x789

goroutine 32 [chan send]:
github.com/ovh/cds/sdk/cdsclient.(*client).QueuePolling(0xc42013c480, 0x4b0a6c0, 0xc4201c6300, 0xc42021c180, 0xc42021c120, 0xc42021c1e0, 0x77359400, 0x0, 0x0)
    /Users/yesnault/src/github.com/ovh/cds/sdk/cdsclient/client_queue.go:62 +0x824
main.mainCommandRun.func1.4(0xc420203000, 0xc42021c180, 0xc42021c120, 0xc42021c1e0, 0x4b0a6c0, 0xc4201c6300)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:166 +0x88
created by main.mainCommandRun.func1
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:165 +0x942

goroutine 138 [select]:
main.(*currentWorker).takeWorkflowJob.func1(0x4b0a6c0, 0xc4201c6d00, 0xc420a362d0, 0xe5, 0xc4201c6d40)
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/take_workflow_node_run_job.go:37 +0x121
created by main.(*currentWorker).takeWorkflowJob
    /Users/yesnault/src/github.com/ovh/cds/engine/worker/take_workflow_node_run_job.go:35 +0x25d
```

  '+ if log-level = debug, activate gops

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>