### PR TITLE
fix (api): more details on logs

### DIFF
--- a/engine/api/workflow/dao_run.go
+++ b/engine/api/workflow/dao_run.go
@@ -252,7 +252,7 @@ func loadRun(db gorp.SqlExecutor, query string, args ...interface{}) (*sdk.Workf
 		if err == sql.ErrNoRows {
 			return nil, sdk.ErrWorkflowNotFound
 		}
-		return nil, sdk.WrapError(err, "loadRun> Unable to load workflow run", query, args)
+		return nil, sdk.WrapError(err, "loadRun> Unable to load workflow run. query:%s args:%v", query, args)
 	}
 	wr := sdk.WorkflowRun(*runDB)
 

--- a/engine/api/workflow/execute_node_run.go
+++ b/engine/api/workflow/execute_node_run.go
@@ -111,7 +111,7 @@ func execute(db gorp.SqlExecutor, store cache.Store, p *sdk.Project, n *sdk.Work
 
 	// Save the node run in database
 	if err := UpdateNodeRun(db, n); err != nil {
-		return sdk.WrapError(fmt.Errorf("Unable to update node id=%d at status %s", n.ID, n.Status), "workflow.execute> Unable to execute node")
+		return sdk.WrapError(fmt.Errorf("Unable to update node id=%d at status %s. err:%s", n.ID, n.Status, err), "workflow.execute> Unable to execute node")
 	}
 
 	//Reload the workflow


### PR DESCRIPTION
Worker take a job, send info and there's errors on API (see below). This PR is only to add more context on logs.
Theses errors explains why a worker take a Job (workflow) and does not work on job after.

```
2017-11-04 15:44:20 | warn | POST    | 500  | /queue/workflows/8717/spawn/infos      postSpawnInfosWorkflowJobHandler> Cannot save job 8717: AddSpawnInfosNodeJobRun> Cannot update node job run: workflow.execute> Unable to execute node: Unable to update node id=2611 at status Building
2017-11-04 15:44:20 | err  | workflow.execute> Unable to add infos on run 554: loadRun> Unable to load workflow run%!(EXTRA string=select workflow_run.*
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>