### PR TITLE
fix (api): LoadAndLockNodeJobRunWait on spawnInfo

### DIFF
--- a/engine/api/workflow/execute_node_job_run.go
+++ b/engine/api/workflow/execute_node_job_run.go
@@ -123,7 +123,7 @@ func UpdateNodeJobRunStatus(db gorp.SqlExecutor, store cache.Store, p *sdk.Proje
 
 // AddSpawnInfosNodeJobRun saves spawn info before starting worker
 func AddSpawnInfosNodeJobRun(db gorp.SqlExecutor, store cache.Store, p *sdk.Project, id int64, infos []sdk.SpawnInfo) (*sdk.WorkflowNodeJobRun, error) {
-	j, err := LoadAndLockNodeJobRunNoWait(db, store, id)
+	j, err := LoadAndLockNodeJobRunWait(db, store, id)
 	if err != nil {
 		return nil, sdk.WrapError(err, "AddSpawnInfosNodeJobRun> Cannot load node job run")
 	}

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -264,7 +264,7 @@ func (api *API) postWorkflowJobResultHandler() AsynchronousHandler {
 
 		//Add spawn infos
 		if _, err := workflow.AddSpawnInfosNodeJobRun(tx, api.Cache, p, job.ID, infos); err != nil {
-			log.Error("addQueueResultHandler> Cannot save spawn info job %d: %s", job.ID, err)
+			log.Error("postWorkflowJobResultHandler> Cannot save spawn info job %d: %s", job.ID, err)
 			return err
 		}
 
@@ -469,7 +469,7 @@ func (api *API) postWorkflowJobVariableHandler() AsynchronousHandler {
 		}
 		defer tx.Rollback()
 
-		job, errj := workflow.LoadAndLockNodeJobRunNoWait(tx, api.Cache, id)
+		job, errj := workflow.LoadAndLockNodeJobRunWait(tx, api.Cache, id)
 		if errj != nil {
 			return sdk.WrapError(errj, "postWorkflowJobVariableHandler> Unable to load job")
 		}


### PR DESCRIPTION
SpawnInfo can be send in same time by hatchery & worker

this avoid many err as:

```
| 2017-11-05 14:08:01 | warn | POST    | 500  | /queue/workflows/8831/spawn/infos      postSpawnInfosWorkflowJobHandler> Cannot save job 8831: AddSpawnInfosNodeJobRun> Cannot update node job run: workflow.execute> Unable to execute node: Unable to update node id=2664 at status Waiting. err:pq: canceling statement due to statement timeout
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>