### PR TITLE
feat (api): workflow Mutex

### DIFF
--- a/engine/api/application/dao_test.go
+++ b/engine/api/application/dao_test.go
@@ -197,4 +197,5 @@ func TestLoadByWorkflowID(t *testing.T) {
 	assert.Equal(t, 1, len(actuals))
 	assert.Equal(t, app.Name, actuals[0].Name)
 	assert.Equal(t, proj.ID, actuals[0].ProjectID)
+
 }

--- a/engine/api/workflow/dao_node.go
+++ b/engine/api/workflow/dao_node.go
@@ -323,7 +323,7 @@ func postLoadNodeContext(db gorp.SqlExecutor, store cache.Store, ctx *sdk.Workfl
 		ctx.EnvironmentID = sqlContext.EnvID.Int64
 	}
 	if sqlContext.Mutex.Valid {
-		ctx.Mutex = sqlContext.Mutex.Valid
+		ctx.Mutex = sqlContext.Mutex.Bool
 	}
 
 	//Unmarshal payload

--- a/engine/api/workflow/dao_node.go
+++ b/engine/api/workflow/dao_node.go
@@ -152,6 +152,7 @@ type sqlContext struct {
 	DefaultPayload            sql.NullString `db:"default_payload"`
 	DefaultPipelineParameters sql.NullString `db:"default_pipeline_parameters"`
 	Conditions                sql.NullString `db:"conditions"`
+	Mutex                     sql.NullBool   `db:"mutex"`
 }
 
 // UpdateNodeContext updates the node context in database
@@ -159,6 +160,7 @@ func UpdateNodeContext(db gorp.SqlExecutor, c *sdk.WorkflowNodeContext) error {
 	var sqlContext = sqlContext{}
 	sqlContext.ID = c.ID
 	sqlContext.WorkflowNodeID = c.WorkflowNodeID
+	sqlContext.Mutex = sql.NullBool{Bool: c.Mutex, Valid: true}
 
 	// Set ApplicationID in context
 	if c.ApplicationID != 0 {
@@ -271,7 +273,8 @@ func loadNode(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, id int64,
 func LoadNodeContextByNodeName(db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, workflowName, nodeName string) (*sdk.WorkflowNodeContext, error) {
 	dbnc := NodeContext{}
 	query := `
-		SELECT workflow_node_context.id, workflow_node_context.workflow_node_id FROM workflow_node_context
+		SELECT workflow_node_context.id, workflow_node_context.workflow_node_id 
+		FROM workflow_node_context
 		JOIN workflow_node ON workflow_node.id = workflow_node_context.workflow_node_id
 		JOIN workflow ON workflow.id = workflow_node.workflow_id
 		JOIN project ON workflow.project_id = project.id
@@ -310,7 +313,7 @@ func LoadNodeContext(db gorp.SqlExecutor, store cache.Store, nodeID int64) (*sdk
 func postLoadNodeContext(db gorp.SqlExecutor, store cache.Store, ctx *sdk.WorkflowNodeContext) error {
 	var sqlContext = sqlContext{}
 	if err := db.SelectOne(&sqlContext,
-		"select application_id, environment_id, default_payload, default_pipeline_parameters, conditions from workflow_node_context where id = $1", ctx.ID); err != nil {
+		"select application_id, environment_id, default_payload, default_pipeline_parameters, conditions, mutex from workflow_node_context where id = $1", ctx.ID); err != nil {
 		return err
 	}
 	if sqlContext.AppID.Valid {
@@ -318,6 +321,9 @@ func postLoadNodeContext(db gorp.SqlExecutor, store cache.Store, ctx *sdk.Workfl
 	}
 	if sqlContext.EnvID.Valid {
 		ctx.EnvironmentID = sqlContext.EnvID.Int64
+	}
+	if sqlContext.Mutex.Valid {
+		ctx.Mutex = sqlContext.Mutex.Valid
 	}
 
 	//Unmarshal payload

--- a/engine/api/workflow/dao_node_run.go
+++ b/engine/api/workflow/dao_node_run.go
@@ -113,6 +113,7 @@ func fromDBNodeRun(rr NodeRun) (*sdk.WorkflowNodeRun, error) {
 	r.WorkflowRunID = rr.WorkflowRunID
 	r.ID = rr.ID
 	r.WorkflowNodeID = rr.WorkflowNodeID
+	r.WorkflowNodeName = rr.WorkflowNodeName
 	r.Number = rr.Number
 	r.SubNumber = rr.SubNumber
 	r.Status = rr.Status
@@ -189,6 +190,7 @@ func makeDBNodeRun(n sdk.WorkflowNodeRun) (*NodeRun, error) {
 	nodeRunDB.ID = n.ID
 	nodeRunDB.WorkflowRunID = n.WorkflowRunID
 	nodeRunDB.WorkflowNodeID = n.WorkflowNodeID
+	nodeRunDB.WorkflowNodeName = n.WorkflowNodeName
 	nodeRunDB.Number = n.Number
 	nodeRunDB.SubNumber = n.SubNumber
 	nodeRunDB.Status = n.Status
@@ -430,7 +432,7 @@ func PreviousNodeRun(db gorp.SqlExecutor, nr sdk.WorkflowNodeRun, n sdk.Workflow
 	var nodeRun sdk.WorkflowNodeRun
 	var rr = NodeRun{}
 	if err := db.SelectOne(&rr, query, n.Name, workflowID, nr.VCSBranch, nr.Number, nr.WorkflowNodeID, nr.ID); err != nil {
-		return nodeRun, sdk.WrapError(err, "PreviousNodeRun> Cannot load previous RUN: %s [%s %d %s %d]", query, n.Name, workflowID, nr.VCSBranch, nr.Number, nr.WorkflowNodeID)
+		return nodeRun, sdk.WrapError(err, "PreviousNodeRun> Cannot load previous run: %s [%s %d %s %d %d]", query, n.Name, workflowID, nr.VCSBranch, nr.Number, nr.WorkflowNodeID)
 	}
 	pNodeRun, errF := fromDBNodeRun(rr)
 	if errF != nil {

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -158,6 +158,7 @@ func TestInsertSimpleWorkflowWithApplicationAndEnv(t *testing.T) {
 			Context: &sdk.WorkflowNodeContext{
 				Application: &app,
 				Environment: &env,
+				Mutex:       true,
 			},
 		},
 	}
@@ -170,6 +171,8 @@ func TestInsertSimpleWorkflowWithApplicationAndEnv(t *testing.T) {
 	assert.Equal(t, w.ID, w1.ID)
 	assert.Equal(t, w.Root.Context.ApplicationID, w1.Root.Context.ApplicationID)
 	assert.Equal(t, w.Root.Context.EnvironmentID, w1.Root.Context.EnvironmentID)
+	assert.Equal(t, w.Root.Context.Mutex, w1.Root.Context.Mutex)
+
 }
 
 func TestInsertComplexeWorkflowAndExport(t *testing.T) {

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -72,6 +72,8 @@ func TestInsertSimpleWorkflowAndExport(t *testing.T) {
 	assert.Equal(t, w.Root.Pipeline.Name, w1.Root.Pipeline.Name)
 	assertEqualNode(t, w.Root, w1.Root)
 
+	assert.False(t, w1.Root.Context.Mutex)
+
 	ws, err := workflow.LoadAll(db, proj.Key)
 	test.NoError(t, err)
 	assert.Equal(t, 1, len(ws))

--- a/engine/api/workflow/gorp_model.go
+++ b/engine/api/workflow/gorp_model.go
@@ -38,6 +38,7 @@ type NodeRun struct {
 	WorkflowRunID      int64          `db:"workflow_run_id"`
 	ID                 int64          `db:"id"`
 	WorkflowNodeID     int64          `db:"workflow_node_id"`
+	WorkflowNodeName   string         `db:"workflow_node_name"`
 	Number             int64          `db:"num"`
 	SubNumber          int64          `db:"sub_num"`
 	Status             string         `db:"status"`

--- a/engine/api/workflow/process.go
+++ b/engine/api/workflow/process.go
@@ -307,14 +307,15 @@ func processWorkflowNodeRun(dbCopy *gorp.DbMap, db gorp.SqlExecutor, store cache
 	copy(stages, n.Pipeline.Stages)
 
 	run := &sdk.WorkflowNodeRun{
-		LastModified:   time.Now(),
-		Start:          time.Now(),
-		Number:         w.Number,
-		SubNumber:      int64(subnumber),
-		WorkflowRunID:  w.ID,
-		WorkflowNodeID: n.ID,
-		Status:         string(sdk.StatusWaiting),
-		Stages:         stages,
+		LastModified:     time.Now(),
+		Start:            time.Now(),
+		Number:           w.Number,
+		SubNumber:        int64(subnumber),
+		WorkflowRunID:    w.ID,
+		WorkflowNodeID:   n.ID,
+		WorkflowNodeName: n.Name,
+		Status:           string(sdk.StatusWaiting),
+		Stages:           stages,
 	}
 
 	runPayload := map[string]string{}
@@ -551,6 +552,39 @@ func processWorkflowNodeRun(dbCopy *gorp.DbMap, db gorp.SqlExecutor, store cache
 
 	if err := updateWorkflowRun(db, w); err != nil {
 		return true, sdk.WrapError(err, "processWorkflowNodeRun> unable to update workflow run")
+	}
+
+	//Check the context.mutex to know if we are allowed to run it
+	if n.Context.Mutex {
+		log.Info("There is a mutex !")
+		//Check if there are builing workflownoderun with the same workflow_node_name for the same workflow
+		mutexQuery := `select count(1) 
+		from workflow_node_run 
+		join workflow_run on workflow_run.id = workflow_node_run.workflow_run_id
+		join workflow on workflow.id = workflow_run.workflow_id
+		where workflow.id = $1
+		and workflow_node_run.id <> $2
+		and workflow_node_run.workflow_node_name = $3 
+		and workflow_node_run.status = $4`
+		nbMutex, err := db.SelectInt(mutexQuery, n.WorkflowID, run.ID, n.Name, string(sdk.StatusBuilding))
+		if err != nil {
+			return false, sdk.WrapError(err, "processWorkflowNodeRun> unable to check mutexes")
+		}
+		if nbMutex > 0 {
+			log.Debug("processWorkflowNodeRun> Noderun %s processed but not executed because of mutex", n.Name)
+			AddWorkflowRunInfo(w, false, sdk.SpawnMsg{
+				ID:   sdk.MsgWorkflowNodeMutex.ID,
+				Args: []interface{}{n.Name},
+			})
+
+			if err := updateWorkflowRun(db, w); err != nil {
+				return true, sdk.WrapError(err, "processWorkflowNodeRun> unable to update workflow run")
+			}
+
+			//Mutex is locked. exit without error
+			return true, nil
+		}
+		//Mutex is free, continue
 	}
 
 	//Execute the node run !

--- a/engine/sql/073_workflow_mutex.sql
+++ b/engine/sql/073_workflow_mutex.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+ALTER TABLE workflow_node_context ADD COLUMN mutex BOOLEAN DEFAULT FALSE;
+UPDATE workflow_node_context SET mutex = 'false';
+
+ALTER TABLE workflow_node_run ADD COLUMN workflow_node_name text;
+UPDATE workflow_node_run SET workflow_node_name = '';
+
+-- +migrate Down
+ALTER TABLE workflow_node_context DROP COLUMN mutex;
+ALTER TABLE workflow_node_run DROP COLUMN workflow_node_run;
+

--- a/engine/sql/073_workflow_mutex.sql
+++ b/engine/sql/073_workflow_mutex.sql
@@ -2,7 +2,7 @@
 ALTER TABLE workflow_node_context ADD COLUMN mutex BOOLEAN DEFAULT FALSE;
 UPDATE workflow_node_context SET mutex = 'false';
 
-ALTER TABLE workflow_node_run ADD COLUMN workflow_node_name text;
+ALTER TABLE workflow_node_run ADD COLUMN workflow_node_name text DEFAULT '';
 UPDATE workflow_node_run SET workflow_node_name = '';
 
 -- +migrate Down

--- a/sdk/messages.go
+++ b/sdk/messages.go
@@ -69,8 +69,8 @@ var (
 	MsgWorkflowStarting                    = &Message{"MsgWorkflowStarting", trad{FR: "Le workflow %s#%s a été démarré", EN: "Workflow %s#%s has been started"}, nil}
 	MsgWorkflowError                       = &Message{"MsgWorkflowError", trad{FR: "Une erreur est survenue: %v", EN: "An error has occured: %v"}, nil}
 	MsgWorkflowNodeStop                    = &Message{"MsgWorkflowNodeStop", trad{FR: "Le pipeline a été arrété par %s", EN: "The pipeline has been stopped by %s"}, nil}
-	MsgWorkflowNodeMutex                   = &Message{"MsgWorkflowNodeMutex", trad{FR: "Le pipeline %s est en attente de la libération du mutex", EN: "The pipeline %s is waiting for mutex release"}, nil}
-	MsgWorkflowNodeMutexRelease            = &Message{"MsgWorkflowNodeMutexRelease", trad{FR: "Le mutex a été libéré pour le pipeline %s", EN: "The mutex has been released for pipeline %s"}, nil}
+	MsgWorkflowNodeMutex                   = &Message{"MsgWorkflowNodeMutex", trad{FR: "Le pipeline %s est mis en attente tant qu'il est en cours sur un autre run", EN: "The pipeline %s is waiting while it's running on another run"}, nil}
+	MsgWorkflowNodeMutexRelease            = &Message{"MsgWorkflowNodeMutexRelease", trad{FR: "Lancement du pipeline %s", EN: "Triggering pipeline %s"}, nil}
 	MsgWorkflowImportedUpdated             = &Message{"MsgWorkflowImportedUpdated", trad{FR: "Le workflow %s a été mis à jour", EN: "Workflow %s has been updated"}, nil}
 	MsgWorkflowImportedInserted            = &Message{"MsgWorkflowImportedInserted", trad{FR: "Le workflow %s a été créé", EN: "Workflow %s has been created"}, nil}
 )

--- a/sdk/messages.go
+++ b/sdk/messages.go
@@ -69,6 +69,8 @@ var (
 	MsgWorkflowStarting                    = &Message{"MsgWorkflowStarting", trad{FR: "Le workflow %s#%s a été démarré", EN: "Workflow %s#%s has been started"}, nil}
 	MsgWorkflowError                       = &Message{"MsgWorkflowError", trad{FR: "Une erreur est survenue: %v", EN: "An error has occured: %v"}, nil}
 	MsgWorkflowNodeStop                    = &Message{"MsgWorkflowNodeStop", trad{FR: "Le pipeline a été arrété par %s", EN: "The pipeline has been stopped by %s"}, nil}
+	MsgWorkflowNodeMutex                   = &Message{"MsgWorkflowNodeMutex", trad{FR: "Le pipeline %s est en attente de la libération du mutex", EN: "The pipeline %s is waiting for mutex release"}, nil}
+	MsgWorkflowNodeMutexRelease            = &Message{"MsgWorkflowNodeMutexRelease", trad{FR: "Le mutex a été libéré pour le pipeline %s", EN: "The mutex has been released for pipeline %s"}, nil}
 	MsgWorkflowImportedUpdated             = &Message{"MsgWorkflowImportedUpdated", trad{FR: "Le workflow %s a été mis à jour", EN: "Workflow %s has been updated"}, nil}
 	MsgWorkflowImportedInserted            = &Message{"MsgWorkflowImportedInserted", trad{FR: "Le workflow %s a été créé", EN: "Workflow %s has been created"}, nil}
 )
@@ -125,6 +127,8 @@ var Messages = map[string]*Message{
 	MsgWorkflowNodeStop.ID:                    MsgWorkflowNodeStop,
 	MsgWorkflowImportedUpdated.ID:             MsgWorkflowImportedUpdated,
 	MsgWorkflowImportedInserted.ID:            MsgWorkflowImportedInserted,
+	MsgWorkflowNodeMutex.ID:                   MsgWorkflowNodeMutex,
+	MsgWorkflowNodeMutexRelease.ID:            MsgWorkflowNodeMutexRelease,
 }
 
 //Message represent a struc format translated messages

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -686,6 +686,7 @@ type WorkflowNodeContext struct {
 	DefaultPayload            interface{}            `json:"default_payload,omitempty" db:"-"`
 	DefaultPipelineParameters []Parameter            `json:"default_pipeline_parameters,omitempty" db:"-"`
 	Conditions                WorkflowNodeConditions `json:"conditions,omitempty" db:"-"`
+	Mutex                     bool                   `json:"mutex"`
 }
 
 //WorkflowNodeContextDefaultPayloadVCS represents a default payload when a workflow is attached to a repository Webhook

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -92,7 +92,7 @@ type WorkflowNodeRun struct {
 	WorkflowRunID      int64                            `json:"workflow_run_id"`
 	ID                 int64                            `json:"id"`
 	WorkflowNodeID     int64                            `json:"workflow_node_id"`
-	WorkflowNodeName   string                           `json:"workflow_node_string"`
+	WorkflowNodeName   string                           `json:"workflow_node_name"`
 	Number             int64                            `json:"num"`
 	SubNumber          int64                            `json:"subnumber"`
 	Status             string                           `json:"status"`

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -92,6 +92,7 @@ type WorkflowNodeRun struct {
 	WorkflowRunID      int64                            `json:"workflow_run_id"`
 	ID                 int64                            `json:"id"`
 	WorkflowNodeID     int64                            `json:"workflow_node_id"`
+	WorkflowNodeName   string                           `json:"workflow_node_string"`
 	Number             int64                            `json:"num"`
 	SubNumber          int64                            `json:"subnumber"`
 	Status             string                           `json:"status"`


### PR DESCRIPTION
Adding a mutex on a workflow node will let the node run at status `waiting` if the node is already running somewhere else.

Major impacts:

* Persist mutex on workflow node in database
* Added workflow node name in the workflow run for conveniency
* If there is a mutex on a node, avoid call `workflow.execute` on the node run
* At the end of workflow node run, if there is a mutex, try to find other workflow node run for the same node and trigger `workflow.execute` on it

Next:

* We have to discuss about how to manage event channel on mutex release
* UI features will come in another PR