### PR TITLE
fix (worker): add retry on Sending build result

### DIFF
--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -58,11 +58,11 @@ func DeleteWorker(db *gorp.DbMap, id string) error {
 		// Worker is awol while building !
 		// We need to restart this action
 		if jobID.Valid == false {
-			return fmt.Errorf("DeleteWorker> Meh, worker %s crashed while building but action_build_id is NULL!", name)
+			return fmt.Errorf("DeleteWorker> Worker %s crashed while building but action_build_id is NULL!", name)
 		}
 
 		if !jobType.Valid {
-			return fmt.Errorf("DeleteWorker> Meh, worker %s crashed while building but job_type is NULL!", name)
+			return fmt.Errorf("DeleteWorker> Worker %s crashed while building but job_type is NULL!", name)
 		}
 
 		switch jobType.String {
@@ -83,7 +83,7 @@ func DeleteWorker(db *gorp.DbMap, id string) error {
 			}
 		}
 
-		log.Info("Worker %s crashed while building %d !", name, jobID.Int64)
+		log.Info("DeleteWorker> Worker %s crashed while building %d !", name, jobID.Int64)
 	}
 
 	// Well then, let's remove this loser

--- a/engine/worker/builtin.go
+++ b/engine/worker/builtin.go
@@ -43,9 +43,9 @@ func getLogger(w *currentWorker, buildID int64, stepOrder int) LoggerFunc {
 }
 
 func (w *currentWorker) runBuiltin(ctx context.Context, a *sdk.Action, buildID int64, params *[]sdk.Parameter, stepOrder int) sdk.Result {
-	log.Debug("runBuiltin> Begin %p", ctx)
+	log.Info("runBuiltin> Begin %p", ctx)
 	defer func() {
-		log.Debug("runBuiltin> End %p (%s)", ctx, ctx.Err())
+		log.Info("runBuiltin> End %p (%s)", ctx, ctx.Err())
 	}()
 	defer w.drainLogsAndCloseLogger(ctx)
 
@@ -65,6 +65,11 @@ func (w *currentWorker) runBuiltin(ctx context.Context, a *sdk.Action, buildID i
 }
 
 func (w *currentWorker) runPlugin(ctx context.Context, a *sdk.Action, buildID int64, params *[]sdk.Parameter, stepOrder int, sendLog LoggerFunc) sdk.Result {
+	log.Info("runPlugin> Begin %p", ctx)
+	defer func() {
+		log.Info("runPlugin> End %p (%s)", ctx, ctx.Err())
+	}()
+
 	chanRes := make(chan sdk.Result, 1)
 
 	go func(buildID int64, params []sdk.Parameter) {

--- a/engine/worker/run.go
+++ b/engine/worker/run.go
@@ -118,8 +118,8 @@ func (w *currentWorker) replaceVariablesPlaceholder(a *sdk.Action, params []sdk.
 }
 
 func (w *currentWorker) runJob(ctx context.Context, a *sdk.Action, buildID int64, params *[]sdk.Parameter, stepOrder int, stepName string) sdk.Result {
-	log.Debug("runJob> start run %d stepOrder:%d %p", buildID, stepOrder, ctx)
-	defer func() { log.Debug("runJob> end run %d stepOrder:%d %p (%s)", buildID, stepOrder, ctx, ctx.Err()) }()
+	log.Info("runJob> start run %d stepOrder:%d %p", buildID, stepOrder, ctx)
+	defer func() { log.Info("runJob> end run %d stepOrder:%d %p (%s)", buildID, stepOrder, ctx, ctx.Err()) }()
 	// Replace variable placeholder that may have been added by last step
 	w.replaceVariablesPlaceholder(a, *params)
 	// Set the params
@@ -167,9 +167,9 @@ func (w *currentWorker) runJob(ctx context.Context, a *sdk.Action, buildID int64
 }
 
 func (w *currentWorker) runSteps(ctx context.Context, steps []sdk.Action, a *sdk.Action, buildID int64, params *[]sdk.Parameter, stepOrder int, stepName string, stepBaseCount int) (sdk.Result, int) {
-	log.Debug("runSteps> start run %d stepOrder:%d len(steps):%d context=%p", buildID, stepOrder, len(steps), ctx)
+	log.Info("runSteps> start run %d stepOrder:%d len(steps):%d context=%p", buildID, stepOrder, len(steps), ctx)
 	defer func() {
-		log.Debug("runSteps> end run %d stepOrder:%d len(steps):%d context=%p (%s)", buildID, stepOrder, len(steps), ctx, ctx.Err())
+		log.Info("runSteps> end run %d stepOrder:%d len(steps):%d context=%p (%s)", buildID, stepOrder, len(steps), ctx, ctx.Err())
 	}()
 	var criticalStepFailed bool
 	var nbDisabledChildren int

--- a/engine/worker/take_pipeline_build_job.go
+++ b/engine/worker/take_pipeline_build_job.go
@@ -96,7 +96,6 @@ func (w *currentWorker) takePipelineBuildJob(ctx context.Context, pipelineBuildJ
 					cancel()
 					return
 				}
-
 			}
 		}
 	}(pipelineBuildJobID, tick)
@@ -126,6 +125,7 @@ func (w *currentWorker) takePipelineBuildJob(ctx context.Context, pipelineBuildJ
 	var isThereAnyHopeLeft = 10
 	for code >= 300 {
 		var errre error
+		log.Info("takeJob> Sending build result...")
 		_, code, errre = sdk.Request("POST", path, body)
 		if code == http.StatusNotFound {
 			log.Info("takeJob> Cannot send build result: PipelineBuildJob does not exists anymore")


### PR DESCRIPTION
And add logs on start / end step & job

As it was done for Pipeline Build
and to avoid
An error has occured: Post ...//queue/workflows/11831/result: net/http: request canceled (Client.Timeout exceeded while awaiting headers)

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>