### PR TITLE
test (engine): git hook -> retry / delay 5

### DIFF
--- a/tests/sc_git_hook.yml
+++ b/tests/sc_git_hook.yml
@@ -21,8 +21,8 @@ testcases:
   - script: {{.cds.build.cds}} pipeline hook list ITSCGITHOOK TestApp MultiPass --show-url-only
   - script: curl -i -X POST `{{.cds.build.cds}} pipeline hook list ITSCGITHOOK TestApp MultiPass --show-url-only`
   - script: {{.cds.build.cds}} pipeline history ITSCGITHOOK TestApp MultiPass | egrep "Building|Success"
-    retry: 1
-    delay: 3
+    retry: 5
+    delay: 5
 
 - name: Streaming logs of triggered pipeline
   steps:


### PR DESCRIPTION
/hook run a goroutine, after calling it, the pipeline history can show build few seconds after in IT. retry 1, delay 3 is not enough.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>