### PR TITLE
fix (sdk): espace tag on Container Swift

### DIFF
--- a/engine/worker/builtin_artifact_upload.go
+++ b/engine/worker/builtin_artifact_upload.go
@@ -37,6 +37,12 @@ func runArtifactUpload(w *currentWorker) BuiltInAction {
 				sendLog(res.Reason)
 				return res
 			}
+			if strings.Contains(tag.Value, "{") || strings.Contains(tag.Value, "}") || strings.Contains(tag.Value, " ") {
+				res.Status = sdk.StatusFail.String()
+				res.Reason = fmt.Sprintf("tag variable invalid: %s", tag.Value)
+				sendLog(res.Reason)
+				return res
+			}
 			tag.Value = strings.Replace(tag.Value, "/", "-", -1)
 			tag.Value = url.QueryEscape(tag.Value)
 


### PR DESCRIPTION
This will avoid this:

SwiftStore> Creating new session key for 1111-11111-%!B(MISSING)%!B(MISSING).git.branch%!D(MISSING)%!D(MISSING)trusty5
and error from switf after

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>