### PR TITLE
fix (ui): edit existing hook

### DIFF
--- a/engine/api/workflow_hook_test.go
+++ b/engine/api/workflow_hook_test.go
@@ -71,7 +71,7 @@ func Test_getWorkflowHookModelsHandlerAsLambdaUser(t *testing.T) {
 	//Check result
 	models := []sdk.WorkflowHookModel{}
 	test.NoError(t, json.Unmarshal(rec.Body.Bytes(), &models))
-	assert.Len(t, models, 2, "")
+	assert.Len(t, models, 3, "")
 }
 
 func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
@@ -135,7 +135,7 @@ func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
 	//Check result
 	models := []sdk.WorkflowHookModel{}
 	test.NoError(t, json.Unmarshal(rec.Body.Bytes(), &models))
-	assert.Len(t, models, 2, "")
+	assert.Len(t, models, 3, "")
 }
 
 func Test_getWorkflowHookModelHandler(t *testing.T) {

--- a/engine/api/workflow_hook_test.go
+++ b/engine/api/workflow_hook_test.go
@@ -71,7 +71,7 @@ func Test_getWorkflowHookModelsHandlerAsLambdaUser(t *testing.T) {
 	//Check result
 	models := []sdk.WorkflowHookModel{}
 	test.NoError(t, json.Unmarshal(rec.Body.Bytes(), &models))
-	assert.Len(t, models, 3, "")
+	assert.Len(t, models, 2, "")
 }
 
 func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
@@ -135,7 +135,7 @@ func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
 	//Check result
 	models := []sdk.WorkflowHookModel{}
 	test.NoError(t, json.Unmarshal(rec.Body.Bytes(), &models))
-	assert.Len(t, models, 3, "")
+	assert.Len(t, models, 2, "")
 }
 
 func Test_getWorkflowHookModelHandler(t *testing.T) {

--- a/ui/src/app/shared/workflow/node/hook/form/node.hook.component.ts
+++ b/ui/src/app/shared/workflow/node/hook/form/node.hook.component.ts
@@ -34,6 +34,7 @@ export class WorkflowNodeHookFormComponent {
             if (this.hooksModel) {
                 this.selectedHookModel = this.hooksModel.find(hm => hm.id === this._hook.model.id);
             }
+            this.displayConfig = Object.keys(this._hook.config).length !== 0;
         }
     }
     get hook() {


### PR DESCRIPTION
The hook configuration was not editable anymore after creation. This commit fixes that behaviour
introduced here https://github.com/ovh/cds/pull/1772/files#diff-0f3bb1aa71e303bfc2caaf71e00493b4R53

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>