### PR TITLE
feat (worker): logs: debug on try take, info on taken

### DIFF
--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -233,7 +233,7 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 				//Take the job
 				if requirementsOK {
-					log.Info("checkQueue> Taking PipelineBuildJob %d%s", j.ID, t)
+					log.Debug("checkQueue> Try take the PipelineBuildJob %d%s", j.ID, t)
 					canWorkOnAnotherJob := w.takePipelineBuildJob(ctx, j.ID, j.ID == w.bookedJobID)
 					if canWorkOnAnotherJob {
 						continue
@@ -271,12 +271,12 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 				//Take the job
 				if requirementsOK {
-					log.Info("checkQueue> Taking Job %d%s", j.ID, t)
+					log.Debug("checkQueue> Try take the job %d%s", j.ID, t)
 					if canWorkOnAnotherJob, err := w.takeWorkflowJob(ctx, j); err != nil {
+						log.Info("Unable to run this job  %d%s. Take info:%s, continue:%t", j.ID, t, err, canWorkOnAnotherJob)
 						if !canWorkOnAnotherJob {
 							errs <- err
 						} else {
-							log.Info("Unable to run this job, take info:%s, let's continue %d%s", err, j.ID, t)
 							continue
 						}
 					}

--- a/engine/worker/take_pipeline_build_job.go
+++ b/engine/worker/take_pipeline_build_job.go
@@ -48,6 +48,12 @@ func (w *currentWorker) takePipelineBuildJob(ctx context.Context, pipelineBuildJ
 		return true
 	}
 
+	t := ""
+	if isBooked {
+		t = ", this was my booked job"
+	}
+	log.Info("takePipelineBuildJob> Job %d taken%s", pipelineBuildJobID, t)
+
 	pbji := worker.PipelineBuildJobInfo{}
 	if err := json.Unmarshal([]byte(data), &pbji); err != nil {
 		log.Info("takeJob> Cannot unmarshal action: %s", err)

--- a/engine/worker/take_workflow_node_run_job.go
+++ b/engine/worker/take_workflow_node_run_job.go
@@ -21,6 +21,11 @@ func (w *currentWorker) takeWorkflowJob(ctx context.Context, job sdk.WorkflowNod
 	if err != nil {
 		return true, sdk.WrapError(err, "takeWorkflowJob> Unable to take workflow node run job. This worker can work on another job.")
 	}
+	t := ""
+	if w.bookedJobID == job.ID {
+		t = ", this was my booked job"
+	}
+	log.Info("takeWorkflowJob> Job %d taken%s", job.ID, t)
 
 	w.nbActionsDone++
 	// Set build variables


### PR DESCRIPTION
this will avoid to have logs as:

```
go-official-1.9.1-nostalgic-meninsky      | 2017-11-04 15:44:16 | info | checkQueue> Taking job 8717, this was my booked job
go-official-1.9.1-nostalgic-meninsky      | 2017-11-04 15:44:16 | info | checkQueue> Taking job 8714
go-official-1.9.1-nostalgic-meninsky      | 2017-11-04 15:44:16 | info | checkQueue> Taking job 8713
go-official-1.9.1-nostalgic-meninsky      | 2017-11-04 15:44:16 | info | checkQueue> Taking job 8712
```
and we don't know which job is taken.