### PR TITLE
feat (api): pprof handlers

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -250,6 +250,18 @@ func (a *API) CheckConfiguration(config interface{}) error {
 	return nil
 }
 
+func getUserSession(c context.Context) string {
+	i := c.Value(auth.ContextUserSession)
+	if i == nil {
+		return ""
+	}
+	u, ok := i.(string)
+	if !ok {
+		return ""
+	}
+	return u
+}
+
 func getUser(c context.Context) *sdk.User {
 	i := c.Value(auth.ContextUser)
 	if i == nil {

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -34,6 +34,10 @@ func (api *API) InitRouter() {
 	// Admin
 	r.Handle("/admin/warning", r.DELETE(api.adminTruncateWarningsHandler, NeedAdmin(true)))
 	r.Handle("/admin/maintenance", r.POST(api.postAdminMaintenanceHandler, NeedAdmin(true)), r.GET(api.getAdminMaintenanceHandler, NeedAdmin(true)), r.DELETE(api.deleteAdminMaintenanceHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug", r.GET(api.getProfileIndexHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/trace", r.GET(api.getTraceHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/cpu", r.GET(api.getCPUProfileHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/{name}", r.GET(api.getProfileHandler, NeedAdmin(true)))
 
 	// Action plugin
 	r.Handle("/plugin", r.POST(api.addPluginHandler, NeedAdmin(true)), r.PUT(api.updatePluginHandler, NeedAdmin(true)))

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -35,9 +35,9 @@ func (api *API) InitRouter() {
 	r.Handle("/admin/warning", r.DELETE(api.adminTruncateWarningsHandler, NeedAdmin(true)))
 	r.Handle("/admin/maintenance", r.POST(api.postAdminMaintenanceHandler, NeedAdmin(true)), r.GET(api.getAdminMaintenanceHandler, NeedAdmin(true)), r.DELETE(api.deleteAdminMaintenanceHandler, NeedAdmin(true)))
 	r.Handle("/admin/debug", r.GET(api.getProfileIndexHandler, NeedAdmin(true)))
-	r.Handle("/admin/debug/trace", r.GET(api.getTraceHandler, NeedAdmin(true)))
-	r.Handle("/admin/debug/cpu", r.GET(api.getCPUProfileHandler, NeedAdmin(true)))
-	r.Handle("/admin/debug/{name}", r.GET(api.getProfileHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/trace", r.POST(api.getTraceHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/cpu", r.POST(api.getCPUProfileHandler, NeedAdmin(true)))
+	r.Handle("/admin/debug/{name}", r.POST(api.getProfileHandler, NeedAdmin(true)))
 
 	// Action plugin
 	r.Handle("/plugin", r.POST(api.addPluginHandler, NeedAdmin(true)), r.PUT(api.updatePluginHandler, NeedAdmin(true)))

--- a/engine/api/auth/auth.go
+++ b/engine/api/auth/auth.go
@@ -26,6 +26,7 @@ const (
 	ContextHatchery
 	ContextWorker
 	ContextService
+	ContextUserSession
 )
 
 //Driver is an interface to all auth method (local, ldap and beyond...)

--- a/engine/api/auth/localclient.go
+++ b/engine/api/auth/localclient.go
@@ -46,7 +46,7 @@ func (c *LocalClient) CheckAuth(ctx context.Context, w http.ResponseWriter, req 
 	//Check other session
 	sessionToken := req.Header.Get(sdk.SessionTokenHeader)
 	if sessionToken == "" {
-		//Accept session in request query parameter
+		//Accept session in request
 		sessionToken = req.FormValue("session")
 	}
 	if sessionToken == "" {

--- a/engine/api/auth/localclient.go
+++ b/engine/api/auth/localclient.go
@@ -46,8 +46,13 @@ func (c *LocalClient) CheckAuth(ctx context.Context, w http.ResponseWriter, req 
 	//Check other session
 	sessionToken := req.Header.Get(sdk.SessionTokenHeader)
 	if sessionToken == "" {
+		//Accept session in request query parameter
+		sessionToken = req.FormValue("session")
+	}
+	if sessionToken == "" {
 		return ctx, fmt.Errorf("no session header")
 	}
+
 	exists, err := c.store.Exists(sessionstore.SessionKey(sessionToken))
 	if err != nil {
 		return ctx, err
@@ -61,6 +66,7 @@ func (c *LocalClient) CheckAuth(ctx context.Context, w http.ResponseWriter, req 
 		return ctx, fmt.Errorf("authorization failed for %s: %s", username, err)
 	}
 	ctx = context.WithValue(ctx, ContextUser, u)
+	ctx = context.WithValue(ctx, ContextUserSession, sessionToken)
 
 	if !exists {
 		return ctx, fmt.Errorf("invalid session")

--- a/engine/api/debug.go
+++ b/engine/api/debug.go
@@ -1,0 +1,166 @@
+package api
+
+// From https://golang.org/src/net/http/pprof/pprof.go
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/http"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/ovh/cds/sdk/log"
+)
+
+// getProfileIndexHandler returns the profiles index
+func (api *API) getProfileIndexHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		session := getUserSession(ctx)
+		str := fmt.Sprintf(`<html>
+			<head>
+			<title>CDS Debug</title>
+			</head>
+			<body>
+			CDS debug pprof<br>
+			<br>
+			profiles:<br>
+			<table>
+			{{range .}}
+			<tr><td align=right>{{.Count}}<td><a href="debug/{{.Name}}?debug=1&session=%s">{{.Name}}</a>
+			{{end}}
+			</table>
+			<br>
+			<a href="debug/goroutine?debug=2&session=%s">Full goroutine stack dump</a><br>
+			<a href="debug/trace?session=%s&seconds=5">Trace profile for 5 seconds</a><br>
+			<a href="debug/cpu?session=%s&seconds=5">CPU profile for 5 seconds</a><br>
+			</body>
+			</html>
+			`, session, session, session, session)
+
+		var indexTmpl = template.Must(template.New("index").Parse(str))
+
+		profiles := pprof.Profiles()
+		if err := indexTmpl.Execute(w, profiles); err != nil {
+			log.Error("getProfileIndexHandler> %v", err)
+		}
+		return nil
+	}
+}
+
+// getProfileHandler responds with the pprof-formatted profile named by the request.
+func (api *API) getProfileHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		name := mux.Vars(r)["name"]
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		debug, _ := strconv.Atoi(r.FormValue("debug"))
+		p := pprof.Lookup(name)
+		if p == nil {
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "Unknown profile: %s\n", name)
+			return nil
+		}
+		gc, _ := strconv.Atoi(r.FormValue("gc"))
+		if name == "heap" && gc > 0 {
+			runtime.GC()
+		}
+		p.WriteTo(w, debug)
+		return nil
+	}
+}
+
+func sleep(w http.ResponseWriter, d time.Duration) {
+	var clientGone <-chan bool
+	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone = cn.CloseNotify()
+	}
+	select {
+	case <-time.After(d):
+	case <-clientGone:
+	}
+}
+
+func durationExceedsWriteTimeout(r *http.Request, seconds float64) bool {
+	srv, ok := r.Context().Value(http.ServerContextKey).(*http.Server)
+	return ok && srv.WriteTimeout != 0 && seconds >= srv.WriteTimeout.Seconds()
+}
+
+// getTraceHandler responds with the execution trace in binary form.
+// Tracing lasts for duration specified in seconds GET parameter, or for 1 second if not specified.
+func (api *API) getTraceHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		sec, err := strconv.ParseFloat(r.FormValue("seconds"), 64)
+		if sec <= 0 || err != nil {
+			sec = 1
+		}
+
+		if durationExceedsWriteTimeout(r, sec) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Go-Pprof", "1")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, "profile duration exceeds server's WriteTimeout")
+			return nil
+		}
+
+		// Set Content Type assuming trace.Start will work,
+		// because if it does it starts writing.
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if err := trace.Start(w); err != nil {
+			// trace.Start failed, so no writes yet.
+			// Can change header back to text content and send error code.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Go-Pprof", "1")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Could not enable tracing: %s\n", err)
+			return nil
+		}
+		sleep(w, time.Duration(sec*float64(time.Second)))
+		trace.Stop()
+		return nil
+	}
+}
+
+// getCPUProfileHandler responds with the pprof-formatted cpu profile.
+// The package initialization registers it as /debug/pprof/profile.
+func (api *API) getCPUProfileHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		sec, _ := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+		if sec == 0 {
+			sec = 30
+		}
+
+		if durationExceedsWriteTimeout(r, float64(sec)) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Go-Pprof", "1")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, "profile duration exceeds server's WriteTimeout")
+			return nil
+		}
+
+		// Set Content Type assuming StartCPUProfile will work,
+		// because if it does it starts writing.
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if err := pprof.StartCPUProfile(w); err != nil {
+			// StartCPUProfile failed, so no writes yet.
+			// Can change header back to text content
+			// and send error code.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Go-Pprof", "1")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Could not enable CPU profiling: %s\n", err)
+			return nil
+		}
+		sleep(w, time.Duration(sec)*time.Second)
+		pprof.StopCPUProfile()
+
+		return nil
+	}
+}

--- a/engine/api/debug.go
+++ b/engine/api/debug.go
@@ -30,18 +30,39 @@ func (api *API) getProfileIndexHandler() Handler {
 			<title>CDS Debug</title>
 			</head>
 			<body>
-			CDS debug pprof<br>
-			<br>
-			profiles:<br>
-			<table>
+			<h1>CDS debug pprof</h1>
+			<h2>Profiles</h2>
 			{{range .}}
-			<tr><td align=right>{{.Count}}<td><a href="debug/{{.Name}}?debug=1&session=%s">{{.Name}}</a>
+				<form action="debug/{{.Name}}" method="POST">
+					<input type="text" value="{{.Count}}" size="3" disabled></input>				
+					<input type="text" value="{{.Name}}" size="30" disabled></input>
+					<input type="hidden" name="session" value="%s"></input>
+					<input type="hidden" name="debug" value="1"></input>
+					<input type="submit" value="Go"></input>
+				</form>
 			{{end}}
-			</table>
+
 			<br>
-			<a href="debug/goroutine?debug=2&session=%s">Full goroutine stack dump</a><br>
-			<a href="debug/trace?session=%s&seconds=5">Trace profile for 5 seconds</a><br>
-			<a href="debug/cpu?session=%s&seconds=5">CPU profile for 5 seconds</a><br>
+			<form action="debug/goroutine" method="POST">
+				Full goroutine stack dump
+				<input type="hidden" name="session" value="%s"></input>
+				<input type="hidden" name="debug" value="2"></input>
+				<input type="submit" value="Go"></input>
+			</form>
+			<br>
+			<form action="debug/trace" method="POST">
+				Trace
+				<input type="hidden" name="session" value="%s"></input>
+				<input type="text" name="seconds" value="5" size="3"></input> Seconds
+				<input type="submit" value="Go"></input>
+			</form>
+			<br>
+			<form action="debug/cpu" method="POST">
+				CPU Profile
+				<input type="hidden" name="session" value="%s"></input>
+				<input type="text" name="seconds" value="5" size="3"></input> Seconds
+				<input type="submit" value="Go"></input>
+			</form>
 			</body>
 			</html>
 			`, session, session, session, session)


### PR DESCRIPTION
The API handles /admin/debug for admins. You just have to add your session token as a query param.

<img width="228" alt="capture d ecran 2017-11-22 a 21 59 00" src="https://user-images.githubusercontent.com/684151/33149729-0deaa000-cfd1-11e7-8094-7eb66059dc51.png">

It is inspired by the net/http/pprof package, with a few custom things.
I hope we will be able to embbed the next pprof web ui from go 1.10 https://twitter.com/rakyll/status/887401222478602241?lang=fr