### PR TITLE
fix (engine): interpolate with empty string

### DIFF
--- a/sdk/interpolate.go
+++ b/sdk/interpolate.go
@@ -36,7 +36,7 @@ func Interpolate(input string, vars map[string]string) (string, error) {
 		}
 	}
 
-	// in input, replace {{.cds.foo.bar}} per {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
+	// in input, replace {{.cds.foo.bar}} with {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
 	// t.Execute will call "default" function, documented on http://masterminds.github.io/sprig/defaults.html
 	sm := interpolateRegex.FindAllStringSubmatch(input, -1)
 	if len(sm) > 0 {
@@ -48,16 +48,16 @@ func Interpolate(input string, vars map[string]string) (string, error) {
 				// see test "two same unknown" on InterpolateTest
 				if _, ok := alreadyReplaced[sm[i][1]]; !ok {
 					if _, ok := defaults[e]; !ok {
-						// replace {{.cds.foo.bar}} per {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
+						// replace {{.cds.foo.bar}} with {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
 						// with cds.foo.bar unknown from vars
 						nameWithDot := strings.Replace(e, "__", ".", -1)
 						input = strings.Replace(input, sm[i][1], "{{ default \"{{"+nameWithDot+"}}\" "+e+" }}", -1)
 					} else if _, ok := empty[e]; !ok {
-						// replace {{.cds.foo.bar}} per {{ default "" .cds.foo.bar}}
+						// replace {{.cds.foo.bar}} with {{ default "" .cds.foo.bar}}
 						// with cds.foo.bar knowned, but with value empty string ""
 						input = strings.Replace(input, sm[i][1], "{{ default \"\" "+e+" }}", -1)
 					} else {
-						// replace {{.cds.foo.bar}} per {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
+						// replace {{.cds.foo.bar}} with {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
 						// with cds.foo.bar knowned from vars
 						input = strings.Replace(input, sm[i][1], "{{ default \"{{"+defaults[e[1:]]+"}}\" "+e+" }}", -1)
 					}

--- a/sdk/interpolate.go
+++ b/sdk/interpolate.go
@@ -10,15 +10,21 @@ import (
 	"github.com/Masterminds/sprig"
 )
 
-var interpolateRegex = regexp.MustCompile("{{(\\.[a-zA-Z0-9._|\\s]+)}}")
+var interpolateRegex = regexp.MustCompile("({{\\.[a-zA-Z0-9._|\\s]+}})")
 
 // Interpolate returns interpolated input with vars
 func Interpolate(input string, vars map[string]string) (string, error) {
 	data := map[string]string{}
+	defaults := map[string]string{}
+	empty := map[string]string{}
 
 	for k, v := range vars {
 		kb := strings.Replace(k, ".", "__", -1)
 		data[kb] = v
+		defaults["."+kb] = k
+		if v == "" {
+			empty[k] = k
+		}
 		re := regexp.MustCompile("{{." + k + "(.*)}}")
 		for i := 0; i < 10; i++ {
 			sm := re.FindStringSubmatch(input)
@@ -37,10 +43,24 @@ func Interpolate(input string, vars map[string]string) (string, error) {
 		alreadyReplaced := map[string]string{}
 		for i := 0; i < len(sm); i++ {
 			if len(sm[i]) > 0 {
+				e := sm[i][1][2 : len(sm[i][1])-2]
 				// alreadyReplaced: check if var is already replaced.
 				// see test "two same unknown" on InterpolateTest
 				if _, ok := alreadyReplaced[sm[i][1]]; !ok {
-					input = strings.Replace(input, sm[i][1], " default \"{{"+sm[i][1]+"}}\" "+sm[i][1]+" ", -1)
+					if _, ok := defaults[e]; !ok {
+						// replace {{.cds.foo.bar}} per {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
+						// with cds.foo.bar unknown from vars
+						nameWithDot := strings.Replace(e, "__", ".", -1)
+						input = strings.Replace(input, sm[i][1], "{{ default \"{{"+nameWithDot+"}}\" "+e+" }}", -1)
+					} else if _, ok := empty[e]; !ok {
+						// replace {{.cds.foo.bar}} per {{ default "" .cds.foo.bar}}
+						// with cds.foo.bar knowned, but with value empty string ""
+						input = strings.Replace(input, sm[i][1], "{{ default \"\" "+e+" }}", -1)
+					} else {
+						// replace {{.cds.foo.bar}} per {{ default "{{.cds.foo.bar}}" .cds.foo.bar}}
+						// with cds.foo.bar knowned from vars
+						input = strings.Replace(input, sm[i][1], "{{ default \"{{"+defaults[e[1:]]+"}}\" "+e+" }}", -1)
+					}
 					alreadyReplaced[sm[i][1]] = sm[i][1]
 				}
 			}

--- a/sdk/interpolate_test.go
+++ b/sdk/interpolate_test.go
@@ -69,6 +69,52 @@ func TestInterpolate(t *testing.T) {
 			},
 			want: `A:{{.cds.env.myenvpassword}} B:{{.cds.env.myenvpassword}}`,
 		},
+		{
+			name: "empty string",
+			args: args{
+				input: "a {{.cds.app.myKey}} and another key with empty value *{{.cds.app.myKeyAnother}}*",
+				vars:  map[string]string{"cds.app.myKey": "valueKey", "cds.app.myKeyAnother": ""},
+			},
+			want: "a valueKey and another key with empty value **",
+		},
+		{
+			name: "two keys with same first characters",
+			args: args{
+				input: "a {{.cds.app.myKey}} and another key value {{.cds.app.myKeyAnother}}",
+				vars:  map[string]string{"cds.app.myKey": "valueKey", "cds.app.myKeyAnother": "valueKeyAnother"},
+			},
+			want: "a valueKey and another key value valueKeyAnother",
+		},
+		{
+			name: "config",
+			args: args{
+				input: `
+{
+"env": {
+"KEYA":"{{.cds.env.vAppKey}}",
+"KEYB": "{{.cds.env.vAppKeyHatchery}}",
+"ADDR":"{{.cds.env.addr}}"
+},
+"labels": {
+"TOKEN": "{{.cds.env.token}}",
+"HOST": "cds-hatchery-marathon-{{.cds.env.name}}.{{.cds.env.vHost}}",
+}
+}`,
+				vars: map[string]string{"cds.env.name": "", "cds.env.token": "aValidTokenString", "cds.env.addr": "", "cds.env.vAppKey": "aValue"},
+			},
+			want: `
+{
+"env": {
+"KEYA":"aValue",
+"KEYB": "{{.cds.env.vAppKeyHatchery}}",
+"ADDR":""
+},
+"labels": {
+"TOKEN": "aValidTokenString",
+"HOST": "cds-hatchery-marathon-.{{.cds.env.vHost}}",
+}
+}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
two issues fixed:
- replace empty string with empty string, instead of {{.cds__env__foo}} if foo exists with empty value
- replace values for two keys starting with same string: .cds.env.foo and .cds.env.fooBar

go test -v -run TestInterpolate
=== RUN   TestInterpolate
=== RUN   TestInterpolate/simple
=== RUN   TestInterpolate/only_unknown
=== RUN   TestInterpolate/simple_with_unknown
=== RUN   TestInterpolate/upper
=== RUN   TestInterpolate/title_and_filter_on_unknow
=== RUN   TestInterpolate/many
=== RUN   TestInterpolate/two_same_unknown
=== RUN   TestInterpolate/empty_string
=== RUN   TestInterpolate/two_keys_with_same_first_characters
=== RUN   TestInterpolate/config
--- PASS: TestInterpolate (0.00s)
    --- PASS: TestInterpolate/simple (0.00s)
    --- PASS: TestInterpolate/only_unknown (0.00s)
    --- PASS: TestInterpolate/simple_with_unknown (0.00s)
    --- PASS: TestInterpolate/upper (0.00s)
    --- PASS: TestInterpolate/title_and_filter_on_unknow (0.00s)
    --- PASS: TestInterpolate/many (0.00s)
    --- PASS: TestInterpolate/two_same_unknown (0.00s)
    --- PASS: TestInterpolate/empty_string (0.00s)
    --- PASS: TestInterpolate/two_keys_with_same_first_characters (0.00s)
    --- PASS: TestInterpolate/config (0.00s)
PASS
ok      github.com/ovh/cds/sdk    0.015s

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>