### PR TITLE
fix (cdsctl): workflow pull & ask override files

### DIFF
--- a/cli/cdsctl/workflow.go
+++ b/cli/cdsctl/workflow.go
@@ -383,7 +383,7 @@ func workflowPullRun(c cli.Values) error {
 			return err
 		}
 		if !c.GetBool("quiet") {
-			fmt.Printf("File %s created\n", fname)
+			fmt.Println(fname)
 		}
 	}
 	return nil

--- a/cli/cdsctl/workflow.go
+++ b/cli/cdsctl/workflow.go
@@ -327,6 +327,12 @@ var workflowPullCmd = cli.Command{
 			Usage:   "Force, may override files",
 			Default: "false",
 		},
+		{
+			Kind:    reflect.Bool,
+			Name:    "quiet",
+			Usage:   "If true, do not output filename created",
+			Default: "false",
+		},
 	},
 }
 
@@ -355,9 +361,9 @@ func workflowPullRun(c cli.Values) error {
 		}
 
 		fname := filepath.Join(dir, hdr.Name)
-		if _, err := os.Stat(fname); os.IsExist(err) {
+		if _, err = os.Stat(fname); err == nil || os.IsExist(err) {
 			if !c.GetBool("force") {
-				if !cli.AskForConfirmation(fmt.Sprintf("This will override %s. Do you want to continue ?", fname)) {
+				if !cli.AskForConfirmation(fmt.Sprintf("This will override %s. Do you want to continue?", fname)) {
 					os.Exit(0)
 				}
 			}
@@ -375,6 +381,9 @@ func workflowPullRun(c cli.Values) error {
 		}
 		if err := fi.Close(); err != nil {
 			return err
+		}
+		if !c.GetBool("quiet") {
+			fmt.Printf("File %s created\n", fname)
 		}
 	}
 	return nil


### PR DESCRIPTION
os.Stat(fname) returns nil if file exists
add quiet flag, default false. User can see that there are many files written by cmd.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>