### PR TITLE
fix (api): more precision in the log

### DIFF
--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -15,7 +15,7 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 
 	// ErrAlreadyTaken is not useful to log in warning
 	if errProcessed.ID == sdk.ErrAlreadyTaken.ID {
-		log.Debug("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
+		log.Info("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
 	} else {
 		log.Warning("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
 	}

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -10,8 +10,15 @@ import (
 // WriteError is a helper function to return error in a language the called understand
 func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	al := r.Header.Get("Accept-Language")
-	msg, code := sdk.ProcessError(err, al)
+	msg, errProcessed := sdk.ProcessError(err, al)
 	sdkErr := sdk.Error{Message: msg}
-	log.Warning("%-7s | %-4d | %s \t %s", r.Method, code, r.RequestURI, err)
-	WriteJSON(w, r, sdkErr, code)
+
+	// ErrAlreadyTaken is not useful to log in warning
+	if errProcessed.ID == sdk.ErrAlreadyTaken.ID {
+		log.Debug("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
+	} else {
+		log.Warning("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
+	}
+
+	WriteJSON(w, r, sdkErr, errProcessed.Status)
 }

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -14,7 +14,7 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	sdkErr := sdk.Error{Message: msg}
 
 	// ErrAlreadyTaken is not useful to log in warning
-	if errProcessed.ID == sdk.ErrAlreadyTaken.ID {
+	if sdk.ErrorIs(errProcessed, sdk.ErrAlreadyTaken) {
 		log.Info("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)
 	} else {
 		log.Warning("%-7s | %-4d | %s \t %s", r.Method, errProcessed.Status, r.RequestURI, err)

--- a/engine/api/scheduler/dao.go
+++ b/engine/api/scheduler/dao.go
@@ -47,7 +47,7 @@ func loadAndLockPipelineScheduler(db gorp.SqlExecutor, id int64) (*sdk.PipelineS
 	var gorpPS = &PipelineScheduler{}
 	if err := db.SelectOne(gorpPS, query, id); err != nil {
 		if pqerr, ok := err.(*pq.Error); ok && pqerr.Code != "55P03" {
-			log.Error("Run> Unable to lock to pipeline_scheduler %s", err)
+			log.Error("loadAndLockPipelineScheduler> Unable to lock to pipeline_scheduler %+v", pqerr)
 			return nil, nil
 		}
 		return nil, err

--- a/engine/api/scheduler/dao.go
+++ b/engine/api/scheduler/dao.go
@@ -46,10 +46,12 @@ func loadAndLockPipelineScheduler(db gorp.SqlExecutor, id int64) (*sdk.PipelineS
 
 	var gorpPS = &PipelineScheduler{}
 	if err := db.SelectOne(gorpPS, query, id); err != nil {
-		if pqerr, ok := err.(*pq.Error); ok && pqerr.Code != "55P03" {
-			log.Error("loadAndLockPipelineScheduler> Unable to lock to pipeline_scheduler %+v", pqerr)
+		if pqerr, ok := err.(*pq.Error); ok && pqerr.Code == "55P03" {
+			// 55P03 already lock, no error
+			log.Debug("loadAndLockPipelineScheduler> Unable to lock to pipeline_scheduler pqerr:%+v", pqerr)
 			return nil, nil
 		}
+		log.Error("loadAndLockPipelineScheduler> Unable to lock to pipeline_scheduler err:%+v", err)
 		return nil, err
 	}
 	ps := sdk.PipelineScheduler(*gorpPS)

--- a/engine/api/scheduler/executer.go
+++ b/engine/api/scheduler/executer.go
@@ -40,7 +40,7 @@ func ExecuterRun(DBFunc func() *gorp.DbMap, store cache.Store) ([]sdk.PipelineSc
 
 		s, errlock := loadAndLockPipelineScheduler(tx, exs[i].PipelineSchedulerID)
 		if errlock != nil {
-			log.Error("Run> Unable to load to pipeline scheduler %d %s", exs[i].PipelineSchedulerID, errlock)
+			log.Error("ExecuterRun> Unable to load to pipeline scheduler %d %s", exs[i].PipelineSchedulerID, errlock)
 			_ = tx.Rollback()
 			continue
 		}

--- a/engine/api/workflow/process.go
+++ b/engine/api/workflow/process.go
@@ -26,7 +26,7 @@ func processWorkflowRun(db gorp.SqlExecutor, store cache.Store, p *sdk.Project, 
 	}()
 
 	maxsn := MaxSubNumber(w.WorkflowNodeRuns)
-	log.Info("processWorkflowRun> %d.%d", w.Number, maxsn)
+	log.Info("processWorkflowRun> %s/%s %d.%d", p.Name, w.Workflow.Name, w.Number, maxsn)
 	w.LastSubNumber = maxsn
 
 	//Checks startingFromNode

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -367,16 +367,16 @@ func WrapError(err error, format string, args ...interface{}) error {
 }
 
 // ProcessError tries to recognize given error and return error message in a language matching Accepted-Language
-func ProcessError(target error, al string) (string, int) {
+func ProcessError(target error, al string) (string, Error) {
 	// will recursively retrieve the topmost error which does not implement causer, which is assumed to be the original cause
 	target = errors.Cause(target)
 	cdsErr, ok := target.(Error)
 	if !ok {
-		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError.Status
+		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError
 	}
 	acceptedLanguages, _, err := language.ParseAcceptLanguage(al)
 	if err != nil {
-		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError.Status
+		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError
 	}
 
 	tag, _, _ := matcher.Match(acceptedLanguages...)
@@ -394,7 +394,7 @@ func ProcessError(target error, al string) (string, int) {
 	}
 
 	if !ok {
-		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError.Status
+		return errorsAmericanEnglish[ErrUnknownError.ID], ErrUnknownError
 	}
 	if cdsErr.Root != nil {
 		cdsErrRoot, ok := cdsErr.Root.(*Error)
@@ -407,7 +407,7 @@ func ProcessError(target error, al string) (string, int) {
 
 		msg = fmt.Sprintf("%s (caused by: %s)", msg, rootMsg)
 	}
-	return msg, cdsErr.Status
+	return msg, cdsErr
 }
 
 // Exit func display an error message on stderr and exit 1


### PR DESCRIPTION
There is something strange,

```
Run> Unable to load to pipeline scheduler 150 pq: could not obtain lock on row in relation "pipeline_scheduler"
```

This error should be "55P03", so ignored from log.Error. This commit is to have the real pqerr.Code

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>