### PR TITLE
fix (hatchery): load configuration & token

### DIFF
--- a/engine/hatchery/marathon/marathon.go
+++ b/engine/hatchery/marathon/marathon.go
@@ -208,7 +208,7 @@ func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, jobID int64, requiremen
 
 	env := map[string]string{
 		"CDS_API":           h.Client().APIURL(),
-		"CDS_TOKEN":         h.token,
+		"CDS_TOKEN":         h.Configuration().API.Token,
 		"CDS_NAME":          workerName,
 		"CDS_MODEL":         fmt.Sprintf("%d", model.ID),
 		"CDS_HATCHERY":      fmt.Sprintf("%d", h.hatch.ID),

--- a/engine/hatchery/marathon/types.go
+++ b/engine/hatchery/marathon/types.go
@@ -13,35 +13,34 @@ type HatcheryConfiguration struct {
 	hatchery.CommonConfiguration `mapstructure:"commonConfiguration" toml:"commonConfiguration"`
 
 	// MarathonURL "marathon-api"
-	MarathonURL string `mapstructure:"url" toml:"url" default:"http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080" commented:"true" comment:"URL of your marathon"`
+	MarathonURL string `mapstructure:"url" toml:"url" default:"http://1.1.1.1:8080,1.1.1.2:8080,1.1.1.3:8080" commented:"false" comment:"URL of your marathon"`
 
 	// MarathonID "marathon-id"
-	MarathonIDPrefix string `mapstructure:"idPrefix" toml:"idPrefix" default:"/cds/workers" commented:"true" comment:"Prefix of id for workers spawn on marathon. Enter 'workers' to have id as: '/workers/a-worker'"`
+	MarathonIDPrefix string `mapstructure:"idPrefix" toml:"idPrefix" default:"/cds/workers" commented:"false" comment:"Prefix of id for workers spawn on marathon. Enter 'workers' to have id as: '/workers/a-worker'"`
 
 	// MarathonUser "marathon-user"
-	MarathonUser string `mapstructure:"user" toml:"user" default:"" commented:"true" comment:"Marathon Username, used to call Marathon URL"`
+	MarathonUser string `mapstructure:"user" toml:"user" default:"" commented:"false" comment:"Marathon Username, used to call Marathon URL"`
 
 	// MarathonPassword "marathon-password"
-	MarathonPassword string `mapstructure:"password" toml:"password" default:"" commented:"true" comment:"Marathon Password, you need a marathon User to use it"`
+	MarathonPassword string `mapstructure:"password" toml:"password" default:"" commented:"false" comment:"Marathon Password, you need a marathon User to use it"`
 
 	// MarathonLabelsStr "marathon-labels"
-	MarathonLabels string `mapstructure:"labels" toml:"labels" default:"" commented:"true" comment:"Use this option if you want to add labels on workers spawned by this hatchery.\n Format: MarathonLabels = \"A_LABEL=value-of-label\""`
+	MarathonLabels string `mapstructure:"labels" toml:"labels" default:"" commented:"false" comment:"Use this option if you want to add labels on workers spawned by this hatchery.\n Format: MarathonLabels = \"A_LABEL=value-of-label\""`
 
 	// DefaultMemory Worker default memory
-	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"true" comment:"Worker default memory in Mo"`
+	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"false" comment:"Worker default memory in Mo"`
 
 	// WorkerTTL Worker TTL (minutes)
-	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"true" comment:"Worker TTL (minutes)"`
+	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"false" comment:"Worker TTL (minutes)"`
 
 	// WorkerSpawnTimeout Worker Timeout Spawning (seconds)
-	WorkerSpawnTimeout int `mapstructure:"workerSpawnTimeout" toml:"workerSpawnTimeout" default:"120" commented:"true" comment:"Worker Timeout Spawning (seconds)"`
+	WorkerSpawnTimeout int `mapstructure:"workerSpawnTimeout" toml:"workerSpawnTimeout" default:"120" commented:"false" comment:"Worker Timeout Spawning (seconds)"`
 }
 
 // HatcheryMarathon implements HatcheryMode interface for mesos mode
 type HatcheryMarathon struct {
 	Config HatcheryConfiguration
 	hatch  *sdk.Hatchery
-	token  string
 
 	marathonClient marathon.Marathon
 	client         cdsclient.Interface

--- a/engine/hatchery/openstack/types.go
+++ b/engine/hatchery/openstack/types.go
@@ -18,34 +18,34 @@ type HatcheryConfiguration struct {
 	hatchery.CommonConfiguration `mapstructure:"commonConfiguration" toml:"commonConfiguration"`
 
 	// Tenant openstack-tenant
-	Tenant string `mapstructure:"tenant" toml:"tenant" default:"" commented:"true" comment:"Openstack tenant (string)"`
+	Tenant string `mapstructure:"tenant" toml:"tenant" default:"" commented:"false" comment:"Openstack tenant (string)"`
 
 	// User  openstack-user
-	User string `mapstructure:"user" toml:"user" default:"" commented:"true" comment:"Openstack User"`
+	User string `mapstructure:"user" toml:"user" default:"" commented:"false" comment:"Openstack User"`
 
 	// Address  openstack-auth-endpoint
-	Address string `mapstructure:"address" toml:"address" default:"https://auth.cloud.ovh.net/v2.0" commented:"true" comment:"Opentack Auth Endpoint"`
+	Address string `mapstructure:"address" toml:"address" default:"https://auth.cloud.ovh.net/v2.0" commented:"false" comment:"Opentack Auth Endpoint"`
 
 	// Password openstack-password
-	Password string `mapstructure:"password" toml:"password" default:"" commented:"true" comment:"Openstack Password"`
+	Password string `mapstructure:"password" toml:"password" default:"" commented:"false" comment:"Openstack Password"`
 
 	// Region openstack-region
-	Region string `mapstructure:"region" toml:"region" default:"" commented:"true" comment:"Openstack Region"`
+	Region string `mapstructure:"region" toml:"region" default:"" commented:"false" comment:"Openstack Region"`
 
 	// NetworkString openstack-network
-	NetworkString string `mapstructure:"networkString" toml:"networkString" default:"Ext-Net" commented:"true" comment:"Hatchery will use this Network to spawn CDS Worker (Virtual Machine)."`
+	NetworkString string `mapstructure:"networkString" toml:"networkString" default:"Ext-Net" commented:"false" comment:"Hatchery will use this Network to spawn CDS Worker (Virtual Machine)."`
 
 	// IPRange IP Range
-	IPRange string `mapstructure:"iprange" toml:"iprange" default:"" commented:"true" comment:"Facultative. IP Range for spawned workers. \n Format: a.a.a.a/b,c.c.c.c/e \n Hatchery will use an IP from this range to create Virtual Machine (Fixed IP Attribute).\nIf not set, it will get an address from the neutron service"`
+	IPRange string `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"Facultative. IP Range for spawned workers. \n Format: a.a.a.a/b,c.c.c.c/e \n Hatchery will use an IP from this range to create Virtual Machine (Fixed IP Attribute).\nIf not set, it will get an address from the neutron service"`
 
 	// WorkerTTL Worker TTL (minutes)
-	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"30" commented:"true" comment:"Worker TTL (minutes)"`
+	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"30" commented:"false" comment:"Worker TTL (minutes)"`
 
 	// DisableCreateImage if true: hatchery does not create openstack image when a worker model is updated
-	DisableCreateImage bool `mapstructure:"disableCreateImage" toml:"disableCreateImage" default:"false" commented:"true" comment:"if true: hatchery does not create openstack image when a worker model is updated"`
+	DisableCreateImage bool `mapstructure:"disableCreateImage" toml:"disableCreateImage" default:"false" commented:"false" comment:"if true: hatchery does not create openstack image when a worker model is updated"`
 
 	// CreateImageTimeout max wait for create an openstack image (in seconds)
-	CreateImageTimeout int `mapstructure:"createImageTimeout" toml:"createImageTimeout" default:"180" commented:"true" comment:"max wait for create an openstack image (in seconds)"`
+	CreateImageTimeout int `mapstructure:"createImageTimeout" toml:"createImageTimeout" default:"180" commented:"false" comment:"max wait for create an openstack image (in seconds)"`
 }
 
 // HatcheryOpenstack spawns instances of worker model with type 'ISO'

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -13,16 +13,16 @@ type HatcheryConfiguration struct {
 	hatchery.CommonConfiguration `mapstructure:"commonConfiguration" toml:"commonConfiguration"`
 
 	// RatioService Percent reserved for spwaning worker with service requirement
-	RatioService int `mapstructure:"ratioService" toml:"ratioService" default:"75" commented:"true" comment:"Percent reserved for spwaning worker with service requirement"`
+	RatioService int `mapstructure:"ratioService" toml:"ratioService" default:"75" commented:"false" comment:"Percent reserved for spwaning worker with service requirement"`
 
 	// MaxContainers
-	MaxContainers int `mapstructure:"maxContainers" toml:"maxContainers" default:"10" commented:"true" comment:"Max Containers on Host managed by this Hatchery"`
+	MaxContainers int `mapstructure:"maxContainers" toml:"maxContainers" default:"10" commented:"false" comment:"Max Containers on Host managed by this Hatchery"`
 
 	// DefaultMemory Worker default memory
-	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"true" comment:"Worker default memory in Mo"`
+	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"false" comment:"Worker default memory in Mo"`
 
 	// WorkerTTL Worker TTL (minutes)
-	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"true" comment:"Worker TTL (minutes)"`
+	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"false" comment:"Worker TTL (minutes)"`
 }
 
 // HatcherySwarm is a hatchery which can be connected to a remote to a docker remote api

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -15,34 +15,34 @@ type HatcheryConfiguration struct {
 	hatchery.CommonConfiguration `mapstructure:"commonConfiguration" toml:"commonConfiguration"`
 
 	// User vsphere-user
-	VSphereUser string `mapstructure:"user" toml:"user" default:"" commented:"true" comment:"VSphere User"`
+	VSphereUser string `mapstructure:"user" toml:"user" default:"" commented:"false" comment:"VSphere User"`
 
 	// Endpoint vsphere-endpoint
-	VSphereEndpoint string `mapstructure:"endpoint" toml:"endpoint" default:"" commented:"true" comment:"VShpere Endpoint, example:pcc-11-222-333-444.ovh.com"`
+	VSphereEndpoint string `mapstructure:"endpoint" toml:"endpoint" default:"" commented:"false" comment:"VShpere Endpoint, example:pcc-11-222-333-444.ovh.com"`
 
 	// Password vsphere-password
-	VSpherePassword string `mapstructure:"password" toml:"password" default:"" commented:"true" comment:"VShpere Password"`
+	VSpherePassword string `mapstructure:"password" toml:"password" default:"" commented:"false" comment:"VShpere Password"`
 
 	// DatacenterString vsphere-datacenter
-	VSphereDatacenterString string `mapstructure:"datacenterString" toml:"datacenterString" default:"" commented:"true" comment:"VSphere Datacenter"`
+	VSphereDatacenterString string `mapstructure:"datacenterString" toml:"datacenterString" default:"" commented:"false" comment:"VSphere Datacenter"`
 
 	// DatastoreString vsphere-datastore
-	VSphereDatastoreString string `mapstructure:"datastoreString" toml:"datastoreString" default:"" commented:"true" comment:"VSphere Datastore"`
+	VSphereDatastoreString string `mapstructure:"datastoreString" toml:"datastoreString" default:"" commented:"false" comment:"VSphere Datastore"`
 
 	// NetworkString vsphere-network VM Network
-	VSphereNetworkString string `mapstructure:"networkString" toml:"networkString" default:"" commented:"true" comment:"VShpere Network"`
+	VSphereNetworkString string `mapstructure:"networkString" toml:"networkString" default:"" commented:"false" comment:"VShpere Network"`
 
 	// CardName vsphere-ethernet-card Name of the virtual ethernet card
-	VSphereCardName string `mapstructure:"cardName" toml:"cardName" default:"e1000" commented:"true" comment:"Name of the virtual ethernet card"`
+	VSphereCardName string `mapstructure:"cardName" toml:"cardName" default:"e1000" commented:"false" comment:"Name of the virtual ethernet card"`
 
 	// WorkerTTL Worker TTL (minutes)
-	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"30" commented:"true" comment:"Worker TTL (minutes)"`
+	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"30" commented:"false" comment:"Worker TTL (minutes)"`
 
 	// DisableCreateImage if true: hatchery does not create vsphere image when a worker model is updated
-	DisableCreateImage bool `mapstructure:"disableCreateImage" toml:"disableCreateImage" default:"false" commented:"true" comment:"if true: hatchery does not create vsphere image when a worker model is updated"`
+	DisableCreateImage bool `mapstructure:"disableCreateImage" toml:"disableCreateImage" default:"false" commented:"false" comment:"if true: hatchery does not create vsphere image when a worker model is updated"`
 
 	// CreateImageTimeout max wait for create a vsphere image (in seconds)
-	CreateImageTimeout int `mapstructure:"createImageTimeout" toml:"createImageTimeout" default:"180" commented:"true" comment:"max wait for create a vsphere image (in seconds)"`
+	CreateImageTimeout int `mapstructure:"createImageTimeout" toml:"createImageTimeout" default:"180" commented:"false" comment:"max wait for create a vsphere image (in seconds)"`
 }
 
 // HatcheryVSphere spawns vm


### PR DESCRIPTION
Default Values (with a cfg File) are not auto-injected if key is commented in toml.

Default values are injected only for a run with environment variables
see. https://github.com/ovh/cds/blob/master/engine/config.go#L62

On config.go, no defaults.SetDefaults(conf) after viper.Unmarshal (or all hatcheries will start with docker-compose otherwise).

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>