### PR TITLE
fix (api): resyncWorkflowRunHandler UT

### DIFF
--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -166,20 +166,20 @@ func (api *API) resyncWorkflowRunHandler() Handler {
 		}
 		run, err := workflow.LoadRun(api.mustDB(), key, name, number)
 		if err != nil {
-			return sdk.WrapError(err, "resyncWorkflowRunPipelinesHandler> Unable to load last workflow run [%s/%d]", name, number)
+			return sdk.WrapError(err, "resyncWorkflowRunHandler> Unable to load last workflow run [%s/%d]", name, number)
 		}
 
 		tx, errT := api.mustDB().Begin()
 		if errT != nil {
-			return sdk.WrapError(errT, "resyncWorkflowRunPipelinesHandler> Cannot start transaction")
+			return sdk.WrapError(errT, "resyncWorkflowRunHandler> Cannot start transaction")
 		}
 
 		if err := workflow.Resync(tx, api.Cache, run, getUser(ctx)); err != nil {
-			return sdk.WrapError(err, "resyncWorkflowRunPipelinesHandler> Cannot resync pipelines")
+			return sdk.WrapError(err, "resyncWorkflowRunHandler> Cannot resync pipelines")
 		}
 
 		if err := tx.Commit(); err != nil {
-			return sdk.WrapError(err, "resyncWorkflowRunPipelinesHandler> Cannot commit transaction")
+			return sdk.WrapError(err, "resyncWorkflowRunHandler> Cannot commit transaction")
 		}
 		return WriteJSON(w, r, run, http.StatusOK)
 	}

--- a/engine/api/workflow_run_test.go
+++ b/engine/api/workflow_run_test.go
@@ -575,7 +575,7 @@ func Test_getWorkflowNodeRunHandler(t *testing.T) {
 	assert.Equal(t, 200, rec.Code)
 }
 
-func Test_resyncWorkflowRunPipelinesHandler(t *testing.T) {
+func Test_resyncWorkflowRunHandler(t *testing.T) {
 	api, db, router := newTestAPI(t, bootstrap.InitiliazeDB)
 	u, pass := assets.InsertAdminUser(db)
 	key := sdk.RandomString(10)
@@ -668,7 +668,7 @@ func Test_resyncWorkflowRunPipelinesHandler(t *testing.T) {
 		"permWorkflowName": w1.Name,
 		"number":           fmt.Sprintf("%d", wr.Number),
 	}
-	uri = router.GetRoute("POST", api.resyncWorkflowRunPipelinesHandler, vars)
+	uri = router.GetRoute("POST", api.resyncWorkflowRunHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
 


### PR DESCRIPTION
./workflow_run_test.go:671:35: api.resyncWorkflowRunPipelinesHandler undefined (type *API has no field or method resyncWorkflowRunPipelinesHandler)

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>