### PR TITLE
fix (api): perf import pipeline

### DIFF
--- a/engine/api/pipeline_import.go
+++ b/engine/api/pipeline_import.go
@@ -146,12 +146,6 @@ func (api *API) importPipelineHandler() Handler {
 			return sdk.WrapError(err, "importPipelineHandler> Cannot commit transaction")
 		}
 
-		var errlp error
-		proj.Pipelines, errlp = pipeline.LoadPipelines(api.mustDB(), proj.ID, true, getUser(ctx))
-		if errlp != nil {
-			return sdk.WrapError(errlp, "importPipelineHandler> Unable to reload pipelines for project %s", proj.Key)
-		}
-
 		go func() {
 			if err := sanity.CheckProjectPipelines(api.mustDB(), api.Cache, proj); err != nil {
 				log.Error("importPipelineHandler> Cannot check warnings: %s", err)


### PR DESCRIPTION
no need to call pipeline.LoadPipelines, it's already done inside sanity.CheckProjectPipelines

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>