### PR TITLE
fix (hatcheries,worker): book & take care on workflow

### DIFF
--- a/engine/hatchery/docker/docker.go
+++ b/engine/hatchery/docker/docker.go
@@ -216,7 +216,7 @@ func (h *HatcheryDocker) WorkersStartedByModel(model *sdk.Model) int {
 }
 
 // SpawnWorker starts a new worker in a docker container locally
-func (h *HatcheryDocker) SpawnWorker(wm *sdk.Model, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
+func (h *HatcheryDocker) SpawnWorker(wm *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
 	if wm.Type != sdk.Docker {
 		return "", fmt.Errorf("cannot handle %s worker model", wm.Type)
 	}
@@ -269,7 +269,11 @@ func (h *HatcheryDocker) SpawnWorker(wm *sdk.Model, jobID int64, requirements []
 	}
 
 	if jobID > 0 {
-		args = append(args, "-e", fmt.Sprintf("CDS_BOOKED_JOB_ID=%d", jobID))
+		if isWorkflowJob {
+			args = append(args, "-e", fmt.Sprintf("CDS_BOOKED_WORKFLOW_JOB_ID=%d", jobID))
+		} else {
+			args = append(args, "-e", fmt.Sprintf("CDS_BOOKED_PB_JOB_ID=%d", jobID))
+		}
 	}
 
 	if h.Config.DockerAddHost != "" {

--- a/engine/hatchery/local/local.go
+++ b/engine/hatchery/local/local.go
@@ -133,7 +133,7 @@ func (h *HatcheryLocal) killWorker(worker sdk.Worker) error {
 }
 
 // SpawnWorker starts a new worker process
-func (h *HatcheryLocal) SpawnWorker(wm *sdk.Model, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
+func (h *HatcheryLocal) SpawnWorker(wm *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
 	var err error
 
 	if len(h.workers) >= h.Config.Provision.MaxWorker {
@@ -181,7 +181,11 @@ func (h *HatcheryLocal) SpawnWorker(wm *sdk.Model, jobID int64, requirements []s
 	args = append(args, "--force-exit")
 
 	if jobID > 0 {
-		args = append(args, fmt.Sprintf("--booked-job-id=%d", jobID))
+		if isWorkflowJob {
+			args = append(args, fmt.Sprintf("--booked-workflow-job-id=%d", jobID))
+		} else {
+			args = append(args, fmt.Sprintf("--booked-pb-job-id=%d", jobID))
+		}
 	}
 
 	if registerOnly {

--- a/engine/hatchery/marathon/marathon.go
+++ b/engine/hatchery/marathon/marathon.go
@@ -187,11 +187,11 @@ func (h *HatcheryMarathon) CanSpawn(model *sdk.Model, jobID int64, requirements 
 
 // SpawnWorker creates an application on mesos via marathon
 // requirements services are not supported
-func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
-	if jobID > 0 {
-		log.Info("spawnWorker> spawning worker %s (%s) for job %d - %s", model.Name, model.Image, jobID, logInfo)
+func (h *HatcheryMarathon) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string, error) {
+	if spawnArgs.JobID > 0 {
+		log.Info("spawnWorker> spawning worker %s (%s) for job %d - %s", spawnArgs.Model.Name, spawnArgs.Model.Image, spawnArgs.JobID, spawnArgs.LogInfo)
 	} else {
-		log.Info("spawnWorker> spawning worker %s (%s) - %s", model.Name, model.Image, logInfo)
+		log.Info("spawnWorker> spawning worker %s (%s) - %s", spawnArgs.Model.Name, spawnArgs.Model.Image, spawnArgs.LogInfo)
 	}
 
 	var logJob string
@@ -200,21 +200,21 @@ func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, isWorkflowJob bool, job
 	memory := h.Config.DefaultMemory
 
 	cmd := "rm -f worker && curl ${CDS_API}/download/worker/$(uname -m) -o worker &&  chmod +x worker && exec ./worker"
-	if registerOnly {
+	if spawnArgs.RegisterOnly {
 		cmd += " register"
 	}
 	instance := 1
-	workerName := fmt.Sprintf("%s-%s", strings.ToLower(model.Name), strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1))
-	if registerOnly {
+	workerName := fmt.Sprintf("%s-%s", strings.ToLower(spawnArgs.Model.Name), strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1))
+	if spawnArgs.RegisterOnly {
 		workerName = "register-" + workerName
 	}
-	forcePull := strings.HasSuffix(model.Image, ":latest")
+	forcePull := strings.HasSuffix(spawnArgs.Model.Image, ":latest")
 
 	env := map[string]string{
 		"CDS_API":           h.Client().APIURL(),
 		"CDS_TOKEN":         h.Configuration().API.Token,
 		"CDS_NAME":          workerName,
-		"CDS_MODEL":         fmt.Sprintf("%d", model.ID),
+		"CDS_MODEL":         fmt.Sprintf("%d", spawnArgs.Model.ID),
 		"CDS_HATCHERY":      fmt.Sprintf("%d", h.hatch.ID),
 		"CDS_HATCHERY_NAME": fmt.Sprintf("%s", h.hatch.Name),
 		"CDS_SINGLE_USE":    "1",
@@ -233,23 +233,23 @@ func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, isWorkflowJob bool, job
 	if h.Configuration().Provision.WorkerLogsOptions.Graylog.ExtraValue != "" {
 		env["CDS_GRAYLOG_EXTRA_VALUE"] = h.Configuration().Provision.WorkerLogsOptions.Graylog.ExtraValue
 	}
-	if h.Configuration().API.GRPC.URL != "" && model.Communication == sdk.GRPC {
+	if h.Configuration().API.GRPC.URL != "" && spawnArgs.Model.Communication == sdk.GRPC {
 		env["CDS_GRPC_API"] = h.Configuration().API.GRPC.URL
 		env["CDS_GRPC_INSECURE"] = strconv.FormatBool(h.Configuration().API.GRPC.Insecure)
 	}
 
 	//Check if there is a memory requirement
 	//if there is a service requirement: exit
-	if jobID > 0 {
-		if isWorkflowJob {
-			logJob = fmt.Sprintf("for workflow job %d,", jobID)
-			env["CDS_BOOKED_WORKFLOW_JOB_ID"] = fmt.Sprintf("%d", jobID)
+	if spawnArgs.JobID > 0 {
+		if spawnArgs.IsWorkflowJob {
+			logJob = fmt.Sprintf("for workflow job %d,", spawnArgs.JobID)
+			env["CDS_BOOKED_WORKFLOW_JOB_ID"] = fmt.Sprintf("%d", spawnArgs.JobID)
 		} else {
-			logJob = fmt.Sprintf("for pipeline build job %d,", jobID)
-			env["CDS_BOOKED_PB_JOB_ID"] = fmt.Sprintf("%d", jobID)
+			logJob = fmt.Sprintf("for pipeline build job %d,", spawnArgs.JobID)
+			env["CDS_BOOKED_PB_JOB_ID"] = fmt.Sprintf("%d", spawnArgs.JobID)
 		}
 
-		for _, r := range requirements {
+		for _, r := range spawnArgs.Requirements {
 			if r.Type == sdk.MemoryRequirement {
 				var err error
 				memory, err = strconv.Atoi(r.Value)
@@ -269,7 +269,7 @@ func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, isWorkflowJob bool, job
 		Container: &marathon.Container{
 			Docker: &marathon.Docker{
 				ForcePullImage: &forcePull,
-				Image:          model.Image,
+				Image:          spawnArgs.Model.Image,
 				Network:        "BRIDGE",
 			},
 			Type: "DOCKER",

--- a/engine/hatchery/marathon/marathon.go
+++ b/engine/hatchery/marathon/marathon.go
@@ -187,7 +187,7 @@ func (h *HatcheryMarathon) CanSpawn(model *sdk.Model, jobID int64, requirements 
 
 // SpawnWorker creates an application on mesos via marathon
 // requirements services are not supported
-func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
+func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
 	if jobID > 0 {
 		log.Info("spawnWorker> spawning worker %s (%s) for job %d - %s", model.Name, model.Image, jobID, logInfo)
 	} else {
@@ -241,8 +241,13 @@ func (h *HatcheryMarathon) SpawnWorker(model *sdk.Model, jobID int64, requiremen
 	//Check if there is a memory requirement
 	//if there is a service requirement: exit
 	if jobID > 0 {
-		logJob = fmt.Sprintf("for job %d,", jobID)
-		env["CDS_BOOKED_JOB_ID"] = fmt.Sprintf("%d", jobID)
+		if isWorkflowJob {
+			logJob = fmt.Sprintf("for workflow job %d,", jobID)
+			env["CDS_BOOKED_WORKFLOW_JOB_ID"] = fmt.Sprintf("%d", jobID)
+		} else {
+			logJob = fmt.Sprintf("for pipeline build job %d,", jobID)
+			env["CDS_BOOKED_PB_JOB_ID"] = fmt.Sprintf("%d", jobID)
+		}
 
 		for _, r := range requirements {
 			if r.Type == sdk.MemoryRequirement {

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -321,9 +321,9 @@ func (h *HatcherySwarm) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID 
 
 	if jobID > 0 {
 		if isWorkflowJob {
-			env = append(env, "CDS_BOOKED_WORKFLOW_JOB_ID"+"="+strconv.FormatInt(jobID, 10))
+			env = append(env, fmt.Sprintf("CDS_BOOKED_WORKFLOW_JOB_ID=%d", jobID))
 		} else {
-			env = append(env, "CDS_BOOKED_PB_JOB_ID"+"="+strconv.FormatInt(jobID, 10))
+			env = append(env, fmt.Sprintf("CDS_BOOKED_PB_JOB_ID=%d", jobID))
 		}
 	}
 

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -215,7 +215,7 @@ func (h *HatcherySwarm) killAndRemove(ID string) {
 }
 
 //SpawnWorker start a new docker container
-func (h *HatcherySwarm) SpawnWorker(model *sdk.Model, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
+func (h *HatcherySwarm) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
 	//name is the name of the worker and the name of the container
 	name := fmt.Sprintf("swarmy-%s-%s", strings.ToLower(model.Name), strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1))
 	if registerOnly {
@@ -320,7 +320,11 @@ func (h *HatcherySwarm) SpawnWorker(model *sdk.Model, jobID int64, requirements 
 	}
 
 	if jobID > 0 {
-		env = append(env, "CDS_BOOKED_JOB_ID"+"="+strconv.FormatInt(jobID, 10))
+		if isWorkflowJob {
+			env = append(env, "CDS_BOOKED_WORKFLOW_JOB_ID"+"="+strconv.FormatInt(jobID, 10))
+		} else {
+			env = append(env, "CDS_BOOKED_PB_JOB_ID"+"="+strconv.FormatInt(jobID, 10))
+		}
 	}
 
 	//labels are used to make container cleanup easier

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -86,7 +86,7 @@ func (h *HatcheryVSphere) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string
 }
 
 // createVMModel create a model for a specific worker model
-func (h *HatcheryVSphere) createVMModel(model *sdk.Model) (*object.VirtualMachine, error) {
+func (h *HatcheryVSphere) createVMModel(model sdk.Model) (*object.VirtualMachine, error) {
 	log.Info("Create vm model %s", model.Name)
 	ctx := context.Background()
 	imgCfg := imageConfiguration{}
@@ -170,7 +170,7 @@ func (h *HatcheryVSphere) createVMModel(model *sdk.Model) (*object.VirtualMachin
 }
 
 // launchScriptWorker launch a script on the worker
-func (h *HatcheryVSphere) launchScriptWorker(name string, isWorkflowJob bool, jobID int64, model *sdk.Model, registerOnly bool, vmInfo types.ManagedObjectReference) error {
+func (h *HatcheryVSphere) launchScriptWorker(name string, isWorkflowJob bool, jobID int64, model sdk.Model, registerOnly bool, vmInfo types.ManagedObjectReference) error {
 	ctx := context.Background()
 	// Retrieve the new VM
 	vm := object.NewVirtualMachine(h.vclient.Client, vmInfo)

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -195,9 +195,9 @@ func (h *HatcheryVSphere) launchScriptWorker(name string, isWorkflowJob bool, jo
 	}
 
 	if isWorkflowJob {
-		env = append(env, "CDS_BOOKED_WORKFLOW_JOB_ID="+fmt.Sprintf("%d", jobID))
+		env = append(env, fmt.Sprintf("CDS_BOOKED_WORKFLOW_JOB_ID=%d", jobID))
 	} else {
-		env = append(env, "CDS_BOOKED_PB_JOB_ID="+fmt.Sprintf("%d", jobID))
+		env = append(env, fmt.Sprintf("CDS_BOOKED_PB_JOB_ID=%d", jobID))
 	}
 
 	env = append(env, h.getGraylogGrpcEnv(model)...)

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/hatchery"
 	"github.com/ovh/cds/sdk/log"
 )
 
@@ -32,25 +33,25 @@ type imageConfiguration struct {
 }
 
 // SpawnWorker creates a new vm instance
-func (h *HatcheryVSphere) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error) {
+func (h *HatcheryVSphere) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string, error) {
 	var vm *object.VirtualMachine
 	var errV error
 	ctx := context.Background()
-	name := "worker-" + model.Name + "-" + strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1)
-	if registerOnly {
+	name := "worker-" + spawnArgs.Model.Name + "-" + strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1)
+	if spawnArgs.RegisterOnly {
 		name = "register-" + name
 	}
 
-	_, errM := h.getModelByName(model.Name)
+	_, errM := h.getModelByName(spawnArgs.Model.Name)
 
-	if errM != nil || model.NeedRegistration {
+	if errM != nil || spawnArgs.Model.NeedRegistration {
 		// Generate worker model vm
-		vm, errV = h.createVMModel(model)
+		vm, errV = h.createVMModel(spawnArgs.Model)
 	}
 
 	if vm == nil || errV != nil {
-		model.NeedRegistration = errV != nil // if we haven't registered
-		if vm, errV = h.finder.VirtualMachine(ctx, model.Name); errV != nil {
+		spawnArgs.Model.NeedRegistration = errV != nil // if we haven't registered
+		if vm, errV = h.finder.VirtualMachine(ctx, spawnArgs.Model.Name); errV != nil {
 			return "", sdk.WrapError(errV, "SpawnWorker> Cannot find virtual machine with this model")
 		}
 	}
@@ -58,9 +59,9 @@ func (h *HatcheryVSphere) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobI
 	annot := annotation{
 		HatcheryName:            h.Hatchery().Name,
 		WorkerName:              name,
-		RegisterOnly:            registerOnly,
-		WorkerModelLastModified: fmt.Sprintf("%d", model.UserLastModified.Unix()),
-		WorkerModelName:         model.Name,
+		RegisterOnly:            spawnArgs.RegisterOnly,
+		WorkerModelLastModified: fmt.Sprintf("%d", spawnArgs.Model.UserLastModified.Unix()),
+		WorkerModelName:         spawnArgs.Model.Name,
 		Created:                 time.Now(),
 	}
 
@@ -81,7 +82,7 @@ func (h *HatcheryVSphere) SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobI
 		return "", sdk.WrapError(errW, "SpawnWorker> state in error")
 	}
 
-	return "", h.launchScriptWorker(name, isWorkflowJob, jobID, model, registerOnly, info.Result.(types.ManagedObjectReference))
+	return "", h.launchScriptWorker(name, spawnArgs.IsWorkflowJob, spawnArgs.JobID, spawnArgs.Model, spawnArgs.RegisterOnly, info.Result.(types.ManagedObjectReference))
 }
 
 // createVMModel create a model for a specific worker model

--- a/engine/hatchery/vsphere/utils.go
+++ b/engine/hatchery/vsphere/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 // getGraylogGrpcEnv fetch the graylog and grpc configuration from viper and return environement variable in a slice
-func (h *HatcheryVSphere) getGraylogGrpcEnv(model *sdk.Model) []string {
+func (h *HatcheryVSphere) getGraylogGrpcEnv(model sdk.Model) []string {
 	env := []string{}
 
 	if h.Configuration().Provision.WorkerLogsOptions.Graylog.Host != "" {

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -62,6 +62,12 @@ func cmdMain(w *currentWorker) *cobra.Command {
 	flags.Int("ttl", 30, "Worker time to live (minutes)")
 	viper.BindPFlag("ttl", flags.Lookup("ttl"))
 
+	flags.Int64("booked-pb-job-id", 0, "Booked Pipeline Build job id")
+	viper.BindPFlag("booked_pb_job_id", flags.Lookup("booked-pb-job-id"))
+
+	flags.Int64("booked-workflow-job-id", 0, "Booked Workflow job id")
+	viper.BindPFlag("booked_workflow_job_id", flags.Lookup("booked-workflow-job-id"))
+
 	flags.Int64("booked-job-id", 0, "Booked job id")
 	viper.BindPFlag("booked_job_id", flags.Lookup("booked-job-id"))
 
@@ -162,8 +168,11 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		errs := make(chan error, 1)
 
 		//Before start the loop, take the bookJobID
-		if w.bookedJobID != 0 {
-			w.processBookedJob(pbjobs)
+		if w.bookedPBJobID != 0 {
+			w.processBookedPBJob(pbjobs)
+		}
+		if w.bookedWJobID != 0 {
+			w.processBookedWJob(wjobs)
 		}
 		if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
 			log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
@@ -227,14 +236,14 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 				requirementsOK, _ := checkRequirements(w, &j.Job.Action, j.ExecGroups, j.ID)
 
 				t := ""
-				if j.ID == w.bookedJobID {
+				if j.ID == w.bookedPBJobID {
 					t = ", this was my booked job"
 				}
 
 				//Take the job
 				if requirementsOK {
 					log.Info("checkQueue> Taking PipelineBuildJob %d%s", j.ID, t)
-					canWorkOnAnotherJob := w.takePipelineBuildJob(ctx, j.ID, j.ID == w.bookedJobID)
+					canWorkOnAnotherJob := w.takePipelineBuildJob(ctx, j.ID, j.ID == w.bookedPBJobID)
 					if canWorkOnAnotherJob {
 						continue
 					}
@@ -265,7 +274,7 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 				requirementsOK, _ := checkRequirements(w, &j.Job.Action, nil, j.ID)
 				t := ""
-				if j.ID == w.bookedJobID {
+				if j.ID == w.bookedWJobID {
 					t = ", this was my booked job"
 				}
 
@@ -307,21 +316,21 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 	}
 }
 
-func (w *currentWorker) processBookedJob(pbjobs chan<- sdk.PipelineBuildJob) {
-	log.Debug("Try to take the job %d", w.bookedJobID)
-	b, _, err := sdk.Request("GET", fmt.Sprintf("/queue/%d/infos", w.bookedJobID), nil)
+func (w *currentWorker) processBookedPBJob(pbjobs chan<- sdk.PipelineBuildJob) {
+	log.Debug("Try to take the pipeline build job %d", w.bookedPBJobID)
+	b, _, err := sdk.Request("GET", fmt.Sprintf("/queue/%d/infos", w.bookedPBJobID), nil)
 	if err != nil {
-		log.Error("Unable to load pipeline build job %d: %v", w.bookedJobID, err)
+		log.Error("Unable to load pipeline build job %d: %v", w.bookedPBJobID, err)
 		return
 	}
 
 	j := &sdk.PipelineBuildJob{}
 	if err := json.Unmarshal(b, j); err != nil {
-		log.Error("Unable to load pipeline build job %d: %v", w.bookedJobID, err)
+		log.Error("Unable to load pipeline build job %d: %v", w.bookedPBJobID, err)
 		return
 	}
 
-	requirementsOK, errRequirements := checkRequirements(w, &j.Job.Action, j.ExecGroups, w.bookedJobID)
+	requirementsOK, errRequirements := checkRequirements(w, &j.Job.Action, j.ExecGroups, w.bookedPBJobID)
 	if !requirementsOK {
 		var details string
 		for _, r := range errRequirements {
@@ -341,13 +350,44 @@ func (w *currentWorker) processBookedJob(pbjobs chan<- sdk.PipelineBuildJob) {
 	pbjobs <- *j
 }
 
+func (w *currentWorker) processBookedWJob(wjobs chan<- sdk.WorkflowNodeJobRun) {
+	log.Debug("Try to take the workflow node job %d", w.bookedWJobID)
+	wjob, err := w.client.QueueJobInfo(w.bookedWJobID)
+	if err != nil {
+		log.Error("Unable to load workflow node job %d: %v", w.bookedWJobID, err)
+		return
+	}
+
+	requirementsOK, errRequirements := checkRequirements(w, &wjob.Job.Action, nil, wjob.ID)
+	if !requirementsOK {
+		var details string
+		for _, r := range errRequirements {
+			details += fmt.Sprintf(" %s(%s)", r.Value, r.Type)
+		}
+		infos := []sdk.SpawnInfo{{
+			RemoteTime: time.Now(),
+			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
+		}}
+		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos); err != nil {
+			log.Warning("Cannot record QueueJobSendSpawnInfo for job (err spawn): %d %s", wjob.ID, err)
+		}
+		return
+	}
+
+	// requirementsOK is ok
+	wjobs <- *wjob
+}
+
 func (w *currentWorker) doRegister() error {
 	if w.id == "" {
 		var info string
-		if w.bookedJobID > 0 {
-			info = fmt.Sprintf(", I was born to work on job %d", w.bookedJobID)
+		if w.bookedPBJobID > 0 {
+			info = fmt.Sprintf(", I was born to work on pipeline build job %d", w.bookedPBJobID)
 		}
-		log.Info("Registering on CDS engine%s", info)
+		if w.bookedWJobID > 0 {
+			info = fmt.Sprintf(", I was born to work on workflow node job %d", w.bookedWJobID)
+		}
+		log.Info("Registering on CDS engine%s Version:%s", info, sdk.VERSION)
 		form := worker.RegistrationForm{
 			Name:         w.status.Name,
 			Token:        w.token,

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -80,7 +80,8 @@ func initViper(w *currentWorker) {
 	if w.basedir == "" {
 		w.basedir = os.TempDir()
 	}
-	w.bookedJobID = viper.GetInt64("booked_job_id")
+	w.bookedPBJobID = viper.GetInt64("booked_pb_job_id")
+	w.bookedWJobID = viper.GetInt64("booked_workflow_job_id")
 
 	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name)
 }

--- a/engine/worker/main.go
+++ b/engine/worker/main.go
@@ -15,7 +15,8 @@ type currentWorker struct {
 	id            string
 	model         sdk.Model
 	groupID       int64
-	bookedJobID   int64
+	bookedPBJobID int64
+	bookedWJobID  int64
 	nbActionsDone int
 	basedir       string
 	logger        struct {

--- a/engine/worker/take_workflow_node_run_job.go
+++ b/engine/worker/take_workflow_node_run_job.go
@@ -22,7 +22,7 @@ func (w *currentWorker) takeWorkflowJob(ctx context.Context, job sdk.WorkflowNod
 		return true, sdk.WrapError(err, "takeWorkflowJob> Unable to take workflow node run job. This worker can work on another job.")
 	}
 	t := ""
-	if w.bookedJobID == job.ID {
+	if w.bookedWJobID == job.ID {
 		t = ", this was my booked job"
 	}
 	log.Info("takeWorkflowJob> Job %d taken%s", job.ID, t)

--- a/engine/worker/take_workflow_node_run_job.go
+++ b/engine/worker/take_workflow_node_run_job.go
@@ -17,7 +17,7 @@ import (
 // If Take is not possible (as Job already booked for example)
 // it will return true (-> can work on another job), false, otherwise
 func (w *currentWorker) takeWorkflowJob(ctx context.Context, job sdk.WorkflowNodeJobRun) (bool, error) {
-	info, err := w.client.QueueTakeJob(job, w.bookedJobID == job.ID)
+	info, err := w.client.QueueTakeJob(job, w.bookedWJobID == job.ID)
 	if err != nil {
 		return true, sdk.WrapError(err, "takeWorkflowJob> Unable to take workflow node run job. This worker can work on another job.")
 	}

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -54,7 +54,6 @@ type CommonConfiguration struct {
 	} `toml:"logOptions" comment:"Hatchery Log Configuration"`
 }
 
-// Interface describe an interface for each hatchery mode (mesos, local)
 // Interface describe an interface for each hatchery mode
 // Init create new clients for different api
 // SpawnWorker creates a new vm instance
@@ -68,7 +67,7 @@ type CommonConfiguration struct {
 // ID returns hatchery id
 type Interface interface {
 	Init() error
-	SpawnWorker(model *sdk.Model, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error)
+	SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error)
 	CanSpawn(model *sdk.Model, jobID int64, requirements []sdk.Requirement) bool
 	WorkersStartedByModel(model *sdk.Model) int
 	WorkersStarted() int
@@ -162,7 +161,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 				log.Debug("routine> %d - cannot book job %d %s: %s", timestamp, jobID, model.Name, err)
 				break // go to next job
 			}
-			log.Debug("routine> %d - send book job %d %s by hatchery %d", timestamp, jobID, model.Name, h.Hatchery().ID)
+			log.Debug("routine> %d - send book job %d %s by hatchery %d isWorkflowJob:%t", timestamp, jobID, model.Name, h.Hatchery().ID, isWorkflowJob)
 
 			start := time.Now()
 			infos := []sdk.SpawnInfo{
@@ -171,7 +170,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 					Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoHatcheryStarts.ID, Args: []interface{}{fmt.Sprintf("%s", h.Hatchery().Name), fmt.Sprintf("%d", h.Hatchery().ID), model.Name}},
 				},
 			}
-			workerName, errSpawn := h.SpawnWorker(&model, jobID, requirements, false, "spawn for job")
+			workerName, errSpawn := h.SpawnWorker(&model, isWorkflowJob, jobID, requirements, false, "spawn for job")
 			if errSpawn != nil {
 				log.Warning("routine> %d - cannot spawn worker %s for job %d: %s", timestamp, model.Name, jobID, errSpawn)
 				infos = append(infos, sdk.SpawnInfo{
@@ -219,7 +218,7 @@ func provisioning(h Interface, provisionDisabled bool, models []sdk.Model) {
 			existing := h.WorkersStartedByModel(&models[k])
 			for i := existing; i < int(models[k].Provision); i++ {
 				go func(m sdk.Model) {
-					if name, errSpawn := h.SpawnWorker(&m, 0, nil, false, "spawn for provision"); errSpawn != nil {
+					if name, errSpawn := h.SpawnWorker(&m, false, 0, nil, false, "spawn for provision"); errSpawn != nil {
 						log.Warning("provisioning> cannot spawn worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)
 						if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("routine> cannot spawn worker %s for provisioning: %s", m.Name, errSpawn)); err != nil {
 							log.Error("provisioning> cannot client.WorkerModelSpawnError for worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -56,7 +56,7 @@ type CommonConfiguration struct {
 
 // SpawnArguments contains arguments to func SpawnWorker
 type SpawnArguments struct {
-	Model         *sdk.Model
+	Model         sdk.Model
 	IsWorkflowJob bool
 	JobID         int64
 	Requirements  []sdk.Requirement
@@ -180,7 +180,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 					Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoHatcheryStarts.ID, Args: []interface{}{fmt.Sprintf("%s", h.Hatchery().Name), fmt.Sprintf("%d", h.Hatchery().ID), model.Name}},
 				},
 			}
-			workerName, errSpawn := h.SpawnWorker(SpawnArguments{Model: &model, IsWorkflowJob: isWorkflowJob, JobID: jobID, Requirements: requirements, LogInfo: "spawn for job"})
+			workerName, errSpawn := h.SpawnWorker(SpawnArguments{Model: model, IsWorkflowJob: isWorkflowJob, JobID: jobID, Requirements: requirements, LogInfo: "spawn for job"})
 			if errSpawn != nil {
 				log.Warning("routine> %d - cannot spawn worker %s for job %d: %s", timestamp, model.Name, jobID, errSpawn)
 				infos = append(infos, sdk.SpawnInfo{
@@ -228,7 +228,7 @@ func provisioning(h Interface, provisionDisabled bool, models []sdk.Model) {
 			existing := h.WorkersStartedByModel(&models[k])
 			for i := existing; i < int(models[k].Provision); i++ {
 				go func(m sdk.Model) {
-					if name, errSpawn := h.SpawnWorker(SpawnArguments{Model: &m, IsWorkflowJob: false, JobID: 0, Requirements: nil, LogInfo: "spawn for provision"}); errSpawn != nil {
+					if name, errSpawn := h.SpawnWorker(SpawnArguments{Model: m, IsWorkflowJob: false, JobID: 0, Requirements: nil, LogInfo: "spawn for provision"}); errSpawn != nil {
 						log.Warning("provisioning> cannot spawn worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)
 						if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("routine> cannot spawn worker %s for provisioning: %s", m.Name, errSpawn)); err != nil {
 							log.Error("provisioning> cannot client.WorkerModelSpawnError for worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -54,6 +54,16 @@ type CommonConfiguration struct {
 	} `toml:"logOptions" comment:"Hatchery Log Configuration"`
 }
 
+// SpawnArguments contains arguments to func SpawnWorker
+type SpawnArguments struct {
+	Model         *sdk.Model
+	IsWorkflowJob bool
+	JobID         int64
+	Requirements  []sdk.Requirement
+	RegisterOnly  bool
+	LogInfo       string
+}
+
 // Interface describe an interface for each hatchery mode
 // Init create new clients for different api
 // SpawnWorker creates a new vm instance
@@ -67,7 +77,7 @@ type CommonConfiguration struct {
 // ID returns hatchery id
 type Interface interface {
 	Init() error
-	SpawnWorker(model *sdk.Model, isWorkflowJob bool, jobID int64, requirements []sdk.Requirement, registerOnly bool, logInfo string) (string, error)
+	SpawnWorker(spawnArgs SpawnArguments) (string, error)
 	CanSpawn(model *sdk.Model, jobID int64, requirements []sdk.Requirement) bool
 	WorkersStartedByModel(model *sdk.Model) int
 	WorkersStarted() int
@@ -170,7 +180,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 					Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoHatcheryStarts.ID, Args: []interface{}{fmt.Sprintf("%s", h.Hatchery().Name), fmt.Sprintf("%d", h.Hatchery().ID), model.Name}},
 				},
 			}
-			workerName, errSpawn := h.SpawnWorker(&model, isWorkflowJob, jobID, requirements, false, "spawn for job")
+			workerName, errSpawn := h.SpawnWorker(SpawnArguments{Model: &model, IsWorkflowJob: isWorkflowJob, JobID: jobID, Requirements: requirements, LogInfo: "spawn for job"})
 			if errSpawn != nil {
 				log.Warning("routine> %d - cannot spawn worker %s for job %d: %s", timestamp, model.Name, jobID, errSpawn)
 				infos = append(infos, sdk.SpawnInfo{
@@ -218,7 +228,7 @@ func provisioning(h Interface, provisionDisabled bool, models []sdk.Model) {
 			existing := h.WorkersStartedByModel(&models[k])
 			for i := existing; i < int(models[k].Provision); i++ {
 				go func(m sdk.Model) {
-					if name, errSpawn := h.SpawnWorker(&m, false, 0, nil, false, "spawn for provision"); errSpawn != nil {
+					if name, errSpawn := h.SpawnWorker(SpawnArguments{Model: &m, IsWorkflowJob: false, JobID: 0, Requirements: nil, LogInfo: "spawn for provision"}); errSpawn != nil {
 						log.Warning("provisioning> cannot spawn worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)
 						if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("routine> cannot spawn worker %s for provisioning: %s", m.Name, errSpawn)); err != nil {
 							log.Error("provisioning> cannot client.WorkerModelSpawnError for worker %s with model %s for provisioning: %s", name, m.Name, errSpawn)

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -222,7 +222,7 @@ func workerRegister(h Interface, models []sdk.Model) error {
 
 		if h.NeedRegistration(&m) {
 			log.Info("workerRegister> spawn a worker for register worker model %s (%d)", m.Name, m.ID)
-			if _, errSpawn := h.SpawnWorker(SpawnArguments{Model: &m, IsWorkflowJob: false, JobID: 0, Requirements: nil, RegisterOnly: true, LogInfo: "spawn for register"}); errSpawn != nil {
+			if _, errSpawn := h.SpawnWorker(SpawnArguments{Model: m, IsWorkflowJob: false, JobID: 0, Requirements: nil, RegisterOnly: true, LogInfo: "spawn for register"}); errSpawn != nil {
 				log.Warning("workerRegister> cannot spawn worker for register: %s", m.Name, errSpawn)
 				if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("workerRegister> cannot spawn worker for register: %s", errSpawn)); err != nil {
 					log.Error("workerRegister> error on call client.WorkerModelSpawnError on worker model %s for register: %s", m.Name, errSpawn)

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -222,7 +222,7 @@ func workerRegister(h Interface, models []sdk.Model) error {
 
 		if h.NeedRegistration(&m) {
 			log.Info("workerRegister> spawn a worker for register worker model %s (%d)", m.Name, m.ID)
-			if _, errSpawn := h.SpawnWorker(&m, 0, nil, true, "spawn for register"); errSpawn != nil {
+			if _, errSpawn := h.SpawnWorker(&m, false, 0, nil, true, "spawn for register"); errSpawn != nil {
 				log.Warning("workerRegister> cannot spawn worker for register: %s", m.Name, errSpawn)
 				if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("workerRegister> cannot spawn worker for register: %s", errSpawn)); err != nil {
 					log.Error("workerRegister> error on call client.WorkerModelSpawnError on worker model %s for register: %s", m.Name, errSpawn)

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -222,7 +222,7 @@ func workerRegister(h Interface, models []sdk.Model) error {
 
 		if h.NeedRegistration(&m) {
 			log.Info("workerRegister> spawn a worker for register worker model %s (%d)", m.Name, m.ID)
-			if _, errSpawn := h.SpawnWorker(&m, false, 0, nil, true, "spawn for register"); errSpawn != nil {
+			if _, errSpawn := h.SpawnWorker(SpawnArguments{Model: &m, IsWorkflowJob: false, JobID: 0, Requirements: nil, RegisterOnly: true, LogInfo: "spawn for register"}); errSpawn != nil {
 				log.Warning("workerRegister> cannot spawn worker for register: %s", m.Name, errSpawn)
 				if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("workerRegister> cannot spawn worker for register: %s", errSpawn)); err != nil {
 					log.Error("workerRegister> error on call client.WorkerModelSpawnError on worker model %s for register: %s", m.Name, errSpawn)


### PR DESCRIPTION
A worker can be launch to run a Pipeline Build Job or a Workflow Job
Before this commit, we can see:

```
| 2017-11-05 11:33:40 | warn | GET     | 404  | /queue/8820/infos      getPipelineBuildJobHandler> Unable to load pipeline build job id: Pipeline build not found
| 2017-11-05 11:33:40 | warn | GET     | 404  | /queue/8821/infos      getPipelineBuildJobHandler> Unable to load pipeline build job id: Pipeline build not found
| 2017-11-05 11:33:40 | warn | GET     | 404  | /queue/8812/infos      getPipelineBuildJobHandler> Unable to load pipeline build job id: Pipeline build not found
| 2017-11-05 11:33:40 | warn | GET     | 404  | /queue/8811/infos      getPipelineBuildJobHandler> Unable to load pipeline build job id: Pipeline build not found
```
from Worker launched to work on workflow job

Two separate arguments on the worker to avoid any confusion.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>