### PR TITLE
fix (vcs): GET/PUT bitbucket /settings

### DIFF
--- a/engine/vcs/bitbucket/types.go
+++ b/engine/vcs/bitbucket/types.go
@@ -3,6 +3,7 @@ package bitbucket
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -70,7 +71,7 @@ type HooksConfig struct {
 }
 
 func (h *HooksConfig) MarshalJSON() ([]byte, error) {
-	m := make(map[string]string)
+	m := make(map[string]interface{})
 	m["version"] = h.Version
 	m["locationCount"] = fmt.Sprintf("%d", len(h.Details))
 	for i, d := range h.Details {
@@ -86,12 +87,14 @@ func (h *HooksConfig) MarshalJSON() ([]byte, error) {
 		m["branchFilter"+keySuffix] = d.BranchFilter
 		m["tagFilter"+keySuffix] = d.TagFilter
 		m["userFilter"+keySuffix] = d.UserFilter
+		m["skipSsl"+keySuffix] = d.SkipSsl
+		m["useAuth"+keySuffix] = d.UseAuth
 	}
 	return json.Marshal(m)
 }
 
 func (h *HooksConfig) UnmarshalJSON(b []byte) error {
-	m := make(map[string]string)
+	m := make(map[string]interface{})
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
@@ -109,14 +112,18 @@ func (h *HooksConfig) UnmarshalJSON(b []byte) error {
 		if i > 0 {
 			keySuffix = fmt.Sprintf("%d", i+1)
 		}
+		skipSsl, _ := strconv.ParseBool(fmt.Sprintf("%s", m["skipSsl"+keySuffix]))
+		useAuth, _ := strconv.ParseBool(fmt.Sprintf("%s", m["useAuth"+keySuffix]))
 		h.Details[i] = HookConfigDetail{
-			BranchFilter:    m["branchFilter"+keySuffix],
-			Method:          m["httpMethod"+keySuffix],
-			PostContentType: m["postContentType"+keySuffix],
-			PostData:        m["postData"+keySuffix],
-			TagFilter:       m["tagFilter"+keySuffix],
-			URL:             m["url"+keySuffix],
-			UserFilter:      m["userFilter"+keySuffix],
+			BranchFilter:    fmt.Sprintf("%s", m["branchFilter"+keySuffix]),
+			Method:          fmt.Sprintf("%s", m["httpMethod"+keySuffix]),
+			PostContentType: fmt.Sprintf("%s", m["postContentType"+keySuffix]),
+			PostData:        fmt.Sprintf("%s", m["postData"+keySuffix]),
+			TagFilter:       fmt.Sprintf("%s", m["tagFilter"+keySuffix]),
+			URL:             fmt.Sprintf("%s", m["url"+keySuffix]),
+			UserFilter:      fmt.Sprintf("%s", m["userFilter"+keySuffix]),
+			SkipSsl:         skipSsl,
+			UseAuth:         useAuth,
 		}
 	}
 	return nil
@@ -130,6 +137,8 @@ type HookConfigDetail struct {
 	BranchFilter    string `json:"branchFilter"`
 	TagFilter       string `json:"tagFilter"`
 	UserFilter      string `json:"userFilter"`
+	SkipSsl         bool   `json:"skipSsl"`
+	UseAuth         bool   `json:"useAuth"`
 }
 
 type Hook struct {

--- a/engine/vcs/bitbucket/types_test.go
+++ b/engine/vcs/bitbucket/types_test.go
@@ -1,0 +1,49 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHooksConfig(t *testing.T) {
+	a := `{
+	"branchFilter2": "",
+	"httpMethod": "POST",
+	"httpMethod2": "GET",
+	"locationCount": "2",
+	"postContentType": "application/x-www-form-urlencoded",
+	"postContentType2": "application/x-www-form-urlencoded",
+	"postData": "",
+	"skipSsl2": true,
+	"tagFilter": "",
+	"tagFilter2": "",
+	"url": "aa" ,
+	"url2": "http://foo.local",
+	"userFilter": "",
+	"userFilter2": "",
+	"version": "3"
+	}`
+	h := HooksConfig{}
+	err := json.Unmarshal([]byte(a), &h)
+	assert.NoError(t, err)
+
+	b, err := json.Marshal(h)
+	assert.NoError(t, err)
+
+	h2 := HooksConfig{}
+	err = json.Unmarshal(b, &h2)
+	assert.NoError(t, err)
+	for _, d := range h.Details {
+		if d.URL != "aa" && d.URL != "http://foo.local" {
+			assert.Fail(t, "Unmarshal failed. Url should be aa or http://foo.local")
+		}
+	}
+	for _, d := range h2.Details {
+		if d.PostContentType != "application/x-www-form-urlencoded" {
+			assert.Fail(t, "Unmarshal failed. PostContentType should be application/x-www-form-urlencoded")
+		}
+	}
+
+}


### PR DESCRIPTION
Example of GET (mix of string / bool in value)

```json
{
    "version": "3",
    "locationCount": "2",
    "httpMethod": "POST",
    "url": "https://foo",
    "postContentType": "application/x-www-form-urlencoded",
    "postData": "",
    "branchFilter": "",
    "tagFilter": "",
    "userFilter": "",
    "httpMethod2": "GET",
    "url2": "http://foo.local",
    "skipSsl2": true,
    "postContentType2": "application/x-www-form-urlencoded",
    "branchFilter2": "",
    "tagFilter2": "",
    "userFilter2": ""
}
```
Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>