### PR TITLE
fix (plugin/plugin-kafka-publish): no async close

### DIFF
--- a/contrib/plugins/plugin-kafka-publish/kafka_ack.go
+++ b/contrib/plugins/plugin-kafka-publish/kafka_ack.go
@@ -65,7 +65,7 @@ func ackFromKafka(kafka, topic, group, user, password string, timeout time.Durat
 	if err != nil {
 		return nil, err
 	}
-	defer partitionOffsetManager.AsyncClose()
+	defer partitionOffsetManager.Close()
 
 	// Start a consumer at next offset
 	offset, _ := partitionOffsetManager.NextOffset()
@@ -73,7 +73,7 @@ func ackFromKafka(kafka, topic, group, user, password string, timeout time.Durat
 	if err != nil {
 		return nil, err
 	}
-	defer partitionConsumer.AsyncClose()
+	defer partitionConsumer.Close()
 
 	// Wait for timeout
 	go func() {

--- a/contrib/plugins/plugin-kafka-publish/kafka_consummer.go
+++ b/contrib/plugins/plugin-kafka-publish/kafka_consummer.go
@@ -85,7 +85,7 @@ func consumeFromKafka(kafka, topic, group, user, password string, gpgPrivatekey,
 	if err != nil {
 		return err
 	}
-	defer partitionOffsetManager.AsyncClose()
+	defer partitionOffsetManager.Close()
 
 	// Start a consumer at next offset
 	offset, _ := partitionOffsetManager.NextOffset()
@@ -93,7 +93,7 @@ func consumeFromKafka(kafka, topic, group, user, password string, gpgPrivatekey,
 	if err != nil {
 		return err
 	}
-	defer partitionConsumer.AsyncClose()
+	defer partitionConsumer.Close()
 
 	// Asynchronously handle message
 	go consumptionHandler(partitionConsumer, topic, partitionOffsetManager, messagesChan, errorsChan)


### PR DESCRIPTION
With async :
calling MarkOffset does not necessarily commit the offset to the backend
store immediately for efficiency reasons, and it may never be committed if
your application crashes

This PR ensure that markOffset is done before stop the worker

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>