### PR TITLE
feat (sdk) template routes

### DIFF
--- a/sdk/cdsclient/client_environment.go
+++ b/sdk/cdsclient/client_environment.go
@@ -9,7 +9,7 @@ import (
 
 func (c *client) EnvironmentCreate(key string, env *sdk.Environment) error {
 	code, err := c.PostJSON("/project/"+key+"/environment", env, nil)
-	if code != 201 {
+	if code != 200 {
 		if err == nil {
 			return fmt.Errorf("HTTP Code %d", code)
 		}

--- a/sdk/cdsclient/client_template.go
+++ b/sdk/cdsclient/client_template.go
@@ -1,0 +1,54 @@
+package cdsclient
+
+import (
+	"fmt"
+
+	"github.com/ovh/cds/sdk"
+)
+
+// TemplateList
+func (c *client) TemplateList() ([]sdk.Template, error) {
+	templates := []sdk.Template{}
+	code, err := c.GetJSON("/template/build", templates)
+	if code != 200 {
+		if err == nil {
+			return nil, fmt.Errorf("HTTP Code %d", code)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return templates, nil
+}
+
+// TemplateGet Get the build template corresponding to the given name
+func (c *client) TemplateGet(name string) (*sdk.Template, error) {
+	tpls, err := c.TemplateList()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range tpls {
+		if t.Name == name {
+			return &t, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s: not found", err)
+}
+
+// TemplateApplicationCreate creates given application and apply build template
+func (c *client) TemplateApplicationCreate(projectKey, name string, template *sdk.Template) error {
+	opts := sdk.ApplyTemplatesOptions{
+		ApplicationName: name,
+		TemplateName:    template.Name,
+		TemplateParams:  template.Params,
+	}
+	code, err := c.PostJSON(fmt.Sprintf("/project/%s/template", projectKey), opts, nil)
+	if code != 200 {
+		if err == nil {
+			return fmt.Errorf("HTTP Code %d", code)
+		}
+	}
+	return err
+}

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -63,6 +63,9 @@ type Interface interface {
 	QueueArtifactUpload(id int64, tag, filePath string) error
 	Requirements() ([]sdk.Requirement, error)
 	ServiceRegister(sdk.Service) (string, error)
+	TemplateList() ([]sdk.Template, error)
+	TemplateGet(name string) (*sdk.Template, error)
+	TemplateApplicationCreate(projectKey, name string, template *sdk.Template) error
 	UserLogin(username, password string) (bool, string, error)
 	UserList() ([]sdk.User, error)
 	UserSignup(username, fullname, email, callback string) error


### PR DESCRIPTION
* `POST /project/{key}/environment` returns a `200` code on success, which is not properly handled by the new *cdsclient* sdk that used to expect a `201`.
* Initialize `/template` routes in the new *cdsclient* sdk.