### PR TITLE
feat (worker, api): upload pipeline build artifact with swift temp url

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -327,8 +327,10 @@ func (a *API) Serve(ctx context.Context) error {
 	//Initialize artifacts storage
 	var objectstoreKind objectstore.Kind
 	switch a.Config.Artifact.Mode {
-	case "openstack", "swift":
+	case "openstack":
 		objectstoreKind = objectstore.Openstack
+	case "swift":
+		objectstoreKind = objectstore.Swift
 	case "filesystem", "local":
 		objectstoreKind = objectstore.Filesystem
 	default:

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -226,8 +226,11 @@ func (api *API) InitRouter() {
 	// Artifacts
 	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/artifact/{tag}", r.GET(api.listArtifactsHandler))
 	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/{buildNumber}/artifact", r.GET(api.listArtifactsBuildHandler))
+	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/{buildNumber}/artifact/{tag}/url", r.POSTEXECUTE(api.postArtifactWithTempURLHandler))
+	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/{buildNumber}/artifact/{tag}/url/callback", r.POSTEXECUTE(api.postArtifactWithTempURLCallbackHandler))
 	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/{buildNumber}/artifact/{tag}", r.POSTEXECUTE(api.uploadArtifactHandler))
 	r.Handle("/project/{key}/application/{permApplicationName}/pipeline/{permPipelineKey}/artifact/download/{id}", r.GET(api.downloadArtifactHandler))
+	r.Handle("/artifact/store", r.GET(api.getArtifactsStoreHandler, Auth(false)))
 	r.Handle("/artifact/{hash}", r.GET(api.downloadArtifactDirectHandler, Auth(false)))
 
 	// Hooks

--- a/engine/api/artifact.go
+++ b/engine/api/artifact.go
@@ -152,6 +152,7 @@ func (api *API) downloadArtifactHandler() Handler {
 		}
 
 		if _, err := io.Copy(w, f); err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "downloadArtifactHandler> Cannot stream artifact")
 		}
 
@@ -287,6 +288,7 @@ func (api *API) downloadArtifactDirectHandler() Handler {
 		}
 
 		if _, err := io.Copy(w, f); err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "downloadArtifactDirectHandler> Cannot stream artifact")
 		}
 

--- a/engine/api/artifact.go
+++ b/engine/api/artifact.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ovh/cds/engine/api/application"
 	"github.com/ovh/cds/engine/api/artifact"
+	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/engine/api/environment"
 	"github.com/ovh/cds/engine/api/objectstore"
 	"github.com/ovh/cds/engine/api/permission"
@@ -263,6 +264,12 @@ func (api *API) listArtifactsHandler() Handler {
 	}
 }
 
+func (api *API) getArtifactsStoreHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		return WriteJSON(w, r, objectstore.Instance(), http.StatusOK)
+	}
+}
+
 func (api *API) downloadArtifactDirectHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		vars := mux.Vars(r)
@@ -289,6 +296,138 @@ func (api *API) downloadArtifactDirectHandler() Handler {
 
 		w.Header().Add("Content-Type", "application/octet-stream")
 		w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", art.Name))
+
+		return nil
+	}
+}
+
+func (api *API) postArtifactWithTempURLHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		if !objectstore.Instance().TemporaryURLSupported {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLHandler")
+		}
+
+		store, ok := objectstore.Storage().(objectstore.DriverWithRedirect)
+		if !ok {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLHandler > cast error")
+		}
+
+		vars := mux.Vars(r)
+		proj := vars["key"]
+		pip := vars["permPipelineKey"]
+		app := vars["permApplicationName"]
+		tag := vars["tag"]
+		buildNumberString := vars["buildNumber"]
+		envName := r.FormValue("envName")
+
+		var env *sdk.Environment
+		if envName == "" || envName == sdk.DefaultEnv.Name {
+			env = &sdk.DefaultEnv
+		} else {
+			var errE error
+			env, errE = environment.LoadEnvironmentByName(api.mustDB(), proj, envName)
+			if errE != nil {
+				return sdk.WrapError(errE, "postArtifactWithTempURLHandler> Cannot load environment %s", envName)
+			}
+		}
+
+		if !permission.AccessToEnvironment(env.ID, getUser(ctx), permission.PermissionReadExecute) {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLHandler> No enought right on this environment %s")
+		}
+
+		buildNumber, errI := strconv.Atoi(buildNumberString)
+		if errI != nil {
+			return sdk.WrapError(sdk.ErrWrongRequest, "postArtifactWithTempURLHandler> BuildNumber must be an integer: %s", errI)
+		}
+
+		hash, errG := generateHash()
+		if errG != nil {
+			return sdk.WrapError(errG, "postArtifactWithTempURLHandler> Could not generate hash")
+		}
+
+		art := new(sdk.Artifact)
+		if err := UnmarshalBody(r, art); err != nil {
+			return sdk.WrapError(err, "postArtifactWithTempURLHandler> Unable to unmarshal artifact")
+		}
+
+		art.DownloadHash = hash
+		art.Project = proj
+		art.Application = app
+		art.Pipeline = pip
+		art.Environment = env.Name
+		art.BuildNumber = buildNumber
+		art.Tag = tag
+
+		url, key, err := store.StoreURL(art)
+		if err != nil {
+			return sdk.WrapError(err, "postArtifactWithTempURLHandler> Could not generate hash")
+		}
+
+		art.TempURL = url
+		art.TempURLSecretKey = key
+
+		cacheKey := cache.Key("artifacts", art.GetPath(), art.GetName())
+		api.Cache.Set(cacheKey, art)
+
+		return WriteJSON(w, r, art, http.StatusOK)
+	}
+}
+
+func (api *API) postArtifactWithTempURLCallbackHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		if !objectstore.Instance().TemporaryURLSupported {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLCallbackHandler")
+		}
+
+		vars := mux.Vars(r)
+		projKey := vars["key"]
+		pipName := vars["permPipelineKey"]
+		appName := vars["permApplicationName"]
+		envName := r.FormValue("envName")
+
+		art := new(sdk.Artifact)
+		if err := UnmarshalBody(r, art); err != nil {
+			return sdk.WrapError(err, "postArtifactWithTempURLCallbackHandler> Unable to read artifact")
+		}
+
+		cacheKey := cache.Key("artifacts", art.GetPath(), art.GetName())
+		cachedArt := new(sdk.Artifact)
+		if !api.Cache.Get(cacheKey, cachedArt) {
+			return sdk.WrapError(sdk.ErrNotFound, "postArtifactWithTempURLCallbackHandler> Unable to find artifact")
+		}
+
+		if art.DownloadHash != cachedArt.DownloadHash {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLCallbackHandler> Submitted artifact doesn't match")
+		}
+
+		var env *sdk.Environment
+		if envName == "" || envName == sdk.DefaultEnv.Name {
+			env = &sdk.DefaultEnv
+		} else {
+			var errE error
+			env, errE = environment.LoadEnvironmentByName(api.mustDB(), projKey, envName)
+			if errE != nil {
+				return sdk.WrapError(errE, "postArtifactWithTempURLCallbackHandler> Cannot load environment %s", envName)
+			}
+		}
+
+		if !permission.AccessToEnvironment(env.ID, getUser(ctx), permission.PermissionReadExecute) {
+			return sdk.WrapError(sdk.ErrForbidden, "postArtifactWithTempURLCallbackHandler> No enought right on this environment %s")
+		}
+
+		pip, errpip := pipeline.LoadPipeline(api.mustDB(), projKey, pipName, false)
+		if errpip != nil {
+			return sdk.WrapError(errpip, "postArtifactWithTempURLCallbackHandler> Unable to load pipeline %s/%s", projKey, pipName)
+		}
+
+		app, errapp := application.LoadByName(api.mustDB(), api.Cache, projKey, appName, getUser(ctx))
+		if errapp != nil {
+			return sdk.WrapError(errapp, "postArtifactWithTempURLCallbackHandler> Unable to load application %s/%s", projKey, appName)
+		}
+
+		if err := artifact.InsertArtifact(api.mustDB(), pip.ID, app.ID, env.ID, *art); err != nil {
+			return sdk.WrapError(err, "postArtifactWithTempURLCallbackHandler> Unable to save artifact")
+		}
 
 		return nil
 	}

--- a/engine/api/artifact/artifact.go
+++ b/engine/api/artifact/artifact.go
@@ -222,7 +222,7 @@ func DeleteArtifact(db gorp.SqlExecutor, id int64) error {
 	return nil
 }
 
-func insertArtifact(db gorp.SqlExecutor, pipelineID, applicationID int64, environmentID int64, art sdk.Artifact) error {
+func InsertArtifact(db gorp.SqlExecutor, pipelineID, applicationID int64, environmentID int64, art sdk.Artifact) error {
 	query := `DELETE FROM "artifact" WHERE name = $1 AND tag = $2 AND pipeline_id = $3 AND application_id = $4 AND environment_id = $5`
 	_, err := db.Exec(query, art.Name, art.Tag, pipelineID, applicationID, environmentID)
 	if err != nil {
@@ -265,7 +265,7 @@ func SaveFile(db *gorp.DbMap, p *sdk.Pipeline, a *sdk.Application, art sdk.Artif
 	}
 	log.Debug("objectpath=%s\n", objectPath)
 	art.ObjectPath = objectPath
-	if err := insertArtifact(tx, p.ID, a.ID, e.ID, art); err != nil {
+	if err := InsertArtifact(tx, p.ID, a.ID, e.ID, art); err != nil {
 		return sdk.WrapError(err, "SaveFile> Cannot insert artifact in DB")
 	}
 

--- a/engine/api/artifact/artifact.go
+++ b/engine/api/artifact/artifact.go
@@ -2,7 +2,6 @@ package artifact
 
 import (
 	"database/sql"
-	"fmt"
 	"io"
 	"strings"
 
@@ -271,17 +270,4 @@ func SaveFile(db *gorp.DbMap, p *sdk.Pipeline, a *sdk.Application, art sdk.Artif
 	}
 
 	return tx.Commit()
-}
-
-// StreamFile Stream artifact
-func StreamFile(w io.Writer, o objectstore.Object) error {
-	f, err := objectstore.FetchArtifact(o)
-	if err != nil {
-		return fmt.Errorf("cannot fetch artifact: %s", err)
-	}
-
-	if err := objectstore.StreamFile(w, f); err != nil {
-		return err
-	}
-	return f.Close()
 }

--- a/engine/api/objectstore/objectstore.go
+++ b/engine/api/objectstore/objectstore.go
@@ -9,6 +9,7 @@ import (
 )
 
 var storage Driver
+var instance sdk.ArtifactsStore
 
 //Status is for status handler
 func Status() string {
@@ -17,6 +18,16 @@ func Status() string {
 	}
 
 	return storage.Status()
+}
+
+// Instance returns the objectstore singleton
+func Instance() sdk.ArtifactsStore {
+	return instance
+}
+
+// Storage returns the Driver singleton
+func Storage() Driver {
+	return storage
 }
 
 //StoreArtifact an artifact with default objectstore driver
@@ -159,6 +170,11 @@ type ConfigOptionsFilesystem struct {
 func New(c context.Context, cfg Config) (Driver, error) {
 	switch cfg.Kind {
 	case Openstack:
+		instance = sdk.ArtifactsStore{
+			Name:                  "Openstack",
+			Private:               false,
+			TemporaryURLSupported: false,
+		}
 		return NewOpenstackStore(c, cfg.Options.Openstack.Address,
 			cfg.Options.Openstack.Username,
 			cfg.Options.Openstack.Password,
@@ -166,6 +182,11 @@ func New(c context.Context, cfg Config) (Driver, error) {
 			cfg.Options.Openstack.Region,
 			cfg.Options.Openstack.ContainerPrefix)
 	case Swift:
+		instance = sdk.ArtifactsStore{
+			Name:                  "Swift",
+			Private:               false,
+			TemporaryURLSupported: true,
+		}
 		return NewSwiftStore(cfg.Options.Openstack.Address,
 			cfg.Options.Openstack.Username,
 			cfg.Options.Openstack.Password,
@@ -173,6 +194,11 @@ func New(c context.Context, cfg Config) (Driver, error) {
 			cfg.Options.Openstack.Tenant,
 			cfg.Options.Openstack.ContainerPrefix)
 	case Filesystem:
+		instance = sdk.ArtifactsStore{
+			Name:                  "Local FS",
+			Private:               false,
+			TemporaryURLSupported: false,
+		}
 		return NewFilesystemStore(cfg.Options.Filesystem.Basedir)
 	default:
 		return nil, fmt.Errorf("Invalid flag --artifact-mode")

--- a/engine/api/objectstore/objectstore.go
+++ b/engine/api/objectstore/objectstore.go
@@ -101,6 +101,11 @@ type Driver interface {
 	Delete(o Object) error
 }
 
+type DriverWithRedirect interface {
+	StoreURL(o Object) (string, string, error)
+	FetchURL(o Object) (string, string, error)
+}
+
 // Initialize setup wanted ObjectStore driver
 func Initialize(c context.Context, cfg Config) error {
 	var err error
@@ -153,65 +158,23 @@ type ConfigOptionsFilesystem struct {
 // New initialise a new ArtifactStorage
 func New(c context.Context, cfg Config) (Driver, error) {
 	switch cfg.Kind {
-	case Openstack, Swift:
+	case Openstack:
 		return NewOpenstackStore(c, cfg.Options.Openstack.Address,
 			cfg.Options.Openstack.Username,
 			cfg.Options.Openstack.Password,
 			cfg.Options.Openstack.Tenant,
 			cfg.Options.Openstack.Region,
 			cfg.Options.Openstack.ContainerPrefix)
+	case Swift:
+		return NewSwiftStore(cfg.Options.Openstack.Address,
+			cfg.Options.Openstack.Username,
+			cfg.Options.Openstack.Password,
+			cfg.Options.Openstack.Region,
+			cfg.Options.Openstack.Tenant,
+			cfg.Options.Openstack.ContainerPrefix)
 	case Filesystem:
 		return NewFilesystemStore(cfg.Options.Filesystem.Basedir)
 	default:
 		return nil, fmt.Errorf("Invalid flag --artifact-mode")
 	}
-}
-
-//StreamFile streams file
-func StreamFile(w io.Writer, f io.ReadCloser) error {
-	n, err := copyBuffer(w, f, nil)
-	if err != nil {
-		return fmt.Errorf("cannot stream to client [%dbytes copied]: %s", n, err)
-	}
-	return nil
-}
-
-func copyBuffer(dst io.Writer, src io.Reader, buf []byte) (written int64, err error) {
-	// If the reader has a WriteTo method, use it to do the copy.
-	// Avoids an allocation and a copy.
-	if wt, ok := src.(io.WriterTo); ok {
-		return wt.WriteTo(dst)
-	}
-	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
-	if rt, ok := dst.(io.ReaderFrom); ok {
-		return rt.ReadFrom(src)
-	}
-	if buf == nil {
-		buf = make([]byte, 32*1024)
-	}
-	for {
-		nr, er := src.Read(buf)
-		if nr > 0 {
-			nw, ew := dst.Write(buf[0:nr])
-			if nw > 0 {
-				written += int64(nw)
-			}
-			if ew != nil {
-				err = fmt.Errorf("writer: %s", ew)
-				break
-			}
-			if nr != nw {
-				err = io.ErrShortWrite
-				break
-			}
-		}
-		if er == io.EOF {
-			break
-		}
-		if er != nil {
-			err = fmt.Errorf("reader: %s", er)
-			break
-		}
-	}
-	return written, err
 }

--- a/engine/api/objectstore/openstack.go
+++ b/engine/api/objectstore/openstack.go
@@ -79,7 +79,7 @@ func (ops *OpenstackStore) Store(o Object, data io.ReadCloser) (string, error) {
 	container := ops.containerprefix + o.GetPath()
 	object := o.GetName()
 
-	ops.escape(container, object)
+	escape(container, object)
 
 	log.Debug("OpenstackStore> Storing /%s/%s\n", container, object)
 
@@ -104,7 +104,7 @@ func (ops *OpenstackStore) Store(o Object, data io.ReadCloser) (string, error) {
 func (ops *OpenstackStore) Fetch(o Object) (io.ReadCloser, error) {
 	container := ops.containerprefix + o.GetPath()
 	object := o.GetName()
-	ops.escape(container, object)
+	escape(container, object)
 
 	log.Debug("OpenstackStore> Fetching /%s/%s\n", container, object)
 
@@ -116,7 +116,7 @@ func (ops *OpenstackStore) Fetch(o Object) (io.ReadCloser, error) {
 	return data, nil
 }
 
-func (ops *OpenstackStore) escape(container, object string) (string, string) {
+func escape(container, object string) (string, string) {
 	container = url.QueryEscape(container)
 	container = strings.Replace(container, "/", "-", -1)
 	object = url.QueryEscape(object)

--- a/engine/api/objectstore/swift.go
+++ b/engine/api/objectstore/swift.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/ovh/cds/engine/api/sessionstore"
-
 	"github.com/ncw/swift"
+
+	"github.com/ovh/cds/engine/api/sessionstore"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/log"
 )

--- a/engine/api/objectstore/swift.go
+++ b/engine/api/objectstore/swift.go
@@ -65,6 +65,8 @@ func (s *SwiftStore) Store(o Object, data io.ReadCloser) (string, error) {
 
 	log.Debug("SwiftStore> copy object %s/%s", container, object)
 	if _, err := io.Copy(file, data); err != nil {
+		_ = file.Close()
+		_ = data.Close()
 		return "", sdk.WrapError(err, "SwiftStore> Unable to copy object buffer %s", object)
 	}
 
@@ -79,6 +81,7 @@ func (s *SwiftStore) Store(o Object, data io.ReadCloser) (string, error) {
 	return container + "/" + object, nil
 }
 
+// Fetch an object from swift
 func (s *SwiftStore) Fetch(o Object) (io.ReadCloser, error) {
 	container := s.containerprefix + o.GetPath()
 	object := o.GetName()
@@ -100,6 +103,7 @@ func (s *SwiftStore) Fetch(o Object) (io.ReadCloser, error) {
 	return pipeReader, nil
 }
 
+// Delete an object from swift
 func (s *SwiftStore) Delete(o Object) error {
 	container := s.containerprefix + o.GetPath()
 	object := o.GetName()
@@ -111,6 +115,7 @@ func (s *SwiftStore) Delete(o Object) error {
 	return nil
 }
 
+// StoreURL returns a temporary url and a secret key to store an object
 func (s *SwiftStore) StoreURL(o Object) (string, string, error) {
 	container := s.containerprefix + o.GetPath()
 	object := o.GetName()
@@ -150,6 +155,7 @@ func (s *SwiftStore) containerKey(container string) (string, error) {
 	return key, nil
 }
 
+// FetchURL returns a temporary url and a secret key to fetch an object
 func (s *SwiftStore) FetchURL(o Object) (string, string, error) {
 	container := s.containerprefix + o.GetPath()
 	object := o.GetName()

--- a/engine/api/objectstore/swift.go
+++ b/engine/api/objectstore/swift.go
@@ -1,0 +1,135 @@
+package objectstore
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/ovh/cds/engine/api/sessionstore"
+
+	"github.com/ncw/swift"
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
+)
+
+// SwiftStore implements ObjectStore interface with openstack swift implementation
+type SwiftStore struct {
+	swift.Connection
+	containerprefix string
+}
+
+// NewSwiftStore create a new ObjectStore with openstack driver and check configuration
+func NewSwiftStore(authURL, user, password, region, tenant, containerprefix string) (Driver, error) {
+	s := SwiftStore{
+		swift.Connection{
+			AuthUrl:  authURL,
+			Region:   region,
+			Tenant:   tenant,
+			UserName: user,
+			ApiKey:   password,
+		}, containerprefix}
+
+	if err := s.Authenticate(); err != nil {
+		return nil, sdk.WrapError(err, "Swift> Unable to authenticate")
+	}
+	return &s, nil
+}
+
+// Status returns the status of swift account
+func (s *SwiftStore) Status() string {
+	info, _, err := s.Account()
+	if err != nil {
+		return "Swift KO: " + err.Error()
+	}
+	return fmt.Sprintf("Swift OK (%d containers, %d objects, %d bytes used", info.Containers, info.Containers, info.BytesUsed)
+}
+
+// Store stores in swift
+func (s *SwiftStore) Store(o Object, data io.ReadCloser) (string, error) {
+	container := s.containerprefix + o.GetPath()
+	object := o.GetName()
+	escape(container, object)
+	log.Debug("SwiftStore> Storing /%s/%s\n", container, object)
+
+	log.Debug("SwiftStore> creating container %s", container)
+	if err := s.ContainerCreate(container, nil); err != nil {
+		return "", sdk.WrapError(err, "SwiftStore> Unable to create container %s", container)
+	}
+
+	log.Debug("SwiftStore> creating object %s/%s", container, object)
+
+	file, errC := s.ObjectCreate(container, object, false, "", "application/octet-stream", nil)
+	if errC != nil {
+		return "", sdk.WrapError(errC, "SwiftStore> Unable to create object %s", object)
+	}
+
+	log.Debug("SwiftStore> copy object %s/%s", container, object)
+	if _, err := io.Copy(file, data); err != nil {
+		return "", sdk.WrapError(err, "SwiftStore> Unable to copy object buffer %s", object)
+	}
+
+	if err := file.Close(); err != nil {
+		return "", sdk.WrapError(err, "SwiftStore> Unable to close object buffer %s", object)
+	}
+
+	if err := data.Close(); err != nil {
+		return "", sdk.WrapError(err, "SwiftStore> Unable to close data buffer")
+	}
+
+	return container + "/" + object, nil
+}
+
+func (s *SwiftStore) Fetch(o Object) (io.ReadCloser, error) {
+	container := s.containerprefix + o.GetPath()
+	object := o.GetName()
+	escape(container, object)
+
+	pipeReader, pipeWriter := io.Pipe()
+	log.Debug("OpenstacSwiftStorekStore> Fetching /%s/%s\n", container, object)
+
+	go func() {
+		log.Debug("SwiftStore> downloading object %s%s", container, object)
+
+		if _, err := s.ObjectGet(container, object, pipeWriter, false, nil); err != nil {
+			log.Error("SwiftStore> Unable to get object %s/%s", container, object)
+		}
+
+		log.Debug("SwiftStore> object %s%s downloaded", container, object)
+		pipeWriter.Close()
+	}()
+	return pipeReader, nil
+}
+
+func (s *SwiftStore) Delete(o Object) error {
+	container := s.containerprefix + o.GetPath()
+	object := o.GetName()
+	escape(container, object)
+
+	if err := s.ObjectDelete(container, object); err != nil {
+		return sdk.WrapError(err, "SwiftStore> Unable to delete object")
+	}
+	return nil
+}
+
+func (s *SwiftStore) StoreURL(o Object) (string, string, error) {
+	container := s.containerprefix + o.GetPath()
+	object := o.GetName()
+	escape(container, object)
+
+	if err := s.ContainerCreate(container, nil); err != nil {
+		return "", "", sdk.WrapError(err, "SwiftStore> Unable to create container %s", container)
+	}
+
+	key, _ := sessionstore.NewSessionKey()
+	url := s.ObjectTempUrl(container, object, string(key), "PUT", time.Now().Add(15*time.Minute))
+	return url, string(key), nil
+}
+
+func (s *SwiftStore) FetchURL(o Object) (string, string, error) {
+	container := s.containerprefix + o.GetPath()
+	object := o.GetName()
+	escape(container, object)
+	key, _ := sessionstore.NewSessionKey()
+	url := s.ObjectTempUrl(container, object, string(key), "GET", time.Now().Add(15*time.Minute))
+	return url, string(key), nil
+}

--- a/engine/api/plugin.go
+++ b/engine/api/plugin.go
@@ -257,6 +257,7 @@ func (api *API) downloadPluginHandler() Handler {
 		w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", name))
 
 		if _, err := io.Copy(w, f); err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "downloadPluginHandler> Cannot stream artifact")
 		}
 

--- a/engine/api/plugin.go
+++ b/engine/api/plugin.go
@@ -256,8 +256,12 @@ func (api *API) downloadPluginHandler() Handler {
 		w.Header().Add("Content-Type", "application/octet-stream")
 		w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", name))
 
-		if err := objectstore.StreamFile(w, f); err != nil {
-			return sdk.WrapError(err, "downloadPluginHandler> Error while streaming plugin %s", name)
+		if _, err := io.Copy(w, f); err != nil {
+			return sdk.WrapError(err, "downloadPluginHandler> Cannot stream artifact")
+		}
+
+		if err := f.Close(); err != nil {
+			return sdk.WrapError(err, "downloadPluginHandler> Cannot close artifact")
 		}
 
 		return nil

--- a/engine/api/project/gorp_model.go
+++ b/engine/api/project/gorp_model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/secret"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 type dbProject sdk.Project
@@ -47,7 +48,7 @@ func (p *dbProject) PostGet(db gorp.SqlExecutor) error {
 
 		if len(clearVCSServer) > 0 {
 			if err := yaml.Unmarshal(clearVCSServer, &p.VCSServers); err != nil {
-				return sdk.WrapError(err, "Unable to load project %d", p.ID)
+				log.Error("Unable to load project %d: %v", p.ID, err)
 			}
 		}
 	}

--- a/engine/api/repositoriesmanager/repositories_manager.go
+++ b/engine/api/repositoriesmanager/repositories_manager.go
@@ -322,6 +322,7 @@ func (c *vcsClient) Release(fullname, tagName, releaseTitle, releaseDescription 
 
 func (c *vcsClient) UploadReleaseFile(fullname string, releaseName, uploadURL string, artifactName string, r io.ReadCloser) error {
 	path := fmt.Sprintf("/vcs/%s/repos/%s/releases/%s/artifacts/%s", c.name, fullname, releaseName, artifactName)
+	defer r.Close()
 
 	fileContent, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -11,8 +12,8 @@ import (
 	"github.com/go-gorp/gorp"
 	"github.com/gorilla/mux"
 
-	"github.com/ovh/cds/engine/api/artifact"
 	"github.com/ovh/cds/engine/api/cache"
+	"github.com/ovh/cds/engine/api/objectstore"
 	"github.com/ovh/cds/engine/api/permission"
 	"github.com/ovh/cds/engine/api/project"
 	"github.com/ovh/cds/engine/api/workflow"
@@ -540,9 +541,17 @@ func (api *API) downloadworkflowArtifactDirectHandler() Handler {
 		w.Header().Add("Content-Type", "application/octet-stream")
 		w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", art.Name))
 
-		log.Debug("downloadworkflowArtifactDirectHandler: Serving %+v", art)
-		if err := artifact.StreamFile(w, art); err != nil {
-			return sdk.WrapError(err, "downloadworkflowArtifactDirectHandler: Cannot stream artifact")
+		f, err := objectstore.FetchArtifact(art)
+		if err != nil {
+			return sdk.WrapError(err, "downloadArtifactDirectHandler> Cannot fetch artifact")
+		}
+
+		if _, err := io.Copy(w, f); err != nil {
+			return sdk.WrapError(err, "downloadPluginHandler> Cannot stream artifact")
+		}
+
+		if err := f.Close(); err != nil {
+			return sdk.WrapError(err, "downloadPluginHandler> Cannot close artifact")
 		}
 		return nil
 	}
@@ -596,8 +605,17 @@ func (api *API) getDownloadArtifactHandler() Handler {
 		w.Header().Add("Content-Type", "application/octet-stream")
 		w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", art.Name))
 
-		if err := artifact.StreamFile(w, art); err != nil {
-			return sdk.WrapError(err, "Cannot stream artifact %s", art.Name)
+		f, err := objectstore.FetchArtifact(art)
+		if err != nil {
+			return sdk.WrapError(err, "getDownloadArtifactHandler> Cannot fetch artifact")
+		}
+
+		if _, err := io.Copy(w, f); err != nil {
+			return sdk.WrapError(err, "getDownloadArtifactHandler> Cannot stream artifact")
+		}
+
+		if err := f.Close(); err != nil {
+			return sdk.WrapError(err, "getDownloadArtifactHandler> Cannot close artifact")
 		}
 		return nil
 	}

--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -547,6 +547,7 @@ func (api *API) downloadworkflowArtifactDirectHandler() Handler {
 		}
 
 		if _, err := io.Copy(w, f); err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "downloadPluginHandler> Cannot stream artifact")
 		}
 
@@ -607,10 +608,12 @@ func (api *API) getDownloadArtifactHandler() Handler {
 
 		f, err := objectstore.FetchArtifact(art)
 		if err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "getDownloadArtifactHandler> Cannot fetch artifact")
 		}
 
 		if _, err := io.Copy(w, f); err != nil {
+			_ = f.Close()
 			return sdk.WrapError(err, "getDownloadArtifactHandler> Cannot stream artifact")
 		}
 

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -302,7 +302,7 @@ func Stream(method string, path string, args []byte, mods ...RequestModifier) (i
 }
 
 // UploadMultiPart upload multipart
-func UploadMultiPart(method string, path string, body *bytes.Buffer, mods ...RequestModifier) ([]byte, int, error) {
+func UploadMultiPart(method string, path string, body io.Reader, mods ...RequestModifier) ([]byte, int, error) {
 
 	if verbose {
 		log.Printf("Starting UploadMultiPart %s %s", method, path)
@@ -352,8 +352,8 @@ func UploadMultiPart(method string, path string, body *bytes.Buffer, mods ...Req
 	}
 
 	if verbose {
-		if len(body.Bytes()) > 0 {
-			log.Printf("Response Body: %s\n", body.String())
+		if len(respBody) > 0 {
+			log.Printf("Response Body: %s\n", respBody)
 		}
 	}
 

--- a/vendor/github.com/ncw/swift/COPYING
+++ b/vendor/github.com/ncw/swift/COPYING
@@ -1,0 +1,20 @@
+Copyright (C) 2012 by Nick Craig-Wood http://www.craig-wood.com/nick/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/ncw/swift/README.md
+++ b/vendor/github.com/ncw/swift/README.md
@@ -1,0 +1,142 @@
+Swift
+=====
+
+This package provides an easy to use library for interfacing with
+Swift / Openstack Object Storage / Rackspace cloud files from the Go
+Language
+
+See here for package docs
+
+  http://godoc.org/github.com/ncw/swift
+
+[![Build Status](https://api.travis-ci.org/ncw/swift.svg?branch=master)](https://travis-ci.org/ncw/swift) [![GoDoc](https://godoc.org/github.com/ncw/swift?status.svg)](https://godoc.org/github.com/ncw/swift) 
+
+Install
+-------
+
+Use go to install the library
+
+    go get github.com/ncw/swift
+
+Usage
+-----
+
+See here for full package docs
+
+- http://godoc.org/github.com/ncw/swift
+
+Here is a short example from the docs
+
+    import "github.com/ncw/swift"
+
+    // Create a connection
+    c := swift.Connection{
+        UserName: "user",
+        ApiKey:   "key",
+        AuthUrl:  "auth_url",
+        Domain:   "domain",  // Name of the domain (v3 auth only)
+        Tenant:   "tenant",  // Name of the tenant (v2 auth only)
+    }
+    // Authenticate
+    err := c.Authenticate()
+    if err != nil {
+        panic(err)
+    }
+    // List all the containers
+    containers, err := c.ContainerNames(nil)
+    fmt.Println(containers)
+    // etc...
+
+Additions
+---------
+
+The `rs` sub project contains a wrapper for the Rackspace specific CDN Management interface.
+
+Testing
+-------
+
+To run the tests you can either use an embedded fake Swift server
+either use a real Openstack Swift server or a Rackspace Cloud files account.
+
+When using a real Swift server, you need to set these environment variables
+before running the tests
+
+    export SWIFT_API_USER='user'
+    export SWIFT_API_KEY='key'
+    export SWIFT_AUTH_URL='https://url.of.auth.server/v1.0'
+
+And optionally these if using v2 authentication
+
+    export SWIFT_TENANT='TenantName'
+    export SWIFT_TENANT_ID='TenantId'
+
+And optionally these if using v3 authentication
+
+    export SWIFT_TENANT='TenantName'
+    export SWIFT_TENANT_ID='TenantId'
+    export SWIFT_API_DOMAIN_ID='domain id'
+    export SWIFT_API_DOMAIN='domain name'
+
+And optionally these if using v3 trust
+
+    export SWIFT_TRUST_ID='TrustId'
+
+And optionally this if you want to skip server certificate validation
+
+    export SWIFT_AUTH_INSECURE=1
+
+And optionally this to configure the connect channel timeout, in seconds
+
+    export SWIFT_CONNECTION_CHANNEL_TIMEOUT=60
+
+And optionally this to configure the data channel timeout, in seconds
+
+    export SWIFT_DATA_CHANNEL_TIMEOUT=60
+
+Then run the tests with `go test`
+
+License
+-------
+
+This is free software under the terms of MIT license (check COPYING file
+included in this package).
+
+Contact and support
+-------------------
+
+The project website is at:
+
+- https://github.com/ncw/swift
+
+There you can file bug reports, ask for help or contribute patches.
+
+Authors
+-------
+
+- Nick Craig-Wood <nick@craig-wood.com>
+
+Contributors
+------------
+
+- Brian "bojo" Jones <mojobojo@gmail.com>
+- Janika Liiv <janika@toggl.com>
+- Yamamoto, Hirotaka <ymmt2005@gmail.com>
+- Stephen <yo@groks.org>
+- platformpurple <stephen@platformpurple.com>
+- Paul Querna <pquerna@apache.org>
+- Livio Soares <liviobs@gmail.com>
+- thesyncim <thesyncim@gmail.com>
+- lsowen <lsowen@s1network.com>
+- Sylvain Baubeau <sbaubeau@redhat.com>
+- Chris Kastorff <encryptio@gmail.com>
+- Dai HaoJun <haojun.dai@hp.com>
+- Hua Wang <wanghua.humble@gmail.com>
+- Fabian Ruff <fabian@progra.de>
+- Arturo Reuschenbach Puncernau <reuschenbach@gmail.com>
+- Petr Kotek <petr.kotek@bigcommerce.com>
+- Stefan Majewsky <stefan.majewsky@sap.com>
+- Cezar Sa Espinola <cezarsa@gmail.com>
+- Sam Gunaratne <samgzeit@gmail.com>
+- Richard Scothern <richard.scothern@gmail.com>
+- Michel Couillard <couillard.michel@voxlog.ca>
+- Christopher Waldon <ckwaldon@us.ibm.com>

--- a/vendor/github.com/ncw/swift/auth.go
+++ b/vendor/github.com/ncw/swift/auth.go
@@ -1,0 +1,320 @@
+package swift
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Auth defines the operations needed to authenticate with swift
+//
+// This encapsulates the different authentication schemes in use
+type Authenticator interface {
+	// Request creates an http.Request for the auth - return nil if not needed
+	Request(*Connection) (*http.Request, error)
+	// Response parses the http.Response
+	Response(resp *http.Response) error
+	// The public storage URL - set Internal to true to read
+	// internal/service net URL
+	StorageUrl(Internal bool) string
+	// The access token
+	Token() string
+	// The CDN url if available
+	CdnUrl() string
+}
+
+type CustomEndpointAuthenticator interface {
+	StorageUrlForEndpoint(endpointType EndpointType) string
+}
+
+type EndpointType string
+
+const (
+	// Use public URL as storage URL
+	EndpointTypePublic = EndpointType("public")
+
+	// Use internal URL as storage URL
+	EndpointTypeInternal = EndpointType("internal")
+
+	// Use admin URL as storage URL
+	EndpointTypeAdmin = EndpointType("admin")
+)
+
+// newAuth - create a new Authenticator from the AuthUrl
+//
+// A hint for AuthVersion can be provided
+func newAuth(c *Connection) (Authenticator, error) {
+	AuthVersion := c.AuthVersion
+	if AuthVersion == 0 {
+		if strings.Contains(c.AuthUrl, "v3") {
+			AuthVersion = 3
+		} else if strings.Contains(c.AuthUrl, "v2") {
+			AuthVersion = 2
+		} else if strings.Contains(c.AuthUrl, "v1") {
+			AuthVersion = 1
+		} else {
+			return nil, newErrorf(500, "Can't find AuthVersion in AuthUrl - set explicitly")
+		}
+	}
+	switch AuthVersion {
+	case 1:
+		return &v1Auth{}, nil
+	case 2:
+		return &v2Auth{
+			// Guess as to whether using API key or
+			// password it will try both eventually so
+			// this is just an optimization.
+			useApiKey: len(c.ApiKey) >= 32,
+		}, nil
+	case 3:
+		return &v3Auth{}, nil
+	}
+	return nil, newErrorf(500, "Auth Version %d not supported", AuthVersion)
+}
+
+// ------------------------------------------------------------
+
+// v1 auth
+type v1Auth struct {
+	Headers http.Header // V1 auth: the authentication headers so extensions can access them
+}
+
+// v1 Authentication - make request
+func (auth *v1Auth) Request(c *Connection) (*http.Request, error) {
+	req, err := http.NewRequest("GET", c.AuthUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("X-Auth-Key", c.ApiKey)
+	req.Header.Set("X-Auth-User", c.UserName)
+	return req, nil
+}
+
+// v1 Authentication - read response
+func (auth *v1Auth) Response(resp *http.Response) error {
+	auth.Headers = resp.Header
+	return nil
+}
+
+// v1 Authentication - read storage url
+func (auth *v1Auth) StorageUrl(Internal bool) string {
+	storageUrl := auth.Headers.Get("X-Storage-Url")
+	if Internal {
+		newUrl, err := url.Parse(storageUrl)
+		if err != nil {
+			return storageUrl
+		}
+		newUrl.Host = "snet-" + newUrl.Host
+		storageUrl = newUrl.String()
+	}
+	return storageUrl
+}
+
+// v1 Authentication - read auth token
+func (auth *v1Auth) Token() string {
+	return auth.Headers.Get("X-Auth-Token")
+}
+
+// v1 Authentication - read cdn url
+func (auth *v1Auth) CdnUrl() string {
+	return auth.Headers.Get("X-CDN-Management-Url")
+}
+
+// ------------------------------------------------------------
+
+// v2 Authentication
+type v2Auth struct {
+	Auth        *v2AuthResponse
+	Region      string
+	useApiKey   bool // if set will use API key not Password
+	useApiKeyOk bool // if set won't change useApiKey any more
+	notFirst    bool // set after first run
+}
+
+// v2 Authentication - make request
+func (auth *v2Auth) Request(c *Connection) (*http.Request, error) {
+	auth.Region = c.Region
+	// Toggle useApiKey if not first run and not OK yet
+	if auth.notFirst && !auth.useApiKeyOk {
+		auth.useApiKey = !auth.useApiKey
+	}
+	auth.notFirst = true
+	// Create a V2 auth request for the body of the connection
+	var v2i interface{}
+	if !auth.useApiKey {
+		// Normal swift authentication
+		v2 := v2AuthRequest{}
+		v2.Auth.PasswordCredentials.UserName = c.UserName
+		v2.Auth.PasswordCredentials.Password = c.ApiKey
+		v2.Auth.Tenant = c.Tenant
+		v2.Auth.TenantId = c.TenantId
+		v2i = v2
+	} else {
+		// Rackspace special with API Key
+		v2 := v2AuthRequestRackspace{}
+		v2.Auth.ApiKeyCredentials.UserName = c.UserName
+		v2.Auth.ApiKeyCredentials.ApiKey = c.ApiKey
+		v2.Auth.Tenant = c.Tenant
+		v2.Auth.TenantId = c.TenantId
+		v2i = v2
+	}
+	body, err := json.Marshal(v2i)
+	if err != nil {
+		return nil, err
+	}
+	url := c.AuthUrl
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	url += "tokens"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+	return req, nil
+}
+
+// v2 Authentication - read response
+func (auth *v2Auth) Response(resp *http.Response) error {
+	auth.Auth = new(v2AuthResponse)
+	err := readJson(resp, auth.Auth)
+	// If successfully read Auth then no need to toggle useApiKey any more
+	if err == nil {
+		auth.useApiKeyOk = true
+	}
+	return err
+}
+
+// Finds the Endpoint Url of "type" from the v2AuthResponse using the
+// Region if set or defaulting to the first one if not
+//
+// Returns "" if not found
+func (auth *v2Auth) endpointUrl(Type string, endpointType EndpointType) string {
+	for _, catalog := range auth.Auth.Access.ServiceCatalog {
+		if catalog.Type == Type {
+			for _, endpoint := range catalog.Endpoints {
+				if auth.Region == "" || (auth.Region == endpoint.Region) {
+					switch endpointType {
+					case EndpointTypeInternal:
+						return endpoint.InternalUrl
+					case EndpointTypePublic:
+						return endpoint.PublicUrl
+					case EndpointTypeAdmin:
+						return endpoint.AdminUrl
+					default:
+						return ""
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// v2 Authentication - read storage url
+//
+// If Internal is true then it reads the private (internal / service
+// net) URL.
+func (auth *v2Auth) StorageUrl(Internal bool) string {
+	endpointType := EndpointTypePublic
+	if Internal {
+		endpointType = EndpointTypeInternal
+	}
+	return auth.StorageUrlForEndpoint(endpointType)
+}
+
+// v2 Authentication - read storage url
+//
+// Use the indicated endpointType to choose a URL.
+func (auth *v2Auth) StorageUrlForEndpoint(endpointType EndpointType) string {
+	return auth.endpointUrl("object-store", endpointType)
+}
+
+// v2 Authentication - read auth token
+func (auth *v2Auth) Token() string {
+	return auth.Auth.Access.Token.Id
+}
+
+// v2 Authentication - read cdn url
+func (auth *v2Auth) CdnUrl() string {
+	return auth.endpointUrl("rax:object-cdn", EndpointTypePublic)
+}
+
+// ------------------------------------------------------------
+
+// V2 Authentication request
+//
+// http://docs.openstack.org/developer/keystone/api_curl_examples.html
+// http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/curl_auth.html
+// http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_authenticate_v2.0_tokens_.html
+type v2AuthRequest struct {
+	Auth struct {
+		PasswordCredentials struct {
+			UserName string `json:"username"`
+			Password string `json:"password"`
+		} `json:"passwordCredentials"`
+		Tenant   string `json:"tenantName,omitempty"`
+		TenantId string `json:"tenantId,omitempty"`
+	} `json:"auth"`
+}
+
+// V2 Authentication request - Rackspace variant
+//
+// http://docs.openstack.org/developer/keystone/api_curl_examples.html
+// http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/curl_auth.html
+// http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_authenticate_v2.0_tokens_.html
+type v2AuthRequestRackspace struct {
+	Auth struct {
+		ApiKeyCredentials struct {
+			UserName string `json:"username"`
+			ApiKey   string `json:"apiKey"`
+		} `json:"RAX-KSKEY:apiKeyCredentials"`
+		Tenant   string `json:"tenantName,omitempty"`
+		TenantId string `json:"tenantId,omitempty"`
+	} `json:"auth"`
+}
+
+// V2 Authentication reply
+//
+// http://docs.openstack.org/developer/keystone/api_curl_examples.html
+// http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/curl_auth.html
+// http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_authenticate_v2.0_tokens_.html
+type v2AuthResponse struct {
+	Access struct {
+		ServiceCatalog []struct {
+			Endpoints []struct {
+				InternalUrl string
+				PublicUrl   string
+				AdminUrl    string
+				Region      string
+				TenantId    string
+			}
+			Name string
+			Type string
+		}
+		Token struct {
+			Expires string
+			Id      string
+			Tenant  struct {
+				Id   string
+				Name string
+			}
+		}
+		User struct {
+			DefaultRegion string `json:"RAX-AUTH:defaultRegion"`
+			Id            string
+			Name          string
+			Roles         []struct {
+				Description string
+				Id          string
+				Name        string
+				TenantId    string
+			}
+		}
+	}
+}

--- a/vendor/github.com/ncw/swift/auth_v3.go
+++ b/vendor/github.com/ncw/swift/auth_v3.go
@@ -1,0 +1,228 @@
+package swift
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+const (
+	v3AuthMethodToken        = "token"
+	v3AuthMethodPassword     = "password"
+	v3CatalogTypeObjectStore = "object-store"
+)
+
+// V3 Authentication request
+// http://docs.openstack.org/developer/keystone/api_curl_examples.html
+// http://developer.openstack.org/api-ref-identity-v3.html
+type v3AuthRequest struct {
+	Auth struct {
+		Identity struct {
+			Methods  []string        `json:"methods"`
+			Password *v3AuthPassword `json:"password,omitempty"`
+			Token    *v3AuthToken    `json:"token,omitempty"`
+		} `json:"identity"`
+		Scope *v3Scope `json:"scope,omitempty"`
+	} `json:"auth"`
+}
+
+type v3Scope struct {
+	Project *v3Project `json:"project,omitempty"`
+	Domain  *v3Domain  `json:"domain,omitempty"`
+	Trust   *v3Trust   `json:"OS-TRUST:trust,omitempty"`
+}
+
+type v3Domain struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type v3Project struct {
+	Name   string    `json:"name,omitempty"`
+	Id     string    `json:"id,omitempty"`
+	Domain *v3Domain `json:"domain,omitempty"`
+}
+
+type v3Trust struct {
+	Id string `json:"id"`
+}
+
+type v3User struct {
+	Domain   *v3Domain `json:"domain,omitempty"`
+	Id       string    `json:"id,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	Password string    `json:"password,omitempty"`
+}
+
+type v3AuthToken struct {
+	Id string `json:"id"`
+}
+
+type v3AuthPassword struct {
+	User v3User `json:"user"`
+}
+
+// V3 Authentication response
+type v3AuthResponse struct {
+	Token struct {
+		Expires_At, Issued_At string
+		Methods               []string
+		Roles                 []struct {
+			Id, Name string
+			Links    struct {
+				Self string
+			}
+		}
+
+		Project struct {
+			Domain struct {
+				Id, Name string
+			}
+			Id, Name string
+		}
+
+		Catalog []struct {
+			Id, Namem, Type string
+			Endpoints       []struct {
+				Id, Region_Id, Url, Region string
+				Interface                  EndpointType
+			}
+		}
+
+		User struct {
+			Id, Name string
+			Domain   struct {
+				Id, Name string
+				Links    struct {
+					Self string
+				}
+			}
+		}
+
+		Audit_Ids []string
+	}
+}
+
+type v3Auth struct {
+	Region  string
+	Auth    *v3AuthResponse
+	Headers http.Header
+}
+
+func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
+	auth.Region = c.Region
+
+	var v3i interface{}
+
+	v3 := v3AuthRequest{}
+
+	if c.UserName == "" && c.UserId == "" {
+		v3.Auth.Identity.Methods = []string{v3AuthMethodToken}
+		v3.Auth.Identity.Token = &v3AuthToken{Id: c.ApiKey}
+	} else {
+		v3.Auth.Identity.Methods = []string{v3AuthMethodPassword}
+		v3.Auth.Identity.Password = &v3AuthPassword{
+			User: v3User{
+				Name:     c.UserName,
+				Id:       c.UserId,
+				Password: c.ApiKey,
+			},
+		}
+
+		var domain *v3Domain
+
+		if c.Domain != "" {
+			domain = &v3Domain{Name: c.Domain}
+		} else if c.DomainId != "" {
+			domain = &v3Domain{Id: c.DomainId}
+		}
+		v3.Auth.Identity.Password.User.Domain = domain
+	}
+
+	if c.TrustId != "" {
+		v3.Auth.Scope = &v3Scope{Trust: &v3Trust{Id: c.TrustId}}
+	} else if c.TenantId != "" || c.Tenant != "" {
+
+		v3.Auth.Scope = &v3Scope{Project: &v3Project{}}
+
+		if c.TenantId != "" {
+			v3.Auth.Scope.Project.Id = c.TenantId
+		} else if c.Tenant != "" {
+			v3.Auth.Scope.Project.Name = c.Tenant
+			switch {
+			case c.TenantDomain != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: c.TenantDomain}
+			case c.TenantDomainId != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Id: c.TenantDomainId}
+			case c.Domain != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: c.Domain}
+			case c.DomainId != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Id: c.DomainId}
+			default:
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: "Default"}
+			}
+		}
+	}
+
+	v3i = v3
+
+	body, err := json.Marshal(v3i)
+
+	if err != nil {
+		return nil, err
+	}
+
+	url := c.AuthUrl
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	url += "auth/tokens"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+	return req, nil
+}
+
+func (auth *v3Auth) Response(resp *http.Response) error {
+	auth.Auth = &v3AuthResponse{}
+	auth.Headers = resp.Header
+	err := readJson(resp, auth.Auth)
+	return err
+}
+
+func (auth *v3Auth) endpointUrl(Type string, endpointType EndpointType) string {
+	for _, catalog := range auth.Auth.Token.Catalog {
+		if catalog.Type == Type {
+			for _, endpoint := range catalog.Endpoints {
+				if endpoint.Interface == endpointType && (auth.Region == "" || (auth.Region == endpoint.Region)) {
+					return endpoint.Url
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (auth *v3Auth) StorageUrl(Internal bool) string {
+	endpointType := EndpointTypePublic
+	if Internal {
+		endpointType = EndpointTypeInternal
+	}
+	return auth.StorageUrlForEndpoint(endpointType)
+}
+
+func (auth *v3Auth) StorageUrlForEndpoint(endpointType EndpointType) string {
+	return auth.endpointUrl("object-store", endpointType)
+}
+
+func (auth *v3Auth) Token() string {
+	return auth.Headers.Get("X-Subject-Token")
+}
+
+func (auth *v3Auth) CdnUrl() string {
+	return ""
+}

--- a/vendor/github.com/ncw/swift/compatibility_1_0.go
+++ b/vendor/github.com/ncw/swift/compatibility_1_0.go
@@ -1,0 +1,28 @@
+// Go 1.0 compatibility functions
+
+// +build !go1.1
+
+package swift
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// Cancel the request - doesn't work under < go 1.1
+func cancelRequest(transport http.RoundTripper, req *http.Request) {
+	log.Printf("Tried to cancel a request but couldn't - recompile with go 1.1")
+}
+
+// Reset a timer - Doesn't work properly < go 1.1
+//
+// This is quite hard to do properly under go < 1.1 so we do a crude
+// approximation and hope that everyone upgrades to go 1.1 quickly
+func resetTimer(t *time.Timer, d time.Duration) {
+	t.Stop()
+	// Very likely this doesn't actually work if we are already
+	// selecting on t.C.  However we've stopped the original timer
+	// so won't break transfers but may not time them out :-(
+	*t = *time.NewTimer(d)
+}

--- a/vendor/github.com/ncw/swift/compatibility_1_1.go
+++ b/vendor/github.com/ncw/swift/compatibility_1_1.go
@@ -1,0 +1,24 @@
+// Go 1.1 and later compatibility functions
+//
+// +build go1.1
+
+package swift
+
+import (
+	"net/http"
+	"time"
+)
+
+// Cancel the request
+func cancelRequest(transport http.RoundTripper, req *http.Request) {
+	if tr, ok := transport.(interface {
+		CancelRequest(*http.Request)
+	}); ok {
+		tr.CancelRequest(req)
+	}
+}
+
+// Reset a timer
+func resetTimer(t *time.Timer, d time.Duration) {
+	t.Reset(d)
+}

--- a/vendor/github.com/ncw/swift/dlo.go
+++ b/vendor/github.com/ncw/swift/dlo.go
@@ -1,0 +1,136 @@
+package swift
+
+import (
+	"os"
+)
+
+// DynamicLargeObjectCreateFile represents an open static large object
+type DynamicLargeObjectCreateFile struct {
+	largeObjectCreateFile
+}
+
+// DynamicLargeObjectCreateFile creates a dynamic large object
+// returning an object which satisfies io.Writer, io.Seeker, io.Closer
+// and io.ReaderFrom.  The flags are as passes to the
+// largeObjectCreate method.
+func (c *Connection) DynamicLargeObjectCreateFile(opts *LargeObjectOpts) (LargeObjectFile, error) {
+	lo, err := c.largeObjectCreate(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return withBuffer(opts, &DynamicLargeObjectCreateFile{
+		largeObjectCreateFile: *lo,
+	}), nil
+}
+
+// DynamicLargeObjectCreate creates or truncates an existing dynamic
+// large object returning a writeable object.  This sets opts.Flags to
+// an appropriate value before calling DynamicLargeObjectCreateFile
+func (c *Connection) DynamicLargeObjectCreate(opts *LargeObjectOpts) (LargeObjectFile, error) {
+	opts.Flags = os.O_TRUNC | os.O_CREATE
+	return c.DynamicLargeObjectCreateFile(opts)
+}
+
+// DynamicLargeObjectDelete deletes a dynamic large object and all of its segments.
+func (c *Connection) DynamicLargeObjectDelete(container string, path string) error {
+	return c.LargeObjectDelete(container, path)
+}
+
+// DynamicLargeObjectMove moves a dynamic large object from srcContainer, srcObjectName to dstContainer, dstObjectName
+func (c *Connection) DynamicLargeObjectMove(srcContainer string, srcObjectName string, dstContainer string, dstObjectName string) error {
+	info, headers, err := c.Object(dstContainer, srcObjectName)
+	if err != nil {
+		return err
+	}
+
+	segmentContainer, segmentPath := parseFullPath(headers["X-Object-Manifest"])
+	if err := c.createDLOManifest(dstContainer, dstObjectName, segmentContainer+"/"+segmentPath, info.ContentType); err != nil {
+		return err
+	}
+
+	if err := c.ObjectDelete(srcContainer, srcObjectName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createDLOManifest creates a dynamic large object manifest
+func (c *Connection) createDLOManifest(container string, objectName string, prefix string, contentType string) error {
+	headers := make(Headers)
+	headers["X-Object-Manifest"] = prefix
+	manifest, err := c.ObjectCreate(container, objectName, false, "", contentType, headers)
+	if err != nil {
+		return err
+	}
+
+	if err := manifest.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close satisfies the io.Closer interface
+func (file *DynamicLargeObjectCreateFile) Close() error {
+	return file.Flush()
+}
+
+func (file *DynamicLargeObjectCreateFile) Flush() error {
+	err := file.conn.createDLOManifest(file.container, file.objectName, file.segmentContainer+"/"+file.prefix, file.contentType)
+	if err != nil {
+		return err
+	}
+	return file.conn.waitForSegmentsToShowUp(file.container, file.objectName, file.Size())
+}
+
+func (c *Connection) getAllDLOSegments(segmentContainer, segmentPath string) ([]Object, error) {
+	//a simple container listing works 99.9% of the time
+	segments, err := c.ObjectsAll(segmentContainer, &ObjectsOpts{Prefix: segmentPath})
+	if err != nil {
+		return nil, err
+	}
+
+	hasObjectName := make(map[string]struct{})
+	for _, segment := range segments {
+		hasObjectName[segment.Name] = struct{}{}
+	}
+
+	//The container listing might be outdated (i.e. not contain all existing
+	//segment objects yet) because of temporary inconsistency (Swift is only
+	//eventually consistent!). Check its completeness.
+	segmentNumber := 0
+	for {
+		segmentNumber++
+		segmentName := getSegment(segmentPath, segmentNumber)
+		if _, seen := hasObjectName[segmentName]; seen {
+			continue
+		}
+
+		//This segment is missing in the container listing. Use a more reliable
+		//request to check its existence. (HEAD requests on segments are
+		//guaranteed to return the correct metadata, except for the pathological
+		//case of an outage of large parts of the Swift cluster or its network,
+		//since every segment is only written once.)
+		segment, _, err := c.Object(segmentContainer, segmentName)
+		switch err {
+		case nil:
+			//found new segment -> add it in the correct position and keep
+			//going, more might be missing
+			if segmentNumber <= len(segments) {
+				segments = append(segments[:segmentNumber], segments[segmentNumber-1:]...)
+				segments[segmentNumber-1] = segment
+			} else {
+				segments = append(segments, segment)
+			}
+			continue
+		case ObjectNotFound:
+			//This segment is missing. Since we upload segments sequentially,
+			//there won't be any more segments after it.
+			return segments, nil
+		default:
+			return nil, err //unexpected error
+		}
+	}
+}

--- a/vendor/github.com/ncw/swift/doc.go
+++ b/vendor/github.com/ncw/swift/doc.go
@@ -1,0 +1,19 @@
+/*
+Package swift provides an easy to use interface to Swift / Openstack Object Storage / Rackspace Cloud Files
+
+Standard Usage
+
+Most of the work is done through the Container*() and Object*() methods.
+
+All methods are safe to use concurrently in multiple go routines.
+
+Object Versioning
+
+As defined by http://docs.openstack.org/api/openstack-object-storage/1.0/content/Object_Versioning-e1e3230.html#d6e983 one can create a container which allows for version control of files.  The suggested method is to create a version container for holding all non-current files, and a current container for holding the latest version that the file points to.  The container and objects inside it can be used in the standard manner, however, pushing a file multiple times will result in it being copied to the version container and the new file put in it's place.  If the current file is deleted, the previous file in the version container will replace it.  This means that if a file is updated 5 times, it must be deleted 5 times to be completely removed from the system.
+
+Rackspace Sub Module
+
+This module specifically allows the enabling/disabling of Rackspace Cloud File CDN management on a container.  This is specific to the Rackspace API and not Swift/Openstack, therefore it has been placed in a submodule.  One can easily create a RsConnection and use it like the standard Connection to access and manipulate containers and objects.
+
+*/
+package swift

--- a/vendor/github.com/ncw/swift/largeobjects.go
+++ b/vendor/github.com/ncw/swift/largeobjects.go
@@ -1,0 +1,448 @@
+package swift
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	gopath "path"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// NotLargeObject is returned if an operation is performed on an object which isn't large.
+var NotLargeObject = errors.New("Not a large object")
+
+// readAfterWriteTimeout defines the time we wait before an object appears after having been uploaded
+var readAfterWriteTimeout = 15 * time.Second
+
+// readAfterWriteWait defines the time to sleep between two retries
+var readAfterWriteWait = 200 * time.Millisecond
+
+// largeObjectCreateFile represents an open static or dynamic large object
+type largeObjectCreateFile struct {
+	conn             *Connection
+	container        string
+	objectName       string
+	currentLength    int64
+	filePos          int64
+	chunkSize        int64
+	segmentContainer string
+	prefix           string
+	contentType      string
+	checkHash        bool
+	segments         []Object
+	headers          Headers
+	minChunkSize     int64
+}
+
+func swiftSegmentPath(path string) (string, error) {
+	checksum := sha1.New()
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	path = hex.EncodeToString(checksum.Sum(append([]byte(path), random...)))
+	return strings.TrimLeft(strings.TrimRight("segments/"+path[0:3]+"/"+path[3:], "/"), "/"), nil
+}
+
+func getSegment(segmentPath string, partNumber int) string {
+	return fmt.Sprintf("%s/%016d", segmentPath, partNumber)
+}
+
+func parseFullPath(manifest string) (container string, prefix string) {
+	components := strings.SplitN(manifest, "/", 2)
+	container = components[0]
+	if len(components) > 1 {
+		prefix = components[1]
+	}
+	return container, prefix
+}
+
+func (headers Headers) IsLargeObjectDLO() bool {
+	_, isDLO := headers["X-Object-Manifest"]
+	return isDLO
+}
+
+func (headers Headers) IsLargeObjectSLO() bool {
+	_, isSLO := headers["X-Static-Large-Object"]
+	return isSLO
+}
+
+func (headers Headers) IsLargeObject() bool {
+	return headers.IsLargeObjectSLO() || headers.IsLargeObjectDLO()
+}
+
+func (c *Connection) getAllSegments(container string, path string, headers Headers) (string, []Object, error) {
+	if manifest, isDLO := headers["X-Object-Manifest"]; isDLO {
+		segmentContainer, segmentPath := parseFullPath(manifest)
+		segments, err := c.getAllDLOSegments(segmentContainer, segmentPath)
+		return segmentContainer, segments, err
+	}
+	if headers.IsLargeObjectSLO() {
+		return c.getAllSLOSegments(container, path)
+	}
+	return "", nil, NotLargeObject
+}
+
+// LargeObjectOpts describes how a large object should be created
+type LargeObjectOpts struct {
+	Container        string  // Name of container to place object
+	ObjectName       string  // Name of object
+	Flags            int     // Creation flags
+	CheckHash        bool    // If set Check the hash
+	Hash             string  // If set use this hash to check
+	ContentType      string  // Content-Type of the object
+	Headers          Headers // Additional headers to upload the object with
+	ChunkSize        int64   // Size of chunks of the object, defaults to 10MB if not set
+	MinChunkSize     int64   // Minimum chunk size, automatically set for SLO's based on info
+	SegmentContainer string  // Name of the container to place segments
+	SegmentPrefix    string  // Prefix to use for the segments
+	NoBuffer         bool    // Prevents using a bufio.Writer to write segments
+}
+
+type LargeObjectFile interface {
+	io.Writer
+	io.Seeker
+	io.Closer
+	Size() int64
+	Flush() error
+}
+
+// largeObjectCreate creates a large object at opts.Container, opts.ObjectName.
+//
+// opts.Flags can have the following bits set
+//   os.TRUNC  - remove the contents of the large object if it exists
+//   os.APPEND - write at the end of the large object
+func (c *Connection) largeObjectCreate(opts *LargeObjectOpts) (*largeObjectCreateFile, error) {
+	var (
+		segmentPath      string
+		segmentContainer string
+		segments         []Object
+		currentLength    int64
+		err              error
+	)
+
+	if opts.SegmentPrefix != "" {
+		segmentPath = opts.SegmentPrefix
+	} else if segmentPath, err = swiftSegmentPath(opts.ObjectName); err != nil {
+		return nil, err
+	}
+
+	if info, headers, err := c.Object(opts.Container, opts.ObjectName); err == nil {
+		if opts.Flags&os.O_TRUNC != 0 {
+			c.LargeObjectDelete(opts.Container, opts.ObjectName)
+		} else {
+			currentLength = info.Bytes
+			if headers.IsLargeObject() {
+				segmentContainer, segments, err = c.getAllSegments(opts.Container, opts.ObjectName, headers)
+				if err != nil {
+					return nil, err
+				}
+				if len(segments) > 0 {
+					segmentPath = gopath.Dir(segments[0].Name)
+				}
+			} else {
+				if err = c.ObjectMove(opts.Container, opts.ObjectName, opts.Container, getSegment(segmentPath, 1)); err != nil {
+					return nil, err
+				}
+				segments = append(segments, info)
+			}
+		}
+	} else if err != ObjectNotFound {
+		return nil, err
+	}
+
+	// segmentContainer is not empty when the manifest already existed
+	if segmentContainer == "" {
+		if opts.SegmentContainer != "" {
+			segmentContainer = opts.SegmentContainer
+		} else {
+			segmentContainer = opts.Container + "_segments"
+		}
+	}
+
+	file := &largeObjectCreateFile{
+		conn:             c,
+		checkHash:        opts.CheckHash,
+		container:        opts.Container,
+		objectName:       opts.ObjectName,
+		chunkSize:        opts.ChunkSize,
+		minChunkSize:     opts.MinChunkSize,
+		headers:          opts.Headers,
+		segmentContainer: segmentContainer,
+		prefix:           segmentPath,
+		segments:         segments,
+		currentLength:    currentLength,
+	}
+
+	if file.chunkSize == 0 {
+		file.chunkSize = 10 * 1024 * 1024
+	}
+
+	if file.minChunkSize > file.chunkSize {
+		file.chunkSize = file.minChunkSize
+	}
+
+	if opts.Flags&os.O_APPEND != 0 {
+		file.filePos = currentLength
+	}
+
+	return file, nil
+}
+
+// LargeObjectDelete deletes the large object named by container, path
+func (c *Connection) LargeObjectDelete(container string, objectName string) error {
+	_, headers, err := c.Object(container, objectName)
+	if err != nil {
+		return err
+	}
+
+	var objects [][]string
+	if headers.IsLargeObject() {
+		segmentContainer, segments, err := c.getAllSegments(container, objectName, headers)
+		if err != nil {
+			return err
+		}
+		for _, obj := range segments {
+			objects = append(objects, []string{segmentContainer, obj.Name})
+		}
+	}
+	objects = append(objects, []string{container, objectName})
+
+	info, err := c.cachedQueryInfo()
+	if err == nil && info.SupportsBulkDelete() && len(objects) > 0 {
+		filenames := make([]string, len(objects))
+		for i, obj := range objects {
+			filenames[i] = obj[0] + "/" + obj[1]
+		}
+		_, err = c.doBulkDelete(filenames)
+		// Don't fail on ObjectNotFound because eventual consistency
+		// makes this situation normal.
+		if err != nil && err != Forbidden && err != ObjectNotFound {
+			return err
+		}
+	} else {
+		for _, obj := range objects {
+			if err := c.ObjectDelete(obj[0], obj[1]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// LargeObjectGetSegments returns all the segments that compose an object
+// If the object is a Dynamic Large Object (DLO), it just returns the objects
+// that have the prefix as indicated by the manifest.
+// If the object is a Static Large Object (SLO), it retrieves the JSON content
+// of the manifest and return all the segments of it.
+func (c *Connection) LargeObjectGetSegments(container string, path string) (string, []Object, error) {
+	_, headers, err := c.Object(container, path)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return c.getAllSegments(container, path, headers)
+}
+
+// Seek sets the offset for the next write operation
+func (file *largeObjectCreateFile) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case 0:
+		file.filePos = offset
+	case 1:
+		file.filePos += offset
+	case 2:
+		file.filePos = file.currentLength + offset
+	default:
+		return -1, fmt.Errorf("invalid value for whence")
+	}
+	if file.filePos < 0 {
+		return -1, fmt.Errorf("negative offset")
+	}
+	return file.filePos, nil
+}
+
+func (file *largeObjectCreateFile) Size() int64 {
+	return file.currentLength
+}
+
+func withLORetry(expectedSize int64, fn func() (Headers, int64, error)) (err error) {
+	endTimer := time.NewTimer(readAfterWriteTimeout)
+	defer endTimer.Stop()
+	waitingTime := readAfterWriteWait
+	for {
+		var headers Headers
+		var sz int64
+		if headers, sz, err = fn(); err == nil {
+			if !headers.IsLargeObjectDLO() || (expectedSize == 0 && sz > 0) || expectedSize == sz {
+				return
+			}
+		} else {
+			return
+		}
+		waitTimer := time.NewTimer(waitingTime)
+		select {
+		case <-endTimer.C:
+			waitTimer.Stop()
+			err = fmt.Errorf("Timeout expired while waiting for object to have size == %d, got: %d", expectedSize, sz)
+			return
+		case <-waitTimer.C:
+			waitingTime *= 2
+		}
+	}
+}
+
+func (c *Connection) waitForSegmentsToShowUp(container, objectName string, expectedSize int64) (err error) {
+	err = withLORetry(expectedSize, func() (Headers, int64, error) {
+		var info Object
+		var headers Headers
+		info, headers, err = c.objectBase(container, objectName)
+		if err != nil {
+			return headers, 0, err
+		}
+		return headers, info.Bytes, nil
+	})
+	return
+}
+
+// Write satisfies the io.Writer interface
+func (file *largeObjectCreateFile) Write(buf []byte) (int, error) {
+	var sz int64
+	var relativeFilePos int
+	writeSegmentIdx := 0
+	for i, obj := range file.segments {
+		if file.filePos < sz+obj.Bytes || (i == len(file.segments)-1 && file.filePos < sz+file.minChunkSize) {
+			relativeFilePos = int(file.filePos - sz)
+			break
+		}
+		writeSegmentIdx++
+		sz += obj.Bytes
+	}
+	sizeToWrite := len(buf)
+	for offset := 0; offset < sizeToWrite; {
+		newSegment, n, err := file.writeSegment(buf[offset:], writeSegmentIdx, relativeFilePos)
+		if err != nil {
+			return 0, err
+		}
+		if writeSegmentIdx < len(file.segments) {
+			file.segments[writeSegmentIdx] = *newSegment
+		} else {
+			file.segments = append(file.segments, *newSegment)
+		}
+		offset += n
+		writeSegmentIdx++
+		relativeFilePos = 0
+	}
+	file.filePos += int64(sizeToWrite)
+	file.currentLength = 0
+	for _, obj := range file.segments {
+		file.currentLength += obj.Bytes
+	}
+	return sizeToWrite, nil
+}
+
+func (file *largeObjectCreateFile) writeSegment(buf []byte, writeSegmentIdx int, relativeFilePos int) (*Object, int, error) {
+	var (
+		readers         []io.Reader
+		existingSegment *Object
+		segmentSize     int
+	)
+	segmentName := getSegment(file.prefix, writeSegmentIdx+1)
+	sizeToRead := int(file.chunkSize)
+	if writeSegmentIdx < len(file.segments) {
+		existingSegment = &file.segments[writeSegmentIdx]
+		if writeSegmentIdx != len(file.segments)-1 {
+			sizeToRead = int(existingSegment.Bytes)
+		}
+		if relativeFilePos > 0 {
+			headers := make(Headers)
+			headers["Range"] = "bytes=0-" + strconv.FormatInt(int64(relativeFilePos-1), 10)
+			existingSegmentReader, _, err := file.conn.ObjectOpen(file.segmentContainer, segmentName, true, headers)
+			if err != nil {
+				return nil, 0, err
+			}
+			defer existingSegmentReader.Close()
+			sizeToRead -= relativeFilePos
+			segmentSize += relativeFilePos
+			readers = []io.Reader{existingSegmentReader}
+		}
+	}
+	if sizeToRead > len(buf) {
+		sizeToRead = len(buf)
+	}
+	segmentSize += sizeToRead
+	readers = append(readers, bytes.NewReader(buf[:sizeToRead]))
+	if existingSegment != nil && segmentSize < int(existingSegment.Bytes) {
+		headers := make(Headers)
+		headers["Range"] = "bytes=" + strconv.FormatInt(int64(segmentSize), 10) + "-"
+		tailSegmentReader, _, err := file.conn.ObjectOpen(file.segmentContainer, segmentName, true, headers)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer tailSegmentReader.Close()
+		segmentSize = int(existingSegment.Bytes)
+		readers = append(readers, tailSegmentReader)
+	}
+	segmentReader := io.MultiReader(readers...)
+	headers, err := file.conn.ObjectPut(file.segmentContainer, segmentName, segmentReader, true, "", file.contentType, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	return &Object{Name: segmentName, Bytes: int64(segmentSize), Hash: headers["Etag"]}, sizeToRead, nil
+}
+
+func withBuffer(opts *LargeObjectOpts, lo LargeObjectFile) LargeObjectFile {
+	if !opts.NoBuffer {
+		return &bufferedLargeObjectFile{
+			LargeObjectFile: lo,
+			bw:              bufio.NewWriterSize(lo, int(opts.ChunkSize)),
+		}
+	}
+	return lo
+}
+
+type bufferedLargeObjectFile struct {
+	LargeObjectFile
+	bw *bufio.Writer
+}
+
+func (blo *bufferedLargeObjectFile) Close() error {
+	err := blo.bw.Flush()
+	if err != nil {
+		return err
+	}
+	return blo.LargeObjectFile.Close()
+}
+
+func (blo *bufferedLargeObjectFile) Write(p []byte) (n int, err error) {
+	return blo.bw.Write(p)
+}
+
+func (blo *bufferedLargeObjectFile) Seek(offset int64, whence int) (int64, error) {
+	err := blo.bw.Flush()
+	if err != nil {
+		return 0, err
+	}
+	return blo.LargeObjectFile.Seek(offset, whence)
+}
+
+func (blo *bufferedLargeObjectFile) Size() int64 {
+	return blo.LargeObjectFile.Size() + int64(blo.bw.Buffered())
+}
+
+func (blo *bufferedLargeObjectFile) Flush() error {
+	err := blo.bw.Flush()
+	if err != nil {
+		return err
+	}
+	return blo.LargeObjectFile.Flush()
+}

--- a/vendor/github.com/ncw/swift/meta.go
+++ b/vendor/github.com/ncw/swift/meta.go
@@ -1,0 +1,174 @@
+// Metadata manipulation in and out of Headers
+
+package swift
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Metadata stores account, container or object metadata.
+type Metadata map[string]string
+
+// Metadata gets the Metadata starting with the metaPrefix out of the Headers.
+//
+// The keys in the Metadata will be converted to lower case
+func (h Headers) Metadata(metaPrefix string) Metadata {
+	m := Metadata{}
+	metaPrefix = http.CanonicalHeaderKey(metaPrefix)
+	for key, value := range h {
+		if strings.HasPrefix(key, metaPrefix) {
+			metaKey := strings.ToLower(key[len(metaPrefix):])
+			m[metaKey] = value
+		}
+	}
+	return m
+}
+
+// AccountMetadata converts Headers from account to a Metadata.
+//
+// The keys in the Metadata will be converted to lower case.
+func (h Headers) AccountMetadata() Metadata {
+	return h.Metadata("X-Account-Meta-")
+}
+
+// ContainerMetadata converts Headers from container to a Metadata.
+//
+// The keys in the Metadata will be converted to lower case.
+func (h Headers) ContainerMetadata() Metadata {
+	return h.Metadata("X-Container-Meta-")
+}
+
+// ObjectMetadata converts Headers from object to a Metadata.
+//
+// The keys in the Metadata will be converted to lower case.
+func (h Headers) ObjectMetadata() Metadata {
+	return h.Metadata("X-Object-Meta-")
+}
+
+// Headers convert the Metadata starting with the metaPrefix into a
+// Headers.
+//
+// The keys in the Metadata will be converted from lower case to http
+// Canonical (see http.CanonicalHeaderKey).
+func (m Metadata) Headers(metaPrefix string) Headers {
+	h := Headers{}
+	for key, value := range m {
+		key = http.CanonicalHeaderKey(metaPrefix + key)
+		h[key] = value
+	}
+	return h
+}
+
+// AccountHeaders converts the Metadata for the account.
+func (m Metadata) AccountHeaders() Headers {
+	return m.Headers("X-Account-Meta-")
+}
+
+// ContainerHeaders converts the Metadata for the container.
+func (m Metadata) ContainerHeaders() Headers {
+	return m.Headers("X-Container-Meta-")
+}
+
+// ObjectHeaders converts the Metadata for the object.
+func (m Metadata) ObjectHeaders() Headers {
+	return m.Headers("X-Object-Meta-")
+}
+
+// Turns a number of ns into a floating point string in seconds
+//
+// Trims trailing zeros and guaranteed to be perfectly accurate
+func nsToFloatString(ns int64) string {
+	if ns < 0 {
+		return "-" + nsToFloatString(-ns)
+	}
+	result := fmt.Sprintf("%010d", ns)
+	split := len(result) - 9
+	result, decimals := result[:split], result[split:]
+	decimals = strings.TrimRight(decimals, "0")
+	if decimals != "" {
+		result += "."
+		result += decimals
+	}
+	return result
+}
+
+// Turns a floating point string in seconds into a ns integer
+//
+// Guaranteed to be perfectly accurate
+func floatStringToNs(s string) (int64, error) {
+	const zeros = "000000000"
+	if point := strings.IndexRune(s, '.'); point >= 0 {
+		tail := s[point+1:]
+		if fill := 9 - len(tail); fill < 0 {
+			tail = tail[:9]
+		} else {
+			tail += zeros[:fill]
+		}
+		s = s[:point] + tail
+	} else if len(s) > 0 { // Make sure empty string produces an error
+		s += zeros
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// FloatStringToTime converts a floating point number string to a time.Time
+//
+// The string is floating point number of seconds since the epoch
+// (Unix time).  The number should be in fixed point format (not
+// exponential), eg "1354040105.123456789" which represents the time
+// "2012-11-27T18:15:05.123456789Z"
+//
+// Some care is taken to preserve all the accuracy in the time.Time
+// (which wouldn't happen with a naive conversion through float64) so
+// a round trip conversion won't change the data.
+//
+// If an error is returned then time will be returned as the zero time.
+func FloatStringToTime(s string) (t time.Time, err error) {
+	ns, err := floatStringToNs(s)
+	if err != nil {
+		return
+	}
+	t = time.Unix(0, ns)
+	return
+}
+
+// TimeToFloatString converts a time.Time object to a floating point string
+//
+// The string is floating point number of seconds since the epoch
+// (Unix time).  The number is in fixed point format (not
+// exponential), eg "1354040105.123456789" which represents the time
+// "2012-11-27T18:15:05.123456789Z".  Trailing zeros will be dropped
+// from the output.
+//
+// Some care is taken to preserve all the accuracy in the time.Time
+// (which wouldn't happen with a naive conversion through float64) so
+// a round trip conversion won't change the data.
+func TimeToFloatString(t time.Time) string {
+	return nsToFloatString(t.UnixNano())
+}
+
+// Read a modification time (mtime) from a Metadata object
+//
+// This is a defacto standard (used in the official python-swiftclient
+// amongst others) for storing the modification time (as read using
+// os.Stat) for an object.  It is stored using the key 'mtime', which
+// for example when written to an object will be 'X-Object-Meta-Mtime'.
+//
+// If an error is returned then time will be returned as the zero time.
+func (m Metadata) GetModTime() (t time.Time, err error) {
+	return FloatStringToTime(m["mtime"])
+}
+
+// Write an modification time (mtime) to a Metadata object
+//
+// This is a defacto standard (used in the official python-swiftclient
+// amongst others) for storing the modification time (as read using
+// os.Stat) for an object.  It is stored using the key 'mtime', which
+// for example when written to an object will be 'X-Object-Meta-Mtime'.
+func (m Metadata) SetModTime(t time.Time) {
+	m["mtime"] = TimeToFloatString(t)
+}

--- a/vendor/github.com/ncw/swift/notes.txt
+++ b/vendor/github.com/ncw/swift/notes.txt
@@ -1,0 +1,55 @@
+Notes on Go Swift
+=================
+
+Make a builder style interface like the Google Go APIs?  Advantages
+are that it is easy to add named methods to the service object to do
+specific things.  Slightly less efficient.  Not sure about how to
+return extra stuff though - in an object?
+
+Make a container struct so these could be methods on it?
+
+Make noResponse check for 204?
+
+Make storage public so it can be extended easily?
+
+Rename to go-swift to match user agent string?
+
+Reconnect on auth error - 401 when token expires isn't tested
+
+Make more api compatible with python cloudfiles?
+
+Retry operations on timeout / network errors?
+- also 408 error
+- GET requests only?
+
+Make Connection thread safe - whenever it is changed take a write lock whenever it is read from a read lock
+
+Add extra headers field to Connection (for via etc)
+
+Make errors use an error heirachy then can catch them with a type assertion
+
+ Error(...)
+ ObjectCorrupted{ Error }
+
+Make a Debug flag in connection for logging stuff
+
+Object If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since etc
+
+Object range
+
+Object create, update with X-Delete-At or X-Delete-After
+
+Large object support
+- check uploads are less than 5GB in normal mode?
+
+Access control CORS?
+
+Swift client retries and backs off for all types of errors
+
+Implement net error interface?
+
+type Error interface {
+    error
+    Timeout() bool   // Is the error a timeout?
+    Temporary() bool // Is the error temporary?
+}

--- a/vendor/github.com/ncw/swift/slo.go
+++ b/vendor/github.com/ncw/swift/slo.go
@@ -1,0 +1,168 @@
+package swift
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+)
+
+// StaticLargeObjectCreateFile represents an open static large object
+type StaticLargeObjectCreateFile struct {
+	largeObjectCreateFile
+}
+
+var SLONotSupported = errors.New("SLO not supported")
+
+type swiftSegment struct {
+	Path string `json:"path,omitempty"`
+	Etag string `json:"etag,omitempty"`
+	Size int64  `json:"size_bytes,omitempty"`
+	// When uploading a manifest, the attributes must be named `path`, `etag` and `size_bytes`
+	// but when querying the JSON content of a manifest with the `multipart-manifest=get`
+	// parameter, Swift names those attributes `name`, `hash` and `bytes`.
+	// We use all the different attributes names in this structure to be able to use
+	// the same structure for both uploading and retrieving.
+	Name         string `json:"name,omitempty"`
+	Hash         string `json:"hash,omitempty"`
+	Bytes        int64  `json:"bytes,omitempty"`
+	ContentType  string `json:"content_type,omitempty"`
+	LastModified string `json:"last_modified,omitempty"`
+}
+
+// StaticLargeObjectCreateFile creates a static large object returning
+// an object which satisfies io.Writer, io.Seeker, io.Closer and
+// io.ReaderFrom.  The flags are as passed to the largeObjectCreate
+// method.
+func (c *Connection) StaticLargeObjectCreateFile(opts *LargeObjectOpts) (LargeObjectFile, error) {
+	info, err := c.cachedQueryInfo()
+	if err != nil || !info.SupportsSLO() {
+		return nil, SLONotSupported
+	}
+	realMinChunkSize := info.SLOMinSegmentSize()
+	if realMinChunkSize > opts.MinChunkSize {
+		opts.MinChunkSize = realMinChunkSize
+	}
+	lo, err := c.largeObjectCreate(opts)
+	if err != nil {
+		return nil, err
+	}
+	return withBuffer(opts, &StaticLargeObjectCreateFile{
+		largeObjectCreateFile: *lo,
+	}), nil
+}
+
+// StaticLargeObjectCreate creates or truncates an existing static
+// large object returning a writeable object. This sets opts.Flags to
+// an appropriate value before calling StaticLargeObjectCreateFile
+func (c *Connection) StaticLargeObjectCreate(opts *LargeObjectOpts) (LargeObjectFile, error) {
+	opts.Flags = os.O_TRUNC | os.O_CREATE
+	return c.StaticLargeObjectCreateFile(opts)
+}
+
+// StaticLargeObjectDelete deletes a static large object and all of its segments.
+func (c *Connection) StaticLargeObjectDelete(container string, path string) error {
+	info, err := c.cachedQueryInfo()
+	if err != nil || !info.SupportsSLO() {
+		return SLONotSupported
+	}
+	return c.LargeObjectDelete(container, path)
+}
+
+// StaticLargeObjectMove moves a static large object from srcContainer, srcObjectName to dstContainer, dstObjectName
+func (c *Connection) StaticLargeObjectMove(srcContainer string, srcObjectName string, dstContainer string, dstObjectName string) error {
+	swiftInfo, err := c.cachedQueryInfo()
+	if err != nil || !swiftInfo.SupportsSLO() {
+		return SLONotSupported
+	}
+	info, headers, err := c.Object(srcContainer, srcObjectName)
+	if err != nil {
+		return err
+	}
+
+	container, segments, err := c.getAllSegments(srcContainer, srcObjectName, headers)
+	if err != nil {
+		return err
+	}
+
+	if err := c.createSLOManifest(dstContainer, dstObjectName, info.ContentType, container, segments); err != nil {
+		return err
+	}
+
+	if err := c.ObjectDelete(srcContainer, srcObjectName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createSLOManifest creates a static large object manifest
+func (c *Connection) createSLOManifest(container string, path string, contentType string, segmentContainer string, segments []Object) error {
+	sloSegments := make([]swiftSegment, len(segments))
+	for i, segment := range segments {
+		sloSegments[i].Path = fmt.Sprintf("%s/%s", segmentContainer, segment.Name)
+		sloSegments[i].Etag = segment.Hash
+		sloSegments[i].Size = segment.Bytes
+	}
+
+	content, err := json.Marshal(sloSegments)
+	if err != nil {
+		return err
+	}
+
+	values := url.Values{}
+	values.Set("multipart-manifest", "put")
+	if _, err := c.objectPut(container, path, bytes.NewBuffer(content), false, "", contentType, nil, values); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (file *StaticLargeObjectCreateFile) Close() error {
+	return file.Flush()
+}
+
+func (file *StaticLargeObjectCreateFile) Flush() error {
+	if err := file.conn.createSLOManifest(file.container, file.objectName, file.contentType, file.segmentContainer, file.segments); err != nil {
+		return err
+	}
+	return file.conn.waitForSegmentsToShowUp(file.container, file.objectName, file.Size())
+}
+
+func (c *Connection) getAllSLOSegments(container, path string) (string, []Object, error) {
+	var (
+		segmentList      []swiftSegment
+		segments         []Object
+		segPath          string
+		segmentContainer string
+	)
+
+	values := url.Values{}
+	values.Set("multipart-manifest", "get")
+
+	file, _, err := c.objectOpen(container, path, true, nil, values)
+	if err != nil {
+		return "", nil, err
+	}
+
+	content, err := ioutil.ReadAll(file)
+	if err != nil {
+		return "", nil, err
+	}
+
+	json.Unmarshal(content, &segmentList)
+	for _, segment := range segmentList {
+		segmentContainer, segPath = parseFullPath(segment.Name[1:])
+		segments = append(segments, Object{
+			Name:  segPath,
+			Bytes: segment.Bytes,
+			Hash:  segment.Hash,
+		})
+	}
+
+	return segmentContainer, segments, nil
+}

--- a/vendor/github.com/ncw/swift/swift.go
+++ b/vendor/github.com/ncw/swift/swift.go
@@ -1,0 +1,2190 @@
+package swift
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultUserAgent    = "goswift/1.0"         // Default user agent
+	DefaultRetries      = 3                     // Default number of retries on token expiry
+	TimeFormat          = "2006-01-02T15:04:05" // Python date format for json replies parsed as UTC
+	UploadTar           = "tar"                 // Data format specifier for Connection.BulkUpload().
+	UploadTarGzip       = "tar.gz"              // Data format specifier for Connection.BulkUpload().
+	UploadTarBzip2      = "tar.bz2"             // Data format specifier for Connection.BulkUpload().
+	allContainersLimit  = 10000                 // Number of containers to fetch at once
+	allObjectsLimit     = 10000                 // Number objects to fetch at once
+	allObjectsChanLimit = 1000                  // ...when fetching to a channel
+)
+
+// ObjectType is the type of the swift object, regular, static large,
+// or dynamic large.
+type ObjectType int
+
+// Values that ObjectType can take
+const (
+	RegularObjectType ObjectType = iota
+	StaticLargeObjectType
+	DynamicLargeObjectType
+)
+
+// Connection holds the details of the connection to the swift server.
+//
+// You need to provide UserName, ApiKey and AuthUrl when you create a
+// connection then call Authenticate on it.
+//
+// The auth version in use will be detected from the AuthURL - you can
+// override this with the AuthVersion parameter.
+//
+// If using v2 auth you can also set Region in the Connection
+// structure.  If you don't set Region you will get the default region
+// which may not be what you want.
+//
+// For reference some common AuthUrls looks like this:
+//
+//  Rackspace US        https://auth.api.rackspacecloud.com/v1.0
+//  Rackspace UK        https://lon.auth.api.rackspacecloud.com/v1.0
+//  Rackspace v2        https://identity.api.rackspacecloud.com/v2.0
+//  Memset Memstore UK  https://auth.storage.memset.com/v1.0
+//  Memstore v2         https://auth.storage.memset.com/v2.0
+//
+// When using Google Appengine you must provide the Connection with an
+// appengine-specific Transport:
+//
+//	import (
+//		"appengine/urlfetch"
+//		"fmt"
+//		"github.com/ncw/swift"
+//	)
+//
+//	func handler(w http.ResponseWriter, r *http.Request) {
+//		ctx := appengine.NewContext(r)
+//		tr := urlfetch.Transport{Context: ctx}
+//		c := swift.Connection{
+//			UserName:  "user",
+//			ApiKey:    "key",
+//			AuthUrl:   "auth_url",
+//			Transport: tr,
+//		}
+//		_ := c.Authenticate()
+//		containers, _ := c.ContainerNames(nil)
+//		fmt.Fprintf(w, "containers: %q", containers)
+//	}
+//
+// If you don't supply a Transport, one is made which relies on
+// http.ProxyFromEnvironment (http://golang.org/pkg/net/http/#ProxyFromEnvironment).
+// This means that the connection will respect the HTTP proxy specified by the
+// environment variables $HTTP_PROXY and $NO_PROXY.
+type Connection struct {
+	// Parameters - fill these in before calling Authenticate
+	// They are all optional except UserName, ApiKey and AuthUrl
+	Domain         string            // User's domain name
+	DomainId       string            // User's domain Id
+	UserName       string            // UserName for api
+	UserId         string            // User Id
+	ApiKey         string            // Key for api access
+	AuthUrl        string            // Auth URL
+	Retries        int               // Retries on error (default is 3)
+	UserAgent      string            // Http User agent (default goswift/1.0)
+	ConnectTimeout time.Duration     // Connect channel timeout (default 10s)
+	Timeout        time.Duration     // Data channel timeout (default 60s)
+	Region         string            // Region to use eg "LON", "ORD" - default is use first region (v2,v3 auth only)
+	AuthVersion    int               // Set to 1, 2 or 3 or leave at 0 for autodetect
+	Internal       bool              // Set this to true to use the the internal / service network
+	Tenant         string            // Name of the tenant (v2,v3 auth only)
+	TenantId       string            // Id of the tenant (v2,v3 auth only)
+	EndpointType   EndpointType      // Endpoint type (v2,v3 auth only) (default is public URL unless Internal is set)
+	TenantDomain   string            // Name of the tenant's domain (v3 auth only), only needed if it differs from the user domain
+	TenantDomainId string            // Id of the tenant's domain (v3 auth only), only needed if it differs the from user domain
+	TrustId        string            // Id of the trust (v3 auth only)
+	Transport      http.RoundTripper `json:"-" xml:"-"` // Optional specialised http.Transport (eg. for Google Appengine)
+	// These are filled in after Authenticate is called as are the defaults for above
+	StorageUrl string
+	AuthToken  string
+	client     *http.Client
+	Auth       Authenticator `json:"-" xml:"-"` // the current authenticator
+	authLock   sync.Mutex    // lock when R/W StorageUrl, AuthToken, Auth
+	// swiftInfo is filled after QueryInfo is called
+	swiftInfo SwiftInfo
+}
+
+// setFromEnv reads the value that param points to (it must be a
+// pointer), if it isn't the zero value then it reads the environment
+// variable name passed in, parses it according to the type and writes
+// it to the pointer.
+func setFromEnv(param interface{}, name string) (err error) {
+	val := os.Getenv(name)
+	if val == "" {
+		return
+	}
+	switch result := param.(type) {
+	case *string:
+		if *result == "" {
+			*result = val
+		}
+	case *int:
+		if *result == 0 {
+			*result, err = strconv.Atoi(val)
+		}
+	case *bool:
+		if *result == false {
+			*result, err = strconv.ParseBool(val)
+		}
+	case *time.Duration:
+		if *result == 0 {
+			*result, err = time.ParseDuration(val)
+		}
+	case *EndpointType:
+		if *result == EndpointType("") {
+			*result = EndpointType(val)
+		}
+	default:
+		return newErrorf(0, "can't set var of type %T", param)
+	}
+	return err
+}
+
+// ApplyEnvironment reads environment variables and applies them to
+// the Connection structure.  It won't overwrite any parameters which
+// are already set in the Connection struct.
+//
+// To make a new Connection object entirely from the environment you
+// would do:
+//
+//    c := new(Connection)
+//    err := c.ApplyEnvironment()
+//    if err != nil { log.Fatal(err) }
+//
+// The naming of these variables follows the official Openstack naming
+// scheme so it should be compatible with OpenStack rc files.
+//
+// For v1 authentication (obsolete)
+//     ST_AUTH - Auth URL
+//     ST_USER - UserName for api
+//     ST_KEY - Key for api access
+//
+// For v2 authentication
+//     OS_AUTH_URL - Auth URL
+//     OS_USERNAME - UserName for api
+//     OS_PASSWORD - Key for api access
+//     OS_TENANT_NAME - Name of the tenant
+//     OS_TENANT_ID   - Id of the tenant
+//     OS_REGION_NAME - Region to use - default is use first region
+//
+// For v3 authentication
+//     OS_AUTH_URL - Auth URL
+//     OS_USERNAME - UserName for api
+//     OS_USER_ID - User Id
+//     OS_PASSWORD - Key for api access
+//     OS_USER_DOMAIN_NAME - User's domain name
+//     OS_USER_DOMAIN_ID - User's domain Id
+//     OS_PROJECT_NAME - Name of the project
+//     OS_PROJECT_DOMAIN_NAME - Name of the tenant's domain, only needed if it differs from the user domain
+//     OS_PROJECT_DOMAIN_ID - Id of the tenant's domain, only needed if it differs the from user domain
+//     OS_TRUST_ID - If of the trust
+//     OS_REGION_NAME - Region to use - default is use first region
+//
+// Other
+//     OS_ENDPOINT_TYPE - Endpoint type public, internal or admin
+//     ST_AUTH_VERSION - Choose auth version - 1, 2 or 3 or leave at 0 for autodetect
+//
+// For manual authentication
+//     OS_STORAGE_URL - storage URL from alternate authentication
+//     OS_AUTH_TOKEN - Auth Token from alternate authentication
+//
+// Library specific
+//     GOSWIFT_RETRIES - Retries on error (default is 3)
+//     GOSWIFT_USER_AGENT - HTTP User agent (default goswift/1.0)
+//     GOSWIFT_CONNECT_TIMEOUT - Connect channel timeout with unit, eg "10s", "100ms" (default "10s")
+//     GOSWIFT_TIMEOUT - Data channel timeout with unit, eg "10s", "100ms" (default "60s")
+//     GOSWIFT_INTERNAL - Set this to "true" to use the the internal network (obsolete - use OS_ENDPOINT_TYPE)
+func (c *Connection) ApplyEnvironment() (err error) {
+	for _, item := range []struct {
+		result interface{}
+		name   string
+	}{
+		// Environment variables - keep in same order as Connection
+		{&c.Domain, "OS_USER_DOMAIN_NAME"},
+		{&c.DomainId, "OS_USER_DOMAIN_ID"},
+		{&c.UserName, "OS_USERNAME"},
+		{&c.UserId, "OS_USER_ID"},
+		{&c.ApiKey, "OS_PASSWORD"},
+		{&c.AuthUrl, "OS_AUTH_URL"},
+		{&c.Retries, "GOSWIFT_RETRIES"},
+		{&c.UserAgent, "GOSWIFT_USER_AGENT"},
+		{&c.ConnectTimeout, "GOSWIFT_CONNECT_TIMEOUT"},
+		{&c.Timeout, "GOSWIFT_TIMEOUT"},
+		{&c.Region, "OS_REGION_NAME"},
+		{&c.AuthVersion, "ST_AUTH_VERSION"},
+		{&c.Internal, "GOSWIFT_INTERNAL"},
+		{&c.Tenant, "OS_TENANT_NAME"},  //v2
+		{&c.Tenant, "OS_PROJECT_NAME"}, // v3
+		{&c.TenantId, "OS_TENANT_ID"},
+		{&c.EndpointType, "OS_ENDPOINT_TYPE"},
+		{&c.TenantDomain, "OS_PROJECT_DOMAIN_NAME"},
+		{&c.TenantDomainId, "OS_PROJECT_DOMAIN_ID"},
+		{&c.TrustId, "OS_TRUST_ID"},
+		{&c.StorageUrl, "OS_STORAGE_URL"},
+		{&c.AuthToken, "OS_AUTH_TOKEN"},
+		// v1 auth alternatives
+		{&c.ApiKey, "ST_KEY"},
+		{&c.UserName, "ST_USER"},
+		{&c.AuthUrl, "ST_AUTH"},
+	} {
+		err = setFromEnv(item.result, item.name)
+		if err != nil {
+			return newErrorf(0, "failed to read env var %q: %v", item.name, err)
+		}
+	}
+	return nil
+}
+
+// Error - all errors generated by this package are of this type.  Other error
+// may be passed on from library functions though.
+type Error struct {
+	StatusCode int // HTTP status code if relevant or 0 if not
+	Text       string
+}
+
+// Error satisfy the error interface.
+func (e *Error) Error() string {
+	return e.Text
+}
+
+// newError make a new error from a string.
+func newError(StatusCode int, Text string) *Error {
+	return &Error{
+		StatusCode: StatusCode,
+		Text:       Text,
+	}
+}
+
+// newErrorf makes a new error from sprintf parameters.
+func newErrorf(StatusCode int, Text string, Parameters ...interface{}) *Error {
+	return newError(StatusCode, fmt.Sprintf(Text, Parameters...))
+}
+
+// errorMap defines http error codes to error mappings.
+type errorMap map[int]error
+
+var (
+	// Specific Errors you might want to check for equality
+	NotModified         = newError(304, "Not Modified")
+	BadRequest          = newError(400, "Bad Request")
+	AuthorizationFailed = newError(401, "Authorization Failed")
+	ContainerNotFound   = newError(404, "Container Not Found")
+	ContainerNotEmpty   = newError(409, "Container Not Empty")
+	ObjectNotFound      = newError(404, "Object Not Found")
+	ObjectCorrupted     = newError(422, "Object Corrupted")
+	TimeoutError        = newError(408, "Timeout when reading or writing data")
+	Forbidden           = newError(403, "Operation forbidden")
+	TooLargeObject      = newError(413, "Too Large Object")
+
+	// Mappings for authentication errors
+	authErrorMap = errorMap{
+		400: BadRequest,
+		401: AuthorizationFailed,
+		403: Forbidden,
+	}
+
+	// Mappings for container errors
+	ContainerErrorMap = errorMap{
+		400: BadRequest,
+		403: Forbidden,
+		404: ContainerNotFound,
+		409: ContainerNotEmpty,
+	}
+
+	// Mappings for object errors
+	objectErrorMap = errorMap{
+		304: NotModified,
+		400: BadRequest,
+		403: Forbidden,
+		404: ObjectNotFound,
+		413: TooLargeObject,
+		422: ObjectCorrupted,
+	}
+)
+
+// checkClose is used to check the return from Close in a defer
+// statement.
+func checkClose(c io.Closer, err *error) {
+	cerr := c.Close()
+	if *err == nil {
+		*err = cerr
+	}
+}
+
+// drainAndClose discards all data from rd and closes it.
+// If an error occurs during Read, it is discarded.
+func drainAndClose(rd io.ReadCloser, err *error) {
+	if rd == nil {
+		return
+	}
+
+	_, _ = io.Copy(ioutil.Discard, rd)
+	cerr := rd.Close()
+	if err != nil && *err == nil {
+		*err = cerr
+	}
+}
+
+// parseHeaders checks a response for errors and translates into
+// standard errors if necessary. If an error is returned, resp.Body
+// has been drained and closed.
+func (c *Connection) parseHeaders(resp *http.Response, errorMap errorMap) error {
+	if errorMap != nil {
+		if err, ok := errorMap[resp.StatusCode]; ok {
+			drainAndClose(resp.Body, nil)
+			return err
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		drainAndClose(resp.Body, nil)
+		return newErrorf(resp.StatusCode, "HTTP Error: %d: %s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+// readHeaders returns a Headers object from the http.Response.
+//
+// If it receives multiple values for a key (which should never
+// happen) it will use the first one
+func readHeaders(resp *http.Response) Headers {
+	headers := Headers{}
+	for key, values := range resp.Header {
+		headers[key] = values[0]
+	}
+	return headers
+}
+
+// Headers stores HTTP headers (can only have one of each header like Swift).
+type Headers map[string]string
+
+// Does an http request using the running timer passed in
+func (c *Connection) doTimeoutRequest(timer *time.Timer, req *http.Request) (*http.Response, error) {
+	// Do the request in the background so we can check the timeout
+	type result struct {
+		resp *http.Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := c.client.Do(req)
+		done <- result{resp, err}
+	}()
+	// Wait for the read or the timeout
+	select {
+	case r := <-done:
+		return r.resp, r.err
+	case <-timer.C:
+		// Kill the connection on timeout so we don't leak sockets or goroutines
+		cancelRequest(c.Transport, req)
+		return nil, TimeoutError
+	}
+	panic("unreachable") // For Go 1.0
+}
+
+// Set defaults for any unset values
+//
+// Call with authLock held
+func (c *Connection) setDefaults() {
+	if c.UserAgent == "" {
+		c.UserAgent = DefaultUserAgent
+	}
+	if c.Retries == 0 {
+		c.Retries = DefaultRetries
+	}
+	if c.ConnectTimeout == 0 {
+		c.ConnectTimeout = 10 * time.Second
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 60 * time.Second
+	}
+	if c.Transport == nil {
+		c.Transport = &http.Transport{
+			//		TLSClientConfig:    &tls.Config{RootCAs: pool},
+			//		DisableCompression: true,
+			Proxy:               http.ProxyFromEnvironment,
+			MaxIdleConnsPerHost: 2048,
+		}
+	}
+	if c.client == nil {
+		c.client = &http.Client{
+			//		CheckRedirect: redirectPolicyFunc,
+			Transport: c.Transport,
+		}
+	}
+}
+
+// Authenticate connects to the Swift server.
+//
+// If you don't call it before calling one of the connection methods
+// then it will be called for you on the first access.
+func (c *Connection) Authenticate() (err error) {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+	return c.authenticate()
+}
+
+// Internal implementation of Authenticate
+//
+// Call with authLock held
+func (c *Connection) authenticate() (err error) {
+	c.setDefaults()
+
+	// Flush the keepalives connection - if we are
+	// re-authenticating then stuff has gone wrong
+	flushKeepaliveConnections(c.Transport)
+
+	if c.Auth == nil {
+		c.Auth, err = newAuth(c)
+		if err != nil {
+			return
+		}
+	}
+
+	retries := 1
+again:
+	var req *http.Request
+	req, err = c.Auth.Request(c)
+	if err != nil {
+		return
+	}
+	if req != nil {
+		timer := time.NewTimer(c.ConnectTimeout)
+		defer timer.Stop()
+		var resp *http.Response
+		resp, err = c.doTimeoutRequest(timer, req)
+		if err != nil {
+			return
+		}
+		defer func() {
+			drainAndClose(resp.Body, &err)
+			// Flush the auth connection - we don't want to keep
+			// it open if keepalives were enabled
+			flushKeepaliveConnections(c.Transport)
+		}()
+		if err = c.parseHeaders(resp, authErrorMap); err != nil {
+			// Try again for a limited number of times on
+			// AuthorizationFailed or BadRequest. This allows us
+			// to try some alternate forms of the request
+			if (err == AuthorizationFailed || err == BadRequest) && retries > 0 {
+				retries--
+				goto again
+			}
+			return
+		}
+		err = c.Auth.Response(resp)
+		if err != nil {
+			return
+		}
+	}
+	if customAuth, isCustom := c.Auth.(CustomEndpointAuthenticator); isCustom && c.EndpointType != "" {
+		c.StorageUrl = customAuth.StorageUrlForEndpoint(c.EndpointType)
+	} else {
+		c.StorageUrl = c.Auth.StorageUrl(c.Internal)
+	}
+	c.AuthToken = c.Auth.Token()
+	if !c.authenticated() {
+		err = newError(0, "Response didn't have storage url and auth token")
+		return
+	}
+	return
+}
+
+// Get an authToken and url
+//
+// The Url may be updated if it needed to authenticate using the OnReAuth function
+func (c *Connection) getUrlAndAuthToken(targetUrlIn string, OnReAuth func() (string, error)) (targetUrlOut, authToken string, err error) {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+	targetUrlOut = targetUrlIn
+	if !c.authenticated() {
+		err = c.authenticate()
+		if err != nil {
+			return
+		}
+		if OnReAuth != nil {
+			targetUrlOut, err = OnReAuth()
+			if err != nil {
+				return
+			}
+		}
+	}
+	authToken = c.AuthToken
+	return
+}
+
+// flushKeepaliveConnections is called to flush pending requests after an error.
+func flushKeepaliveConnections(transport http.RoundTripper) {
+	if tr, ok := transport.(interface {
+		CloseIdleConnections()
+	}); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
+// UnAuthenticate removes the authentication from the Connection.
+func (c *Connection) UnAuthenticate() {
+	c.authLock.Lock()
+	c.StorageUrl = ""
+	c.AuthToken = ""
+	c.authLock.Unlock()
+}
+
+// Authenticated returns a boolean to show if the current connection
+// is authenticated.
+//
+// Doesn't actually check the credentials against the server.
+func (c *Connection) Authenticated() bool {
+	c.authLock.Lock()
+	defer c.authLock.Unlock()
+	return c.authenticated()
+}
+
+// Internal version of Authenticated()
+//
+// Call with authLock held
+func (c *Connection) authenticated() bool {
+	return c.StorageUrl != "" && c.AuthToken != ""
+}
+
+// SwiftInfo contains the JSON object returned by Swift when the /info
+// route is queried. The object contains, among others, the Swift version,
+// the enabled middlewares and their configuration
+type SwiftInfo map[string]interface{}
+
+func (i SwiftInfo) SupportsBulkDelete() bool {
+	_, val := i["bulk_delete"]
+	return val
+}
+
+func (i SwiftInfo) SupportsSLO() bool {
+	_, val := i["slo"]
+	return val
+}
+
+func (i SwiftInfo) SLOMinSegmentSize() int64 {
+	if slo, ok := i["slo"].(map[string]interface{}); ok {
+		val, _ := slo["min_segment_size"].(float64)
+		return int64(val)
+	}
+	return 1
+}
+
+// Discover Swift configuration by doing a request against /info
+func (c *Connection) QueryInfo() (infos SwiftInfo, err error) {
+	infoUrl, err := url.Parse(c.StorageUrl)
+	if err != nil {
+		return nil, err
+	}
+	infoUrl.Path = path.Join(infoUrl.Path, "..", "..", "info")
+	resp, err := c.client.Get(infoUrl.String())
+	if err == nil {
+		if resp.StatusCode != http.StatusOK {
+			drainAndClose(resp.Body, nil)
+			return nil, fmt.Errorf("Invalid status code for info request: %d", resp.StatusCode)
+		}
+		err = readJson(resp, &infos)
+		if err == nil {
+			c.authLock.Lock()
+			c.swiftInfo = infos
+			c.authLock.Unlock()
+		}
+		return infos, err
+	}
+	return nil, err
+}
+
+func (c *Connection) cachedQueryInfo() (infos SwiftInfo, err error) {
+	c.authLock.Lock()
+	infos = c.swiftInfo
+	c.authLock.Unlock()
+	if infos == nil {
+		infos, err = c.QueryInfo()
+		if err != nil {
+			return
+		}
+	}
+	return infos, nil
+}
+
+// RequestOpts contains parameters for Connection.storage.
+type RequestOpts struct {
+	Container  string
+	ObjectName string
+	Operation  string
+	Parameters url.Values
+	Headers    Headers
+	ErrorMap   errorMap
+	NoResponse bool
+	Body       io.Reader
+	Retries    int
+	// if set this is called on re-authentication to refresh the targetUrl
+	OnReAuth func() (string, error)
+}
+
+// Call runs a remote command on the targetUrl, returns a
+// response, headers and possible error.
+//
+// operation is GET, HEAD etc
+// container is the name of a container
+// Any other parameters (if not None) are added to the targetUrl
+//
+// Returns a response or an error.  If response is returned then
+// the resp.Body must be read completely and
+// resp.Body.Close() must be called on it, unless noResponse is set in
+// which case the body will be closed in this function
+//
+// If "Content-Length" is set in p.Headers it will be used - this can
+// be used to override the default chunked transfer encoding for
+// uploads.
+//
+// This will Authenticate if necessary, and re-authenticate if it
+// receives a 401 error which means the token has expired
+//
+// This method is exported so extensions can call it.
+func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response, headers Headers, err error) {
+	c.authLock.Lock()
+	c.setDefaults()
+	c.authLock.Unlock()
+	retries := p.Retries
+	if retries == 0 {
+		retries = c.Retries
+	}
+	var req *http.Request
+	for {
+		var authToken string
+		if targetUrl, authToken, err = c.getUrlAndAuthToken(targetUrl, p.OnReAuth); err != nil {
+			return //authentication failure
+		}
+		var URL *url.URL
+		URL, err = url.Parse(targetUrl)
+		if err != nil {
+			return
+		}
+		if p.Container != "" {
+			URL.Path += "/" + p.Container
+			if p.ObjectName != "" {
+				URL.Path += "/" + p.ObjectName
+			}
+		}
+		if p.Parameters != nil {
+			URL.RawQuery = p.Parameters.Encode()
+		}
+		timer := time.NewTimer(c.ConnectTimeout)
+		defer timer.Stop()
+		reader := p.Body
+		if reader != nil {
+			reader = newWatchdogReader(reader, c.Timeout, timer)
+		}
+		req, err = http.NewRequest(p.Operation, URL.String(), reader)
+		if err != nil {
+			return
+		}
+		if p.Headers != nil {
+			for k, v := range p.Headers {
+				// Set ContentLength in req if the user passed it in in the headers
+				if k == "Content-Length" {
+					contentLength, err := strconv.ParseInt(v, 10, 64)
+					if err != nil {
+						return nil, nil, fmt.Errorf("Invalid %q header %q: %v", k, v, err)
+					}
+					req.ContentLength = contentLength
+				} else {
+					req.Header.Add(k, v)
+				}
+			}
+		}
+		req.Header.Add("User-Agent", c.UserAgent)
+		req.Header.Add("X-Auth-Token", authToken)
+		resp, err = c.doTimeoutRequest(timer, req)
+		if err != nil {
+			if (p.Operation == "HEAD" || p.Operation == "GET") && retries > 0 {
+				retries--
+				continue
+			}
+			return nil, nil, err
+		}
+		// Check to see if token has expired
+		if resp.StatusCode == 401 && retries > 0 {
+			drainAndClose(resp.Body, nil)
+			c.UnAuthenticate()
+			retries--
+		} else {
+			break
+		}
+	}
+
+	if err = c.parseHeaders(resp, p.ErrorMap); err != nil {
+		return nil, nil, err
+	}
+	headers = readHeaders(resp)
+	if p.NoResponse {
+		var err error
+		drainAndClose(resp.Body, &err)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		// Cancel the request on timeout
+		cancel := func() {
+			cancelRequest(c.Transport, req)
+		}
+		// Wrap resp.Body to make it obey an idle timeout
+		resp.Body = newTimeoutReader(resp.Body, c.Timeout, cancel)
+	}
+	return
+}
+
+// storage runs a remote command on a the storage url, returns a
+// response, headers and possible error.
+//
+// operation is GET, HEAD etc
+// container is the name of a container
+// Any other parameters (if not None) are added to the storage url
+//
+// Returns a response or an error.  If response is returned then
+// resp.Body.Close() must be called on it, unless noResponse is set in
+// which case the body will be closed in this function
+//
+// This will Authenticate if necessary, and re-authenticate if it
+// receives a 401 error which means the token has expired
+func (c *Connection) storage(p RequestOpts) (resp *http.Response, headers Headers, err error) {
+	p.OnReAuth = func() (string, error) {
+		return c.StorageUrl, nil
+	}
+	c.authLock.Lock()
+	url := c.StorageUrl
+	c.authLock.Unlock()
+	return c.Call(url, p)
+}
+
+// readLines reads the response into an array of strings.
+//
+// Closes the response when done
+func readLines(resp *http.Response) (lines []string, err error) {
+	defer drainAndClose(resp.Body, &err)
+	reader := bufio.NewReader(resp.Body)
+	buffer := bytes.NewBuffer(make([]byte, 0, 128))
+	var part []byte
+	var prefix bool
+	for {
+		if part, prefix, err = reader.ReadLine(); err != nil {
+			break
+		}
+		buffer.Write(part)
+		if !prefix {
+			lines = append(lines, buffer.String())
+			buffer.Reset()
+		}
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	return
+}
+
+// readJson reads the response into the json type passed in
+//
+// Closes the response when done
+func readJson(resp *http.Response, result interface{}) (err error) {
+	defer drainAndClose(resp.Body, &err)
+	decoder := json.NewDecoder(resp.Body)
+	return decoder.Decode(result)
+}
+
+/* ------------------------------------------------------------ */
+
+// ContainersOpts is options for Containers() and ContainerNames()
+type ContainersOpts struct {
+	Limit     int     // For an integer value n, limits the number of results to at most n values.
+	Prefix    string  // Given a string value x, return container names matching the specified prefix.
+	Marker    string  // Given a string value x, return container names greater in value than the specified marker.
+	EndMarker string  // Given a string value x, return container names less in value than the specified marker.
+	Headers   Headers // Any additional HTTP headers - can be nil
+}
+
+// parse the ContainerOpts
+func (opts *ContainersOpts) parse() (url.Values, Headers) {
+	v := url.Values{}
+	var h Headers
+	if opts != nil {
+		if opts.Limit > 0 {
+			v.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Prefix != "" {
+			v.Set("prefix", opts.Prefix)
+		}
+		if opts.Marker != "" {
+			v.Set("marker", opts.Marker)
+		}
+		if opts.EndMarker != "" {
+			v.Set("end_marker", opts.EndMarker)
+		}
+		h = opts.Headers
+	}
+	return v, h
+}
+
+// ContainerNames returns a slice of names of containers in this account.
+func (c *Connection) ContainerNames(opts *ContainersOpts) ([]string, error) {
+	v, h := opts.parse()
+	resp, _, err := c.storage(RequestOpts{
+		Operation:  "GET",
+		Parameters: v,
+		ErrorMap:   ContainerErrorMap,
+		Headers:    h,
+	})
+	if err != nil {
+		return nil, err
+	}
+	lines, err := readLines(resp)
+	return lines, err
+}
+
+// Container contains information about a container
+type Container struct {
+	Name  string // Name of the container
+	Count int64  // Number of objects in the container
+	Bytes int64  // Total number of bytes used in the container
+}
+
+// Containers returns a slice of structures with full information as
+// described in Container.
+func (c *Connection) Containers(opts *ContainersOpts) ([]Container, error) {
+	v, h := opts.parse()
+	v.Set("format", "json")
+	resp, _, err := c.storage(RequestOpts{
+		Operation:  "GET",
+		Parameters: v,
+		ErrorMap:   ContainerErrorMap,
+		Headers:    h,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var containers []Container
+	err = readJson(resp, &containers)
+	return containers, err
+}
+
+// containersAllOpts makes a copy of opts if set or makes a new one and
+// overrides Limit and Marker
+func containersAllOpts(opts *ContainersOpts) *ContainersOpts {
+	var newOpts ContainersOpts
+	if opts != nil {
+		newOpts = *opts
+	}
+	if newOpts.Limit == 0 {
+		newOpts.Limit = allContainersLimit
+	}
+	newOpts.Marker = ""
+	return &newOpts
+}
+
+// ContainersAll is like Containers but it returns all the Containers
+//
+// It calls Containers multiple times using the Marker parameter
+//
+// It has a default Limit parameter but you may pass in your own
+func (c *Connection) ContainersAll(opts *ContainersOpts) ([]Container, error) {
+	opts = containersAllOpts(opts)
+	containers := make([]Container, 0)
+	for {
+		newContainers, err := c.Containers(opts)
+		if err != nil {
+			return nil, err
+		}
+		containers = append(containers, newContainers...)
+		if len(newContainers) < opts.Limit {
+			break
+		}
+		opts.Marker = newContainers[len(newContainers)-1].Name
+	}
+	return containers, nil
+}
+
+// ContainerNamesAll is like ContainerNamess but it returns all the Containers
+//
+// It calls ContainerNames multiple times using the Marker parameter
+//
+// It has a default Limit parameter but you may pass in your own
+func (c *Connection) ContainerNamesAll(opts *ContainersOpts) ([]string, error) {
+	opts = containersAllOpts(opts)
+	containers := make([]string, 0)
+	for {
+		newContainers, err := c.ContainerNames(opts)
+		if err != nil {
+			return nil, err
+		}
+		containers = append(containers, newContainers...)
+		if len(newContainers) < opts.Limit {
+			break
+		}
+		opts.Marker = newContainers[len(newContainers)-1]
+	}
+	return containers, nil
+}
+
+/* ------------------------------------------------------------ */
+
+// ObjectOpts is options for Objects() and ObjectNames()
+type ObjectsOpts struct {
+	Limit     int     // For an integer value n, limits the number of results to at most n values.
+	Marker    string  // Given a string value x, return object names greater in value than the  specified marker.
+	EndMarker string  // Given a string value x, return object names less in value than the specified marker
+	Prefix    string  // For a string value x, causes the results to be limited to object names beginning with the substring x.
+	Path      string  // For a string value x, return the object names nested in the pseudo path
+	Delimiter rune    // For a character c, return all the object names nested in the container
+	Headers   Headers // Any additional HTTP headers - can be nil
+}
+
+// parse reads values out of ObjectsOpts
+func (opts *ObjectsOpts) parse() (url.Values, Headers) {
+	v := url.Values{}
+	var h Headers
+	if opts != nil {
+		if opts.Limit > 0 {
+			v.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Marker != "" {
+			v.Set("marker", opts.Marker)
+		}
+		if opts.EndMarker != "" {
+			v.Set("end_marker", opts.EndMarker)
+		}
+		if opts.Prefix != "" {
+			v.Set("prefix", opts.Prefix)
+		}
+		if opts.Path != "" {
+			v.Set("path", opts.Path)
+		}
+		if opts.Delimiter != 0 {
+			v.Set("delimiter", string(opts.Delimiter))
+		}
+		h = opts.Headers
+	}
+	return v, h
+}
+
+// ObjectNames returns a slice of names of objects in a given container.
+func (c *Connection) ObjectNames(container string, opts *ObjectsOpts) ([]string, error) {
+	v, h := opts.parse()
+	resp, _, err := c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "GET",
+		Parameters: v,
+		ErrorMap:   ContainerErrorMap,
+		Headers:    h,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return readLines(resp)
+}
+
+// Object contains information about an object
+type Object struct {
+	Name               string     `json:"name"`          // object name
+	ContentType        string     `json:"content_type"`  // eg application/directory
+	Bytes              int64      `json:"bytes"`         // size in bytes
+	ServerLastModified string     `json:"last_modified"` // Last modified time, eg '2011-06-30T08:20:47.736680' as a string supplied by the server
+	LastModified       time.Time  // Last modified time converted to a time.Time
+	Hash               string     `json:"hash"` // MD5 hash, eg "d41d8cd98f00b204e9800998ecf8427e"
+	PseudoDirectory    bool       // Set when using delimiter to show that this directory object does not really exist
+	SubDir             string     `json:"subdir"` // returned only when using delimiter to mark "pseudo directories"
+	ObjectType         ObjectType // type of this object
+}
+
+// Objects returns a slice of Object with information about each
+// object in the container.
+//
+// If Delimiter is set in the opts then PseudoDirectory may be set,
+// with ContentType 'application/directory'.  These are not real
+// objects but represent directories of objects which haven't had an
+// object created for them.
+func (c *Connection) Objects(container string, opts *ObjectsOpts) ([]Object, error) {
+	v, h := opts.parse()
+	v.Set("format", "json")
+	resp, _, err := c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "GET",
+		Parameters: v,
+		ErrorMap:   ContainerErrorMap,
+		Headers:    h,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var objects []Object
+	err = readJson(resp, &objects)
+	// Convert Pseudo directories and dates
+	for i := range objects {
+		object := &objects[i]
+		if object.SubDir != "" {
+			object.Name = object.SubDir
+			object.PseudoDirectory = true
+			object.ContentType = "application/directory"
+		}
+		if object.ServerLastModified != "" {
+			// 2012-11-11T14:49:47.887250
+			//
+			// Remove fractional seconds if present. This
+			// then keeps it consistent with Object
+			// which can only return timestamps accurate
+			// to 1 second
+			//
+			// The TimeFormat will parse fractional
+			// seconds if desired though
+			datetime := strings.SplitN(object.ServerLastModified, ".", 2)[0]
+			object.LastModified, err = time.Parse(TimeFormat, datetime)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return objects, err
+}
+
+// objectsAllOpts makes a copy of opts if set or makes a new one and
+// overrides Limit and Marker
+func objectsAllOpts(opts *ObjectsOpts, Limit int) *ObjectsOpts {
+	var newOpts ObjectsOpts
+	if opts != nil {
+		newOpts = *opts
+	}
+	if newOpts.Limit == 0 {
+		newOpts.Limit = Limit
+	}
+	newOpts.Marker = ""
+	return &newOpts
+}
+
+// A closure defined by the caller to iterate through all objects
+//
+// Call Objects or ObjectNames from here with the *ObjectOpts passed in
+//
+// Do whatever is required with the results then return them
+type ObjectsWalkFn func(*ObjectsOpts) (interface{}, error)
+
+// ObjectsWalk is uses to iterate through all the objects in chunks as
+// returned by Objects or ObjectNames using the Marker and Limit
+// parameters in the ObjectsOpts.
+//
+// Pass in a closure `walkFn` which calls Objects or ObjectNames with
+// the *ObjectsOpts passed to it and does something with the results.
+//
+// Errors will be returned from this function
+//
+// It has a default Limit parameter but you may pass in your own
+func (c *Connection) ObjectsWalk(container string, opts *ObjectsOpts, walkFn ObjectsWalkFn) error {
+	opts = objectsAllOpts(opts, allObjectsChanLimit)
+	for {
+		objects, err := walkFn(opts)
+		if err != nil {
+			return err
+		}
+		var n int
+		var last string
+		switch objects := objects.(type) {
+		case []string:
+			n = len(objects)
+			if n > 0 {
+				last = objects[len(objects)-1]
+			}
+		case []Object:
+			n = len(objects)
+			if n > 0 {
+				last = objects[len(objects)-1].Name
+			}
+		default:
+			panic("Unknown type returned to ObjectsWalk")
+		}
+		if n < opts.Limit {
+			break
+		}
+		opts.Marker = last
+	}
+	return nil
+}
+
+// ObjectsAll is like Objects but it returns an unlimited number of Objects in a slice
+//
+// It calls Objects multiple times using the Marker parameter
+func (c *Connection) ObjectsAll(container string, opts *ObjectsOpts) ([]Object, error) {
+	objects := make([]Object, 0)
+	err := c.ObjectsWalk(container, opts, func(opts *ObjectsOpts) (interface{}, error) {
+		newObjects, err := c.Objects(container, opts)
+		if err == nil {
+			objects = append(objects, newObjects...)
+		}
+		return newObjects, err
+	})
+	return objects, err
+}
+
+// ObjectNamesAll is like ObjectNames but it returns all the Objects
+//
+// It calls ObjectNames multiple times using the Marker parameter
+//
+// It has a default Limit parameter but you may pass in your own
+func (c *Connection) ObjectNamesAll(container string, opts *ObjectsOpts) ([]string, error) {
+	objects := make([]string, 0)
+	err := c.ObjectsWalk(container, opts, func(opts *ObjectsOpts) (interface{}, error) {
+		newObjects, err := c.ObjectNames(container, opts)
+		if err == nil {
+			objects = append(objects, newObjects...)
+		}
+		return newObjects, err
+	})
+	return objects, err
+}
+
+// Account contains information about this account.
+type Account struct {
+	BytesUsed  int64 // total number of bytes used
+	Containers int64 // total number of containers
+	Objects    int64 // total number of objects
+}
+
+// getInt64FromHeader is a helper function to decode int64 from header.
+func getInt64FromHeader(resp *http.Response, header string) (result int64, err error) {
+	value := resp.Header.Get(header)
+	result, err = strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		err = newErrorf(0, "Bad Header '%s': '%s': %s", header, value, err)
+	}
+	return
+}
+
+// Account returns info about the account in an Account struct.
+func (c *Connection) Account() (info Account, headers Headers, err error) {
+	var resp *http.Response
+	resp, headers, err = c.storage(RequestOpts{
+		Operation:  "HEAD",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+	})
+	if err != nil {
+		return
+	}
+	// Parse the headers into a dict
+	//
+	//    {'Accept-Ranges': 'bytes',
+	//     'Content-Length': '0',
+	//     'Date': 'Tue, 05 Jul 2011 16:37:06 GMT',
+	//     'X-Account-Bytes-Used': '316598182',
+	//     'X-Account-Container-Count': '4',
+	//     'X-Account-Object-Count': '1433'}
+	if info.BytesUsed, err = getInt64FromHeader(resp, "X-Account-Bytes-Used"); err != nil {
+		return
+	}
+	if info.Containers, err = getInt64FromHeader(resp, "X-Account-Container-Count"); err != nil {
+		return
+	}
+	if info.Objects, err = getInt64FromHeader(resp, "X-Account-Object-Count"); err != nil {
+		return
+	}
+	return
+}
+
+// AccountUpdate adds, replaces or remove account metadata.
+//
+// Add or update keys by mentioning them in the Headers.
+//
+// Remove keys by setting them to an empty string.
+func (c *Connection) AccountUpdate(h Headers) error {
+	_, _, err := c.storage(RequestOpts{
+		Operation:  "POST",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+		Headers:    h,
+	})
+	return err
+}
+
+// ContainerCreate creates a container.
+//
+// If you don't want to add Headers just pass in nil
+//
+// No error is returned if it already exists but the metadata if any will be updated.
+func (c *Connection) ContainerCreate(container string, h Headers) error {
+	_, _, err := c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "PUT",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+		Headers:    h,
+	})
+	return err
+}
+
+// ContainerDelete deletes a container.
+//
+// May return ContainerDoesNotExist or ContainerNotEmpty
+func (c *Connection) ContainerDelete(container string) error {
+	_, _, err := c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "DELETE",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+	})
+	return err
+}
+
+// Container returns info about a single container including any
+// metadata in the headers.
+func (c *Connection) Container(container string) (info Container, headers Headers, err error) {
+	var resp *http.Response
+	resp, headers, err = c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "HEAD",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+	})
+	if err != nil {
+		return
+	}
+	// Parse the headers into the struct
+	info.Name = container
+	if info.Bytes, err = getInt64FromHeader(resp, "X-Container-Bytes-Used"); err != nil {
+		return
+	}
+	if info.Count, err = getInt64FromHeader(resp, "X-Container-Object-Count"); err != nil {
+		return
+	}
+	return
+}
+
+// ContainerUpdate adds, replaces or removes container metadata.
+//
+// Add or update keys by mentioning them in the Metadata.
+//
+// Remove keys by setting them to an empty string.
+//
+// Container metadata can only be read with Container() not with Containers().
+func (c *Connection) ContainerUpdate(container string, h Headers) error {
+	_, _, err := c.storage(RequestOpts{
+		Container:  container,
+		Operation:  "POST",
+		ErrorMap:   ContainerErrorMap,
+		NoResponse: true,
+		Headers:    h,
+	})
+	return err
+}
+
+// ------------------------------------------------------------
+
+// ObjectCreateFile represents a swift object open for writing
+type ObjectCreateFile struct {
+	checkHash  bool           // whether we are checking the hash
+	pipeReader *io.PipeReader // pipe for the caller to use
+	pipeWriter *io.PipeWriter
+	hash       hash.Hash      // hash being build up as we go along
+	done       chan struct{}  // signals when the upload has finished
+	resp       *http.Response // valid when done has signalled
+	err        error          // ditto
+	headers    Headers        // ditto
+}
+
+// Write bytes to the object - see io.Writer
+func (file *ObjectCreateFile) Write(p []byte) (n int, err error) {
+	n, err = file.pipeWriter.Write(p)
+	if err == io.ErrClosedPipe {
+		if file.err != nil {
+			return 0, file.err
+		}
+		return 0, newError(500, "Write on closed file")
+	}
+	if err == nil && file.checkHash {
+		_, _ = file.hash.Write(p)
+	}
+	return
+}
+
+// Close the object and checks the md5sum if it was required.
+//
+// Also returns any other errors from the server (eg container not
+// found) so it is very important to check the errors on this method.
+func (file *ObjectCreateFile) Close() error {
+	// Close the body
+	err := file.pipeWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	// Wait for the HTTP operation to complete
+	<-file.done
+
+	// Check errors
+	if file.err != nil {
+		return file.err
+	}
+	if file.checkHash {
+		receivedMd5 := strings.ToLower(file.headers["Etag"])
+		calculatedMd5 := fmt.Sprintf("%x", file.hash.Sum(nil))
+		if receivedMd5 != calculatedMd5 {
+			return ObjectCorrupted
+		}
+	}
+	return nil
+}
+
+// Headers returns the response headers from the created object if the upload
+// has been completed. The Close() method must be called on an ObjectCreateFile
+// before this method.
+func (file *ObjectCreateFile) Headers() (Headers, error) {
+	// error out if upload is not complete.
+	select {
+	case <-file.done:
+	default:
+		return nil, fmt.Errorf("Cannot get metadata, object upload failed or has not yet completed.")
+	}
+	return file.headers, nil
+}
+
+// Check it satisfies the interface
+var _ io.WriteCloser = &ObjectCreateFile{}
+
+// objectPutHeaders create a set of headers for a PUT
+//
+// It guesses the contentType from the objectName if it isn't set
+//
+// checkHash may be changed
+func objectPutHeaders(objectName string, checkHash *bool, Hash string, contentType string, h Headers) Headers {
+	if contentType == "" {
+		contentType = mime.TypeByExtension(path.Ext(objectName))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+	}
+	// Meta stuff
+	extraHeaders := map[string]string{
+		"Content-Type": contentType,
+	}
+	for key, value := range h {
+		extraHeaders[key] = value
+	}
+	if Hash != "" {
+		extraHeaders["Etag"] = Hash
+		*checkHash = false // the server will do it
+	}
+	return extraHeaders
+}
+
+// ObjectCreate creates or updates the object in the container.  It
+// returns an io.WriteCloser you should write the contents to.  You
+// MUST call Close() on it and you MUST check the error return from
+// Close().
+//
+// If checkHash is True then it will calculate the MD5 Hash of the
+// file as it is being uploaded and check it against that returned
+// from the server.  If it is wrong then it will return
+// ObjectCorrupted on Close()
+//
+// If you know the MD5 hash of the object ahead of time then set the
+// Hash parameter and it will be sent to the server (as an Etag
+// header) and the server will check the MD5 itself after the upload,
+// and this will return ObjectCorrupted on Close() if it is incorrect.
+//
+// If you don't want any error protection (not recommended) then set
+// checkHash to false and Hash to "".
+//
+// If contentType is set it will be used, otherwise one will be
+// guessed from objectName using mime.TypeByExtension
+func (c *Connection) ObjectCreate(container string, objectName string, checkHash bool, Hash string, contentType string, h Headers) (file *ObjectCreateFile, err error) {
+	extraHeaders := objectPutHeaders(objectName, &checkHash, Hash, contentType, h)
+	pipeReader, pipeWriter := io.Pipe()
+	file = &ObjectCreateFile{
+		hash:       md5.New(),
+		checkHash:  checkHash,
+		pipeReader: pipeReader,
+		pipeWriter: pipeWriter,
+		done:       make(chan struct{}),
+	}
+	// Run the PUT in the background piping it data
+	go func() {
+		opts := RequestOpts{
+			Container:  container,
+			ObjectName: objectName,
+			Operation:  "PUT",
+			Headers:    extraHeaders,
+			Body:       pipeReader,
+			NoResponse: true,
+			ErrorMap:   objectErrorMap,
+		}
+		file.resp, file.headers, file.err = c.storage(opts)
+		// Signal finished
+		pipeReader.Close()
+		close(file.done)
+	}()
+	return
+}
+
+func (c *Connection) objectPut(container string, objectName string, contents io.Reader, checkHash bool, Hash string, contentType string, h Headers, parameters url.Values) (headers Headers, err error) {
+	extraHeaders := objectPutHeaders(objectName, &checkHash, Hash, contentType, h)
+	hash := md5.New()
+	var body io.Reader = contents
+	if checkHash {
+		body = io.TeeReader(contents, hash)
+	}
+	_, headers, err = c.storage(RequestOpts{
+		Container:  container,
+		ObjectName: objectName,
+		Operation:  "PUT",
+		Headers:    extraHeaders,
+		Body:       body,
+		NoResponse: true,
+		ErrorMap:   objectErrorMap,
+		Parameters: parameters,
+	})
+	if err != nil {
+		return
+	}
+	if checkHash {
+		receivedMd5 := strings.ToLower(headers["Etag"])
+		calculatedMd5 := fmt.Sprintf("%x", hash.Sum(nil))
+		if receivedMd5 != calculatedMd5 {
+			err = ObjectCorrupted
+			return
+		}
+	}
+	return
+}
+
+// ObjectPut creates or updates the path in the container from
+// contents.  contents should be an open io.Reader which will have all
+// its contents read.
+//
+// This is a low level interface.
+//
+// If checkHash is True then it will calculate the MD5 Hash of the
+// file as it is being uploaded and check it against that returned
+// from the server.  If it is wrong then it will return
+// ObjectCorrupted.
+//
+// If you know the MD5 hash of the object ahead of time then set the
+// Hash parameter and it will be sent to the server (as an Etag
+// header) and the server will check the MD5 itself after the upload,
+// and this will return ObjectCorrupted if it is incorrect.
+//
+// If you don't want any error protection (not recommended) then set
+// checkHash to false and Hash to "".
+//
+// If contentType is set it will be used, otherwise one will be
+// guessed from objectName using mime.TypeByExtension
+func (c *Connection) ObjectPut(container string, objectName string, contents io.Reader, checkHash bool, Hash string, contentType string, h Headers) (headers Headers, err error) {
+	return c.objectPut(container, objectName, contents, checkHash, Hash, contentType, h, nil)
+}
+
+// ObjectPutBytes creates an object from a []byte in a container.
+//
+// This is a simplified interface which checks the MD5.
+func (c *Connection) ObjectPutBytes(container string, objectName string, contents []byte, contentType string) (err error) {
+	buf := bytes.NewBuffer(contents)
+	h := Headers{"Content-Length": strconv.Itoa(len(contents))}
+	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, h)
+	return
+}
+
+// ObjectPutString creates an object from a string in a container.
+//
+// This is a simplified interface which checks the MD5
+func (c *Connection) ObjectPutString(container string, objectName string, contents string, contentType string) (err error) {
+	buf := strings.NewReader(contents)
+	h := Headers{"Content-Length": strconv.Itoa(len(contents))}
+	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, h)
+	return
+}
+
+// ObjectOpenFile represents a swift object open for reading
+type ObjectOpenFile struct {
+	connection *Connection    // stored copy of Connection used in Open
+	container  string         // stored copy of container used in Open
+	objectName string         // stored copy of objectName used in Open
+	headers    Headers        // stored copy of headers used in Open
+	resp       *http.Response // http connection
+	body       io.Reader      // read data from this
+	checkHash  bool           // true if checking MD5
+	hash       hash.Hash      // currently accumulating MD5
+	bytes      int64          // number of bytes read on this connection
+	eof        bool           // whether we have read end of file
+	pos        int64          // current position when reading
+	lengthOk   bool           // whether length is valid
+	length     int64          // length of the object if read
+	seeked     bool           // whether we have seeked this file or not
+	overSeeked bool           // set if we have seeked to the end or beyond
+}
+
+// Read bytes from the object - see io.Reader
+func (file *ObjectOpenFile) Read(p []byte) (n int, err error) {
+	if file.overSeeked {
+		return 0, io.EOF
+	}
+	n, err = file.body.Read(p)
+	file.bytes += int64(n)
+	file.pos += int64(n)
+	if err == io.EOF {
+		file.eof = true
+	}
+	return
+}
+
+// Seek sets the offset for the next Read to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1
+// means relative to the current offset, and 2 means relative to the
+// end. Seek returns the new offset and an Error, if any.
+//
+// Seek uses HTTP Range headers which, if the file pointer is moved,
+// will involve reopening the HTTP connection.
+//
+// Note that you can't seek to the end of a file or beyond; HTTP Range
+// requests don't support the file pointer being outside the data,
+// unlike os.File
+//
+// Seek(0, 1) will return the current file pointer.
+func (file *ObjectOpenFile) Seek(offset int64, whence int) (newPos int64, err error) {
+	file.overSeeked = false
+	switch whence {
+	case 0: // relative to start
+		newPos = offset
+	case 1: // relative to current
+		newPos = file.pos + offset
+	case 2: // relative to end
+		if !file.lengthOk {
+			return file.pos, newError(0, "Length of file unknown so can't seek from end")
+		}
+		newPos = file.length + offset
+		if offset >= 0 {
+			file.overSeeked = true
+			return
+		}
+	default:
+		panic("Unknown whence in ObjectOpenFile.Seek")
+	}
+	// If at correct position (quite likely), do nothing
+	if newPos == file.pos {
+		return
+	}
+	// Close the file...
+	file.seeked = true
+	err = file.Close()
+	if err != nil {
+		return
+	}
+	// ...and re-open with a Range header
+	if file.headers == nil {
+		file.headers = Headers{}
+	}
+	if newPos > 0 {
+		file.headers["Range"] = fmt.Sprintf("bytes=%d-", newPos)
+	} else {
+		delete(file.headers, "Range")
+	}
+	newFile, _, err := file.connection.ObjectOpen(file.container, file.objectName, false, file.headers)
+	if err != nil {
+		return
+	}
+	// Update the file
+	file.resp = newFile.resp
+	file.body = newFile.body
+	file.checkHash = false
+	file.pos = newPos
+	return
+}
+
+// Length gets the objects content length either from a cached copy or
+// from the server.
+func (file *ObjectOpenFile) Length() (int64, error) {
+	if !file.lengthOk {
+		info, _, err := file.connection.Object(file.container, file.objectName)
+		file.length = info.Bytes
+		file.lengthOk = (err == nil)
+		return file.length, err
+	}
+	return file.length, nil
+}
+
+// Close the object and checks the length and md5sum if it was
+// required and all the object was read
+func (file *ObjectOpenFile) Close() (err error) {
+	// Close the body at the end
+	defer checkClose(file.resp.Body, &err)
+
+	// If not end of file or seeked then can't check anything
+	if !file.eof || file.seeked {
+		return
+	}
+
+	// Check the MD5 sum if requested
+	if file.checkHash {
+		receivedMd5 := strings.ToLower(file.resp.Header.Get("Etag"))
+		calculatedMd5 := fmt.Sprintf("%x", file.hash.Sum(nil))
+		if receivedMd5 != calculatedMd5 {
+			err = ObjectCorrupted
+			return
+		}
+	}
+
+	// Check to see we read the correct number of bytes
+	if file.lengthOk && file.length != file.bytes {
+		err = ObjectCorrupted
+		return
+	}
+	return
+}
+
+// Check it satisfies the interfaces
+var _ io.ReadCloser = &ObjectOpenFile{}
+var _ io.Seeker = &ObjectOpenFile{}
+
+func (c *Connection) objectOpenBase(container string, objectName string, checkHash bool, h Headers, parameters url.Values) (file *ObjectOpenFile, headers Headers, err error) {
+	var resp *http.Response
+	opts := RequestOpts{
+		Container:  container,
+		ObjectName: objectName,
+		Operation:  "GET",
+		ErrorMap:   objectErrorMap,
+		Headers:    h,
+		Parameters: parameters,
+	}
+	resp, headers, err = c.storage(opts)
+	if err != nil {
+		return
+	}
+	// Can't check MD5 on an object with X-Object-Manifest or X-Static-Large-Object set
+	if checkHash && headers.IsLargeObject() {
+		// log.Printf("swift: turning off md5 checking on object with manifest %v", objectName)
+		checkHash = false
+	}
+	file = &ObjectOpenFile{
+		connection: c,
+		container:  container,
+		objectName: objectName,
+		headers:    h,
+		resp:       resp,
+		checkHash:  checkHash,
+		body:       resp.Body,
+	}
+	if checkHash {
+		file.hash = md5.New()
+		file.body = io.TeeReader(resp.Body, file.hash)
+	}
+	// Read Content-Length
+	if resp.Header.Get("Content-Length") != "" {
+		file.length, err = getInt64FromHeader(resp, "Content-Length")
+		file.lengthOk = (err == nil)
+	}
+	return
+}
+
+func (c *Connection) objectOpen(container string, objectName string, checkHash bool, h Headers, parameters url.Values) (file *ObjectOpenFile, headers Headers, err error) {
+	err = withLORetry(0, func() (Headers, int64, error) {
+		file, headers, err = c.objectOpenBase(container, objectName, checkHash, h, parameters)
+		if err != nil {
+			return headers, 0, err
+		}
+		return headers, file.length, nil
+	})
+	return
+}
+
+// ObjectOpen returns an ObjectOpenFile for reading the contents of
+// the object.  This satisfies the io.ReadCloser and the io.Seeker
+// interfaces.
+//
+// You must call Close() on contents when finished
+//
+// Returns the headers of the response.
+//
+// If checkHash is true then it will calculate the md5sum of the file
+// as it is being received and check it against that returned from the
+// server.  If it is wrong then it will return ObjectCorrupted. It
+// will also check the length returned. No checking will be done if
+// you don't read all the contents.
+//
+// Note that objects with X-Object-Manifest or X-Static-Large-Object
+// set won't ever have their md5sum's checked as the md5sum reported
+// on the object is actually the md5sum of the md5sums of the
+// parts. This isn't very helpful to detect a corrupted download as
+// the size of the parts aren't known without doing more operations.
+// If you want to ensure integrity of an object with a manifest then
+// you will need to download everything in the manifest separately.
+//
+// headers["Content-Type"] will give the content type if desired.
+func (c *Connection) ObjectOpen(container string, objectName string, checkHash bool, h Headers) (file *ObjectOpenFile, headers Headers, err error) {
+	return c.objectOpen(container, objectName, checkHash, h, nil)
+}
+
+// ObjectGet gets the object into the io.Writer contents.
+//
+// Returns the headers of the response.
+//
+// If checkHash is true then it will calculate the md5sum of the file
+// as it is being received and check it against that returned from the
+// server.  If it is wrong then it will return ObjectCorrupted.
+//
+// headers["Content-Type"] will give the content type if desired.
+func (c *Connection) ObjectGet(container string, objectName string, contents io.Writer, checkHash bool, h Headers) (headers Headers, err error) {
+	file, headers, err := c.ObjectOpen(container, objectName, checkHash, h)
+	if err != nil {
+		return
+	}
+	defer checkClose(file, &err)
+	_, err = io.Copy(contents, file)
+	return
+}
+
+// ObjectGetBytes returns an object as a []byte.
+//
+// This is a simplified interface which checks the MD5
+func (c *Connection) ObjectGetBytes(container string, objectName string) (contents []byte, err error) {
+	var buf bytes.Buffer
+	_, err = c.ObjectGet(container, objectName, &buf, true, nil)
+	contents = buf.Bytes()
+	return
+}
+
+// ObjectGetString returns an object as a string.
+//
+// This is a simplified interface which checks the MD5
+func (c *Connection) ObjectGetString(container string, objectName string) (contents string, err error) {
+	var buf bytes.Buffer
+	_, err = c.ObjectGet(container, objectName, &buf, true, nil)
+	contents = buf.String()
+	return
+}
+
+// ObjectDelete deletes the object.
+//
+// May return ObjectNotFound if the object isn't found
+func (c *Connection) ObjectDelete(container string, objectName string) error {
+	_, _, err := c.storage(RequestOpts{
+		Container:  container,
+		ObjectName: objectName,
+		Operation:  "DELETE",
+		ErrorMap:   objectErrorMap,
+	})
+	return err
+}
+
+// ObjectTempUrl returns a temporary URL for an object
+func (c *Connection) ObjectTempUrl(container string, objectName string, secretKey string, method string, expires time.Time) string {
+	mac := hmac.New(sha1.New, []byte(secretKey))
+	prefix, _ := url.Parse(c.StorageUrl)
+	body := fmt.Sprintf("%s\n%d\n%s/%s/%s", method, expires.Unix(), prefix.Path, container, objectName)
+	mac.Write([]byte(body))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("%s/%s/%s?temp_url_sig=%s&temp_url_expires=%d", c.StorageUrl, container, objectName, sig, expires.Unix())
+}
+
+// parseResponseStatus parses string like "200 OK" and returns Error.
+//
+// For status codes beween 200 and 299, this returns nil.
+func parseResponseStatus(resp string, errorMap errorMap) error {
+	code := 0
+	reason := resp
+	t := strings.SplitN(resp, " ", 2)
+	if len(t) == 2 {
+		ncode, err := strconv.Atoi(t[0])
+		if err == nil {
+			code = ncode
+			reason = t[1]
+		}
+	}
+	if errorMap != nil {
+		if err, ok := errorMap[code]; ok {
+			return err
+		}
+	}
+	if 200 <= code && code <= 299 {
+		return nil
+	}
+	return newError(code, reason)
+}
+
+// BulkDeleteResult stores results of BulkDelete().
+//
+// Individual errors may (or may not) be returned by Errors.
+// Errors is a map whose keys are a full path of where the object was
+// to be deleted, and whose values are Error objects.  A full path of
+// object looks like "/API_VERSION/USER_ACCOUNT/CONTAINER/OBJECT_PATH".
+type BulkDeleteResult struct {
+	NumberNotFound int64            // # of objects not found.
+	NumberDeleted  int64            // # of deleted objects.
+	Errors         map[string]error // Mapping between object name and an error.
+	Headers        Headers          // Response HTTP headers.
+}
+
+func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, err error) {
+	var buffer bytes.Buffer
+	for _, s := range objects {
+		buffer.WriteString(url.QueryEscape(s) + "\n")
+	}
+	resp, headers, err := c.storage(RequestOpts{
+		Operation:  "DELETE",
+		Parameters: url.Values{"bulk-delete": []string{"1"}},
+		Headers: Headers{
+			"Accept":       "application/json",
+			"Content-Type": "text/plain",
+		},
+		ErrorMap: ContainerErrorMap,
+		Body:     &buffer,
+	})
+	if err != nil {
+		return
+	}
+	var jsonResult struct {
+		NotFound int64  `json:"Number Not Found"`
+		Status   string `json:"Response Status"`
+		Errors   [][]string
+		Deleted  int64 `json:"Number Deleted"`
+	}
+	err = readJson(resp, &jsonResult)
+	if err != nil {
+		return
+	}
+
+	err = parseResponseStatus(jsonResult.Status, objectErrorMap)
+	result.NumberNotFound = jsonResult.NotFound
+	result.NumberDeleted = jsonResult.Deleted
+	result.Headers = headers
+	el := make(map[string]error, len(jsonResult.Errors))
+	for _, t := range jsonResult.Errors {
+		if len(t) != 2 {
+			continue
+		}
+		el[t[0]] = parseResponseStatus(t[1], objectErrorMap)
+	}
+	result.Errors = el
+	return
+}
+
+// BulkDelete deletes multiple objectNames from container in one operation.
+//
+// Some servers may not accept bulk-delete requests since bulk-delete is
+// an optional feature of swift - these will return the Forbidden error.
+//
+// See also:
+// * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-bulk-delete.html
+// * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Bulk_Delete-d1e2338.html
+func (c *Connection) BulkDelete(container string, objectNames []string) (result BulkDeleteResult, err error) {
+	fullPaths := make([]string, len(objectNames))
+	for i, name := range objectNames {
+		fullPaths[i] = fmt.Sprintf("/%s/%s", container, name)
+	}
+	return c.doBulkDelete(fullPaths)
+}
+
+// BulkUploadResult stores results of BulkUpload().
+//
+// Individual errors may (or may not) be returned by Errors.
+// Errors is a map whose keys are a full path of where an object was
+// to be created, and whose values are Error objects.  A full path of
+// object looks like "/API_VERSION/USER_ACCOUNT/CONTAINER/OBJECT_PATH".
+type BulkUploadResult struct {
+	NumberCreated int64            // # of created objects.
+	Errors        map[string]error // Mapping between object name and an error.
+	Headers       Headers          // Response HTTP headers.
+}
+
+// BulkUpload uploads multiple files in one operation.
+//
+// uploadPath can be empty, a container name, or a pseudo-directory
+// within a container.  If uploadPath is empty, new containers may be
+// automatically created.
+//
+// Files are read from dataStream.  The format of the stream is specified
+// by the format parameter.  Available formats are:
+// * UploadTar       - Plain tar stream.
+// * UploadTarGzip   - Gzip compressed tar stream.
+// * UploadTarBzip2  - Bzip2 compressed tar stream.
+//
+// Some servers may not accept bulk-upload requests since bulk-upload is
+// an optional feature of swift - these will return the Forbidden error.
+//
+// See also:
+// * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-extract-archive.html
+// * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Extract_Archive-d1e2338.html
+func (c *Connection) BulkUpload(uploadPath string, dataStream io.Reader, format string, h Headers) (result BulkUploadResult, err error) {
+	extraHeaders := Headers{"Accept": "application/json"}
+	for key, value := range h {
+		extraHeaders[key] = value
+	}
+	// The following code abuses Container parameter intentionally.
+	// The best fix might be to rename Container to UploadPath.
+	resp, headers, err := c.storage(RequestOpts{
+		Container:  uploadPath,
+		Operation:  "PUT",
+		Parameters: url.Values{"extract-archive": []string{format}},
+		Headers:    extraHeaders,
+		ErrorMap:   ContainerErrorMap,
+		Body:       dataStream,
+	})
+	if err != nil {
+		return
+	}
+	// Detect old servers which don't support this feature
+	if headers["Content-Type"] != "application/json" {
+		err = Forbidden
+		return
+	}
+	var jsonResult struct {
+		Created int64  `json:"Number Files Created"`
+		Status  string `json:"Response Status"`
+		Errors  [][]string
+	}
+	err = readJson(resp, &jsonResult)
+	if err != nil {
+		return
+	}
+
+	err = parseResponseStatus(jsonResult.Status, objectErrorMap)
+	result.NumberCreated = jsonResult.Created
+	result.Headers = headers
+	el := make(map[string]error, len(jsonResult.Errors))
+	for _, t := range jsonResult.Errors {
+		if len(t) != 2 {
+			continue
+		}
+		el[t[0]] = parseResponseStatus(t[1], objectErrorMap)
+	}
+	result.Errors = el
+	return
+}
+
+// Object returns info about a single object including any metadata in the header.
+//
+// May return ObjectNotFound.
+//
+// Use headers.ObjectMetadata() to read the metadata in the Headers.
+func (c *Connection) Object(container string, objectName string) (info Object, headers Headers, err error) {
+	err = withLORetry(0, func() (Headers, int64, error) {
+		info, headers, err = c.objectBase(container, objectName)
+		if err != nil {
+			return headers, 0, err
+		}
+		return headers, info.Bytes, nil
+	})
+	return
+}
+
+func (c *Connection) objectBase(container string, objectName string) (info Object, headers Headers, err error) {
+	var resp *http.Response
+	resp, headers, err = c.storage(RequestOpts{
+		Container:  container,
+		ObjectName: objectName,
+		Operation:  "HEAD",
+		ErrorMap:   objectErrorMap,
+		NoResponse: true,
+	})
+	if err != nil {
+		return
+	}
+	// Parse the headers into the struct
+	// HTTP/1.1 200 OK
+	// Date: Thu, 07 Jun 2010 20:59:39 GMT
+	// Server: Apache
+	// Last-Modified: Fri, 12 Jun 2010 13:40:18 GMT
+	// ETag: 8a964ee2a5e88be344f36c22562a6486
+	// Content-Length: 512000
+	// Content-Type: text/plain; charset=UTF-8
+	// X-Object-Meta-Meat: Bacon
+	// X-Object-Meta-Fruit: Bacon
+	// X-Object-Meta-Veggie: Bacon
+	// X-Object-Meta-Dairy: Bacon
+	info.Name = objectName
+	info.ContentType = resp.Header.Get("Content-Type")
+	if resp.Header.Get("Content-Length") != "" {
+		if info.Bytes, err = getInt64FromHeader(resp, "Content-Length"); err != nil {
+			return
+		}
+	}
+	// Currently ceph doesn't return a Last-Modified header for DLO manifests without any segments
+	// See ceph http://tracker.ceph.com/issues/15812
+	if resp.Header.Get("Last-Modified") != "" {
+		info.ServerLastModified = resp.Header.Get("Last-Modified")
+		if info.LastModified, err = time.Parse(http.TimeFormat, info.ServerLastModified); err != nil {
+			return
+		}
+	}
+
+	info.Hash = resp.Header.Get("Etag")
+	if resp.Header.Get("X-Object-Manifest") != "" {
+		info.ObjectType = DynamicLargeObjectType
+	} else if resp.Header.Get("X-Static-Large-Object") != "" {
+		info.ObjectType = StaticLargeObjectType
+	}
+
+	return
+}
+
+// ObjectUpdate adds, replaces or removes object metadata.
+//
+// Add or Update keys by mentioning them in the Metadata.  Use
+// Metadata.ObjectHeaders and Headers.ObjectMetadata to convert your
+// Metadata to and from normal HTTP headers.
+//
+// This removes all metadata previously added to the object and
+// replaces it with that passed in so to delete keys, just don't
+// mention them the headers you pass in.
+//
+// Object metadata can only be read with Object() not with Objects().
+//
+// This can also be used to set headers not already assigned such as
+// X-Delete-At or X-Delete-After for expiring objects.
+//
+// You cannot use this to change any of the object's other headers
+// such as Content-Type, ETag, etc.
+//
+// Refer to copying an object when you need to update metadata or
+// other headers such as Content-Type or CORS headers.
+//
+// May return ObjectNotFound.
+func (c *Connection) ObjectUpdate(container string, objectName string, h Headers) error {
+	_, _, err := c.storage(RequestOpts{
+		Container:  container,
+		ObjectName: objectName,
+		Operation:  "POST",
+		ErrorMap:   objectErrorMap,
+		NoResponse: true,
+		Headers:    h,
+	})
+	return err
+}
+
+// ObjectCopy does a server side copy of an object to a new position
+//
+// All metadata is preserved.  If metadata is set in the headers then
+// it overrides the old metadata on the copied object.
+//
+// The destination container must exist before the copy.
+//
+// You can use this to copy an object to itself - this is the only way
+// to update the content type of an object.
+func (c *Connection) ObjectCopy(srcContainer string, srcObjectName string, dstContainer string, dstObjectName string, h Headers) (headers Headers, err error) {
+	// Meta stuff
+	extraHeaders := map[string]string{
+		"Destination": dstContainer + "/" + dstObjectName,
+	}
+	for key, value := range h {
+		extraHeaders[key] = value
+	}
+	_, headers, err = c.storage(RequestOpts{
+		Container:  srcContainer,
+		ObjectName: srcObjectName,
+		Operation:  "COPY",
+		ErrorMap:   objectErrorMap,
+		NoResponse: true,
+		Headers:    extraHeaders,
+	})
+	return
+}
+
+// ObjectMove does a server side move of an object to a new position
+//
+// This is a convenience method which calls ObjectCopy then ObjectDelete
+//
+// All metadata is preserved.
+//
+// The destination container must exist before the copy.
+func (c *Connection) ObjectMove(srcContainer string, srcObjectName string, dstContainer string, dstObjectName string) (err error) {
+	_, err = c.ObjectCopy(srcContainer, srcObjectName, dstContainer, dstObjectName, nil)
+	if err != nil {
+		return
+	}
+	return c.ObjectDelete(srcContainer, srcObjectName)
+}
+
+// ObjectUpdateContentType updates the content type of an object
+//
+// This is a convenience method which calls ObjectCopy
+//
+// All other metadata is preserved.
+func (c *Connection) ObjectUpdateContentType(container string, objectName string, contentType string) (err error) {
+	h := Headers{"Content-Type": contentType}
+	_, err = c.ObjectCopy(container, objectName, container, objectName, h)
+	return
+}
+
+// ------------------------------------------------------------
+
+// VersionContainerCreate is a helper method for creating and enabling version controlled containers.
+//
+// It builds the current object container, the non-current object version container, and enables versioning.
+//
+// If the server doesn't support versioning then it will return
+// Forbidden however it will have created both the containers at that point.
+func (c *Connection) VersionContainerCreate(current, version string) error {
+	if err := c.ContainerCreate(version, nil); err != nil {
+		return err
+	}
+	if err := c.ContainerCreate(current, nil); err != nil {
+		return err
+	}
+	if err := c.VersionEnable(current, version); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VersionEnable enables versioning on the current container with version as the tracking container.
+//
+// May return Forbidden if this isn't supported by the server
+func (c *Connection) VersionEnable(current, version string) error {
+	h := Headers{"X-Versions-Location": version}
+	if err := c.ContainerUpdate(current, h); err != nil {
+		return err
+	}
+	// Check to see if the header was set properly
+	_, headers, err := c.Container(current)
+	if err != nil {
+		return err
+	}
+	// If failed to set versions header, return Forbidden as the server doesn't support this
+	if headers["X-Versions-Location"] != version {
+		return Forbidden
+	}
+	return nil
+}
+
+// VersionDisable disables versioning on the current container.
+func (c *Connection) VersionDisable(current string) error {
+	h := Headers{"X-Versions-Location": ""}
+	if err := c.ContainerUpdate(current, h); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VersionObjectList returns a list of older versions of the object.
+//
+// Objects are returned in the format <length><object_name>/<timestamp>
+func (c *Connection) VersionObjectList(version, object string) ([]string, error) {
+	opts := &ObjectsOpts{
+		// <3-character zero-padded hexadecimal character length><object name>/
+		Prefix: fmt.Sprintf("%03x", len(object)) + object + "/",
+	}
+	return c.ObjectNames(version, opts)
+}

--- a/vendor/github.com/ncw/swift/timeout_reader.go
+++ b/vendor/github.com/ncw/swift/timeout_reader.go
@@ -1,0 +1,59 @@
+package swift
+
+import (
+	"io"
+	"time"
+)
+
+// An io.ReadCloser which obeys an idle timeout
+type timeoutReader struct {
+	reader  io.ReadCloser
+	timeout time.Duration
+	cancel  func()
+}
+
+// Returns a wrapper around the reader which obeys an idle
+// timeout. The cancel function is called if the timeout happens
+func newTimeoutReader(reader io.ReadCloser, timeout time.Duration, cancel func()) *timeoutReader {
+	return &timeoutReader{
+		reader:  reader,
+		timeout: timeout,
+		cancel:  cancel,
+	}
+}
+
+// Read reads up to len(p) bytes into p
+//
+// Waits at most for timeout for the read to complete otherwise returns a timeout
+func (t *timeoutReader) Read(p []byte) (int, error) {
+	// FIXME limit the amount of data read in one chunk so as to not exceed the timeout?
+	// Do the read in the background
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		n, err := t.reader.Read(p)
+		done <- result{n, err}
+	}()
+	// Wait for the read or the timeout
+	timer := time.NewTimer(t.timeout)
+	defer timer.Stop()
+	select {
+	case r := <-done:
+		return r.n, r.err
+	case <-timer.C:
+		t.cancel()
+		return 0, TimeoutError
+	}
+	panic("unreachable") // for Go 1.0
+}
+
+// Close the channel
+func (t *timeoutReader) Close() error {
+	return t.reader.Close()
+}
+
+// Check it satisfies the interface
+var _ io.ReadCloser = &timeoutReader{}

--- a/vendor/github.com/ncw/swift/travis_realserver.sh
+++ b/vendor/github.com/ncw/swift/travis_realserver.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ ! "${TRAVIS_BRANCH}" = "master" ]; then
+    exit 0
+fi
+
+if [ "${TEST_REAL_SERVER}" = "rackspace" ] && [ ! -z "${RACKSPACE_APIKEY}" ]; then
+    echo "Running tests pointing to Rackspace"
+    export SWIFT_API_KEY=$RACKSPACE_APIKEY
+    export SWIFT_API_USER=$RACKSPACE_USER
+    export SWIFT_AUTH_URL=$RACKSPACE_AUTH
+    go test ./...
+fi
+
+if [ "${TEST_REAL_SERVER}" = "memset" ] && [ ! -z "${MEMSET_APIKEY}" ]; then
+    echo "Running tests pointing to Memset"
+    export SWIFT_API_KEY=$MEMSET_APIKEY
+    export SWIFT_API_USER=$MEMSET_USER
+    export SWIFT_AUTH_URL=$MEMSET_AUTH
+    go test
+fi

--- a/vendor/github.com/ncw/swift/watchdog_reader.go
+++ b/vendor/github.com/ncw/swift/watchdog_reader.go
@@ -1,0 +1,55 @@
+package swift
+
+import (
+	"io"
+	"time"
+)
+
+var watchdogChunkSize = 1 << 20 // 1 MiB
+
+// An io.Reader which resets a watchdog timer whenever data is read
+type watchdogReader struct {
+	timeout   time.Duration
+	reader    io.Reader
+	timer     *time.Timer
+	chunkSize int
+}
+
+// Returns a new reader which will kick the watchdog timer whenever data is read
+func newWatchdogReader(reader io.Reader, timeout time.Duration, timer *time.Timer) *watchdogReader {
+	return &watchdogReader{
+		timeout:   timeout,
+		reader:    reader,
+		timer:     timer,
+		chunkSize: watchdogChunkSize,
+	}
+}
+
+// Read reads up to len(p) bytes into p
+func (t *watchdogReader) Read(p []byte) (int, error) {
+	//read from underlying reader in chunks not larger than t.chunkSize
+	//while resetting the watchdog timer before every read; the small chunk
+	//size ensures that the timer does not fire when reading a large amount of
+	//data from a slow connection
+	start := 0
+	end := len(p)
+	for start < end {
+		length := end - start
+		if length > t.chunkSize {
+			length = t.chunkSize
+		}
+
+		resetTimer(t.timer, t.timeout)
+		n, err := t.reader.Read(p[start : start+length])
+		start += n
+		if n == 0 || err != nil {
+			return start, err
+		}
+	}
+
+	resetTimer(t.timer, t.timeout)
+	return start, nil
+}
+
+// Check it satisfies the interface
+var _ io.Reader = &watchdogReader{}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -952,6 +952,12 @@
 			"revisionTime": "2017-04-28T05:41:52Z"
 		},
 		{
+			"checksumSHA1": "ClTd8kZFg6XnGO/UK6ZDekUCsWI=",
+			"path": "github.com/ncw/swift",
+			"revision": "c95c6e5c2d1a3d37fc44c8c6dc9e231c7500667d",
+			"revisionTime": "2017-10-19T11:44:56Z"
+		},
+		{
 			"checksumSHA1": "pqTEAm1W2tlmdHJ6b/J0no+cfso=",
 			"path": "github.com/nsf/termbox-go",
 			"revision": "b6acae516ace002cb8105a89024544a1480655a5",


### PR DESCRIPTION
This contains:
* new vendored switf client
* upload artifacts with temp url (for pipeline build only)
* few I/O optimizations
 
To enable it, just set objectstore mode to swift and be careful with auth url

In other PR: next steps will be:

* download pipeline build artifact with temp url
* upload and download workflow artifact with temp url
* download plugin with temp url
* remove old code