### PR TITLE
send XMPP message in HTML

### DIFF
--- a/contrib/uservices/cds2xmpp/service/bot.go
+++ b/contrib/uservices/cds2xmpp/service/bot.go
@@ -143,7 +143,7 @@ func (bot *botClient) sendPresencesOnConfs() error {
 
 func (bot *botClient) sendToXMPP() {
 	for {
-		cdsbot.XMPPClient.Send(<-bot.chats)
+		cdsbot.XMPPClient.SendHtml(<-bot.chats)
 		time.Sleep(time.Duration(viper.GetInt("xmpp_delay")) * time.Second)
 	}
 }


### PR DESCRIPTION
Send XMPP message as HTML to highlight notifications.
ref: https://github.com/mattn/go-xmpp/blob/master/xmpp.go#L644