### PR TITLE
fix (sdk): interpolate perf

### DIFF
--- a/sdk/interpolate.go
+++ b/sdk/interpolate.go
@@ -3,11 +3,9 @@ package sdk
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"regexp"
 	"strings"
-
-	"github.com/Masterminds/sprig"
+	"text/template"
 )
 
 var interpolateRegex = regexp.MustCompile("({{\\.[a-zA-Z0-9._|\\s]+}})")
@@ -61,7 +59,7 @@ func Interpolate(input string, vars map[string]string) (string, error) {
 		}
 	}
 
-	t, err := template.New("input").Funcs(sprig.FuncMap()).Parse(input)
+	t, err := template.New("input").Funcs(interpolateHelperFuncs).Parse(input)
 	if err != nil {
 		return "", fmt.Errorf("Invalid template format: %s", err.Error())
 	}

--- a/sdk/interpolate.go
+++ b/sdk/interpolate.go
@@ -12,9 +12,13 @@ var interpolateRegex = regexp.MustCompile("({{\\.[a-zA-Z0-9._|\\s]+}})")
 
 // Interpolate returns interpolated input with vars
 func Interpolate(input string, vars map[string]string) (string, error) {
-	data := map[string]string{}
-	defaults := map[string]string{}
-	empty := map[string]string{}
+	if !strings.Contains(input, "{{") {
+		return input, nil
+	}
+
+	data := make(map[string]string, len(vars))
+	defaults := make(map[string]string, len(vars))
+	empty := make(map[string]string, len(vars))
 
 	for k, v := range vars {
 		kb := strings.Replace(k, ".", "__", -1)

--- a/sdk/interpolate_helper.go
+++ b/sdk/interpolate_helper.go
@@ -2,7 +2,7 @@ package sdk
 
 // This functions come from https://github.com/Masterminds/sprig
 // Copyright (C) 2013 Masterminds
-// Masterminds/sprig is licensed under theMIT License
+// Masterminds/sprig is licensed under the MIT License
 
 import (
 	"encoding/base64"

--- a/sdk/interpolate_helper.go
+++ b/sdk/interpolate_helper.go
@@ -1,0 +1,312 @@
+package sdk
+
+// This functions come from https://github.com/Masterminds/sprig
+// Copyright (C) 2013 Masterminds
+// Masterminds/sprig is licensed under theMIT License
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/template"
+
+	util "github.com/aokoli/goutils"
+	"github.com/huandu/xstrings"
+)
+
+var interpolateHelperFuncs template.FuncMap
+
+func init() {
+	interpolateHelperFuncs = template.FuncMap{
+		"abbrev":     abbrev,
+		"abbrevboth": abbrevboth,
+		"trunc":      trunc,
+		"trim":       strings.TrimSpace,
+		"upper":      strings.ToUpper,
+		"lower":      strings.ToLower,
+		"title":      strings.Title,
+		"untitle":    untitle,
+		"substr":     substring,
+		// Switch order so that "foo" | repeat 5
+		"repeat": func(count int, str string) string { return strings.Repeat(str, count) },
+		// Deprecated: Use trimAll.
+		"trimall": func(a, b string) string { return strings.Trim(b, a) },
+		// Switch order so that "$foo" | trimall "$"
+		"trimAll":      func(a, b string) string { return strings.Trim(b, a) },
+		"trimSuffix":   func(a, b string) string { return strings.TrimSuffix(b, a) },
+		"trimPrefix":   func(a, b string) string { return strings.TrimPrefix(b, a) },
+		"nospace":      util.DeleteWhiteSpace,
+		"initials":     initials,
+		"randAlphaNum": randAlphaNumeric,
+		"randAlpha":    randAlpha,
+		"randAscii":    randAscii,
+		"randNumeric":  randNumeric,
+		"swapcase":     util.SwapCase,
+		"shuffle":      xstrings.Shuffle,
+		"snakecase":    xstrings.ToSnakeCase,
+		"camelcase":    xstrings.ToCamelCase,
+		"quote":        quote,
+		"squote":       squote,
+		"indent":       indent,
+		"nindent":      nindent,
+		"replace":      replace,
+		"plural":       plural,
+		"toString":     strval,
+		"default":      dfault,
+		"empty":        empty,
+		"coalesce":     coalesce,
+		"toJson":       toJson,
+		"toPrettyJson": toPrettyJson,
+		"b64enc":       base64encode,
+		"b64dec":       base64decode,
+	}
+}
+
+// dfault checks whether `given` is set, and returns default if not set.
+//
+// This returns `d` if `given` appears not to be set, and `given` otherwise.
+//
+// For numeric types 0 is unset.
+// For strings, maps, arrays, and slices, len() = 0 is considered unset.
+// For bool, false is unset.
+// Structs are never considered unset.
+//
+// For everything else, including pointers, a nil value is unset.
+func dfault(d interface{}, given ...interface{}) interface{} {
+
+	if empty(given) || empty(given[0]) {
+		return d
+	}
+	return given[0]
+}
+
+// empty returns true if the given value has the zero value for its type.
+func empty(given interface{}) bool {
+	g := reflect.ValueOf(given)
+	if !g.IsValid() {
+		return true
+	}
+
+	// Basically adapted from text/template.isTrue
+	switch g.Kind() {
+	default:
+		return g.IsNil()
+	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
+		return g.Len() == 0
+	case reflect.Bool:
+		return g.Bool() == false
+	case reflect.Complex64, reflect.Complex128:
+		return g.Complex() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return g.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return g.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return g.Float() == 0
+	case reflect.Struct:
+		return false
+	}
+	return true
+}
+
+// coalesce returns the first non-empty value.
+func coalesce(v ...interface{}) interface{} {
+	for _, val := range v {
+		if !empty(val) {
+			return val
+		}
+	}
+	return nil
+}
+
+// toJson encodes an item into a JSON string
+func toJson(v interface{}) string {
+	output, _ := json.Marshal(v)
+	return string(output)
+}
+
+// toPrettyJson encodes an item into a pretty (indented) JSON string
+func toPrettyJson(v interface{}) string {
+	output, _ := json.MarshalIndent(v, "", "  ")
+	return string(output)
+}
+
+func base64encode(v string) string {
+	return base64.StdEncoding.EncodeToString([]byte(v))
+}
+
+func base64decode(v string) string {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}
+
+func abbrev(width int, s string) string {
+	if width < 4 {
+		return s
+	}
+	r, _ := util.Abbreviate(s, width)
+	return r
+}
+
+func abbrevboth(left, right int, s string) string {
+	if right < 4 || left > 0 && right < 7 {
+		return s
+	}
+	r, _ := util.AbbreviateFull(s, left, right)
+	return r
+}
+func initials(s string) string {
+	// Wrap this just to eliminate the var args, which templates don't do well.
+	return util.Initials(s)
+}
+
+func randAlphaNumeric(count int) string {
+	// It is not possible, it appears, to actually generate an error here.
+	r, _ := util.RandomAlphaNumeric(count)
+	return r
+}
+
+func randAlpha(count int) string {
+	r, _ := util.RandomAlphabetic(count)
+	return r
+}
+
+func randAscii(count int) string {
+	r, _ := util.RandomAscii(count)
+	return r
+}
+
+func randNumeric(count int) string {
+	r, _ := util.RandomNumeric(count)
+	return r
+}
+
+func untitle(str string) string {
+	return util.Uncapitalize(str)
+}
+
+func quote(str ...interface{}) string {
+	out := make([]string, len(str))
+	for i, s := range str {
+		out[i] = fmt.Sprintf("%q", strval(s))
+	}
+	return strings.Join(out, " ")
+}
+
+func squote(str ...interface{}) string {
+	out := make([]string, len(str))
+	for i, s := range str {
+		out[i] = fmt.Sprintf("'%v'", s)
+	}
+	return strings.Join(out, " ")
+}
+
+func cat(v ...interface{}) string {
+	r := strings.TrimSpace(strings.Repeat("%v ", len(v)))
+	return fmt.Sprintf(r, v...)
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func nindent(spaces int, v string) string {
+	return "\n" + indent(spaces, v)
+}
+
+func replace(old, new, src string) string {
+	return strings.Replace(src, old, new, -1)
+}
+
+func plural(one, many string, count int) string {
+	if count == 1 {
+		return one
+	}
+	return many
+}
+
+func strslice(v interface{}) []string {
+	switch v := v.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		l := len(v)
+		b := make([]string, l)
+		for i := 0; i < l; i++ {
+			b[i] = strval(v[i])
+		}
+		return b
+	default:
+		val := reflect.ValueOf(v)
+		switch val.Kind() {
+		case reflect.Array, reflect.Slice:
+			l := val.Len()
+			b := make([]string, l)
+			for i := 0; i < l; i++ {
+				b[i] = strval(val.Index(i).Interface())
+			}
+			return b
+		default:
+			return []string{strval(v)}
+		}
+	}
+}
+
+func strval(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case error:
+		return v.Error()
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func trunc(c int, s string) string {
+	if len(s) <= c {
+		return s
+	}
+	return s[0:c]
+}
+
+func join(sep string, v interface{}) string {
+	return strings.Join(strslice(v), sep)
+}
+
+func split(sep, orig string) map[string]string {
+	parts := strings.Split(orig, sep)
+	res := make(map[string]string, len(parts))
+	for i, v := range parts {
+		res["_"+strconv.Itoa(i)] = v
+	}
+	return res
+}
+
+// substring creates a substring of the given string.
+//
+// If start is < 0, this calls string[:length].
+//
+// If start is >= 0 and length < 0, this calls string[start:]
+//
+// Otherwise, this calls string[start, length].
+func substring(start, length int, s string) string {
+	if start < 0 {
+		return s[:length]
+	}
+	if length < 0 {
+		return s[start:]
+	}
+	return s[start:length]
+}

--- a/sdk/interpolate_test.go
+++ b/sdk/interpolate_test.go
@@ -52,14 +52,8 @@ func BenchmarkInterpolate(b *testing.B) {
 			test.args.vars[fmt.Sprint("%d", i)] = fmt.Sprintf(">>%d<<", i)
 		}
 
-		got, err := Interpolate(test.args.input, test.args.vars)
-		if (err != nil) != test.wantErr {
-			b.Errorf("Interpolate() error = %v, wantErr %v", err, test.wantErr)
-			return
-		}
-		if got != test.want {
-			b.Errorf("Interpolate() = %v, want %v", got, test.want)
-		}
+		Interpolate(test.args.input, test.args.vars)
+
 	}
 }
 

--- a/sdk/interpolate_test.go
+++ b/sdk/interpolate_test.go
@@ -13,12 +13,8 @@ func BenchmarkInterpolate(b *testing.B) {
 			vars  map[string]string
 		}
 		test := struct {
-			name    string
-			args    args
-			want    string
-			wantErr bool
+			args args
 		}{
-			name: "config",
 			args: args{
 				input: `
 				{
@@ -34,22 +30,38 @@ func BenchmarkInterpolate(b *testing.B) {
 				}`,
 				vars: map[string]string{"cds.env.name": "", "cds.env.token": "aValidTokenString", "cds.env.addr": "", "cds.env.vAppKey": "aValue"},
 			},
-			want: `
-				{
-				"env": {
-				"KEYA":"aValue",
-				"KEYB": "{{.cds.env.vAppKeyHatchery}}",
-				"ADDR":""
-				},
-				"labels": {
-				"TOKEN": "aValidTokenString",
-				"HOST": "cds-hatchery-marathon-.{{.cds.env.vHost}}",
-				}
-				}`,
 		}
 
 		for i := 0; i < 60; i++ {
-			test.args.vars[fmt.Sprint("%d", i)] = fmt.Sprintf(">>%d<<", i)
+			test.args.vars[fmt.Sprintf("%d", i)] = fmt.Sprintf(">>%d<<", i)
+		}
+
+		Interpolate(test.args.input, test.args.vars)
+	}
+}
+
+func BenchmarkInterpolateNothing(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+
+		type args struct {
+			input string
+			vars  map[string]string
+		}
+		test := struct {
+			args args
+		}{
+			args: args{
+				input: `
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam felis nulla, vulputate ac eros vel, placerat dignissim turpis. Sed et ex lectus. Donec viverra nisi vel dictum rhoncus. Sed dictum tempus quam, ut efficitur arcu viverra vitae. Suspendisse aliquam venenatis scelerisque. Praesent et mattis enim. In efficitur imperdiet nulla a sagittis. Maecenas aliquet magna in sollicitudin ornare.
+				
+				Suspendisse viverra enim nec ante blandit tempus. Sed ut erat suscipit, semper ex eu, eleifend neque. Sed orci justo, bibendum laoreet libero cursus, venenatis fringilla dui. Curabitur tristique odio ut neque sollicitudin ultrices. Integer metus nibh, dignissim non pellentesque et, volutpat vel ante. Pellentesque ultrices ante vel mauris aliquam porttitor. Nunc nec sem facilisis, ullamcorper ex sed, elementum elit. Nulla risus magna, tempor et ultricies id, vehicula ac massa. Mauris venenatis libero libero, id lobortis mi semper aliquam. Aenean neque turpis, feugiat vel rutrum vitae, auctor quis nisl. Donec placerat nec mauris vitae malesuada. Proin quis gravida nulla. Pellentesque in pellentesque metus, in finibus dui. Sed rutrum, libero sit amet cursus scelerisque, sem orci condimentum nunc, quis egestas tellus orci ac nisl. Mauris viverra tincidunt diam ac sollicitudin. Nunc venenatis, nibh at laoreet pellentesque, lacus tellus molestie lorem, et sollicitudin nunc neque ut turpis.
+				`,
+				vars: map[string]string{"cds.env.name": "", "cds.env.token": "aValidTokenString", "cds.env.addr": "", "cds.env.vAppKey": "aValue"},
+			},
+		}
+
+		for i := 0; i < 60; i++ {
+			test.args.vars[fmt.Sprintf("%d", i)] = fmt.Sprintf(">>%d<<", i)
 		}
 
 		Interpolate(test.args.input, test.args.vars)


### PR DESCRIPTION
before
````
Running tool: /Applications/go/bin/go test -v -benchmem -run=^$ github.com/ovh/cds/sdk -bench ^BenchmarkInterpolate$

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk
BenchmarkInterpolate-8   	    5000	    261920 ns/op	  109879 B/op	     682 allocs/op
PASS
ok  	github.com/ovh/cds/sdk	1.352s
Success: Benchmarks passed.
````

after 
````
Running tool: /Applications/go/bin/go test -v -benchmem -run=^$ github.com/ovh/cds/sdk -bench ^BenchmarkInterpolate$

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk
BenchmarkInterpolate-8   	   10000	    152740 ns/op	   59311 B/op	     560 allocs/op
PASS
ok  	github.com/ovh/cds/sdk	1.558s
Success: Benchmarks passed.
````