### PR TITLE
fix(api): fix getRemoteName when project is already in the repo name

### DIFF
--- a/engine/api/pipeline/pipeline_build.go
+++ b/engine/api/pipeline/pipeline_build.go
@@ -1656,7 +1656,7 @@ func paramsToMap(params []sdk.Parameter) map[string]string {
 }
 
 func getRemoteName(project, repo string) string {
-	if project != "" {
+	if project != "" && !strings.Contains(repo, project+"/") {
 		return project + "/" + repo
 	}
 	return repo


### PR DESCRIPTION
Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>