### PR TITLE
Change file download for x86_64 route

### DIFF
--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -41,7 +41,7 @@ func (api *API) InitRouter() {
 
 	// Download file
 	r.ServeAbsoluteFile("/download/cli/x86_64", path.Join(api.Config.Directories.Download, "cds-linux-amd64"), "cds")
-	r.ServeAbsoluteFile("/download/worker/x86_64", path.Join(api.Config.Directories.Download, "cds-worker-linux-386"), "worker")
+	r.ServeAbsoluteFile("/download/worker/x86_64", path.Join(api.Config.Directories.Download, "cds-worker-linux-amd64"), "worker")
 	r.ServeAbsoluteFile("/download/worker/windows_x86_64", path.Join(api.Config.Directories.Download, "cds-worker-windows-amd64"), "worker.exe")
 
 	r.ServeAbsoluteFile("/download/cdsctl-windows-amd64", path.Join(api.Config.Directories.Download, "cdsctl-windows-amd64"), "cdsctl-windows-amd64")


### PR DESCRIPTION
Since arch 386 isn't in TARGET_ARCH in the makefile it should be the amd64 file that is the default download
And x86_64 means 64bit processor so why download a 32bit binary since the automatic worker download is based on uname -m