### PR TITLE
feat (worker): worker auto-update

### DIFF
--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -103,7 +103,6 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 		if cmd.Flag("auto-update").Value.String() == "true" {
 			updateCmd(w)(cmd, args)
-			log.Info("Restart worker done") // fake msg
 		}
 		toRun := true
 		for toRun {

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -126,55 +124,14 @@ func execWorker() {
 	args := []string{"run"}
 	args = append(args, os.Args[1:]...)
 	cmd := exec.Command(current, args...)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		sdk.Exit("Error on starting worker (StdoutPipe)", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		sdk.Exit("Error on starting worker (StderrPipe)", err)
-	}
 
-	stdoutreader := bufio.NewReader(stdout)
-	stderrreader := bufio.NewReader(stderr)
-
-	outchan := make(chan bool)
-	go func() {
-		for {
-			line, errs := stdoutreader.ReadString('\n')
-			if errs != nil {
-				stdout.Close()
-				close(outchan)
-				return
-			}
-			if line != "" {
-				fmt.Printf(line)
-			}
-		}
-	}()
-
-	errchan := make(chan bool)
-	go func() {
-		for {
-			line, errs := stderrreader.ReadString('\n')
-			if errs != nil {
-				stderr.Close()
-				close(errchan)
-				return
-			}
-			if line != "" {
-				fmt.Printf(line)
-			}
-
-		}
-	}()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
 		log.Error("start err:%s", err)
 	}
 
-	<-outchan
-	<-errchan
 	if err := cmd.Wait(); err != nil {
 		log.Error("wait err:%s", err)
 	}

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
+	"bufio"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
+	"os/exec"
 
-	"github.com/google/gops/agent"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,10 +43,18 @@ func cmdMain(w *currentWorker) *cobra.Command {
 	pflags.String("hatchery-name", "", "Hatchery Name spawing worker")
 	viper.BindPFlag("hatchery_name", pflags.Lookup("hatchery-name"))
 
-	flags := mainCmd.Flags()
+	initFlagsRun(mainCmd)
 
+	return mainCmd
+}
+
+func initFlagsRun(cmd *cobra.Command) {
+	flags := cmd.Flags()
 	flags.Bool("single-use", false, "Exit after executing an action")
 	viper.BindPFlag("single_use", flags.Lookup("single-use"))
+
+	flags.Bool("auto-update", false, "Auto update worker binary from CDS API")
+	viper.BindPFlag("auto_update", flags.Lookup("auto-update"))
 
 	flags.Bool("force-exit", false, "If single_use=true, force exit. This is useful if it's spawned by an Hatchery (default: worker wait 30min for being killed by hatchery)")
 	viper.BindPFlag("force_exit", flags.Lookup("force-exit"))
@@ -90,318 +94,89 @@ func cmdMain(w *currentWorker) *cobra.Command {
 
 	flags.String("graylog-extra-value", "", "Ex: --graylog-extra-value=xxxx-yyyy")
 	viper.BindPFlag("graylog_extra_value", flags.Lookup("graylog-extra-value"))
-
-	return mainCmd
 }
 
 func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		//Initliaze context
-		ctx := context.Background()
-		ctx, cancel := context.WithCancel(ctx)
+		viper.SetEnvPrefix("cds")
+		viper.AutomaticEnv()
 
-		initViper(w)
-
-		if viper.GetString("log_level") == "debug" {
-			if err := agent.Listen(nil); err != nil {
-				sdk.Exit("Error on starting gops agent", err)
-			}
+		if cmd.Flag("auto-update").Value.String() == "true" {
+			updateCmd(w)(cmd, args)
+			log.Info("Restart worker done") // fake msg
 		}
-
-		hostname, errh := os.Hostname() // no check of err here
-		if errh != nil {
-			hostname = fmt.Sprintf("error compute hostname: %s", errh)
-		}
-		log.Info("What a good time to be alive, I'm in version %s, my hostname is %s", sdk.VERSION, hostname)
-		w.initServer(ctx)
-
-		// Gracefully shutdown connections
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL)
-		defer func() {
-			log.Info("Run signal.Stop. My hostname is %s", hostname)
-			signal.Stop(c)
-			cancel()
-		}()
-
-		go func() {
-			select {
-			case <-c:
-				defer cancel()
-				return
-			case <-ctx.Done():
-				return
-			}
-		}()
-
-		time.AfterFunc(time.Duration(viper.GetInt("ttl"))*time.Minute, func() {
-			if w.nbActionsDone == 0 {
-				log.Debug("Suicide")
-				cancel()
-			}
-		})
-
-		//Register
-		t0 := time.Now()
-		for w.id == "" && ctx.Err() == nil {
-			if t0.Add(6 * time.Minute).Before(time.Now()) {
-				log.Error("Unable to register to CDS. Exiting...")
-				cancel()
-				os.Exit(1)
-			}
-			if err := w.doRegister(); err != nil {
-				log.Error("Unable to register to CDS (%v). Retry", err)
-			}
-			time.Sleep(2 * time.Second)
-		}
-
-		//Register every 10 seconds if we have nothing to do
-		registerTick := time.NewTicker(10 * time.Second)
-
-		// start logger routine with a large buffer
-		w.logger.logChan = make(chan sdk.Log, 100000)
-		go w.logProcessor(ctx)
-
-		// start queue polling
-		pbjobs := make(chan sdk.PipelineBuildJob, 1)
-		wjobs := make(chan sdk.WorkflowNodeJobRun, 1)
-		errs := make(chan error, 1)
-
-		//Before start the loop, take the bookJobID
-		if w.bookedPBJobID != 0 {
-			w.processBookedPBJob(pbjobs)
-		}
-		if w.bookedWJobID != 0 {
-			w.processBookedWJob(wjobs)
-		}
-		if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
-			log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
-		}
-
-		go func(ctx context.Context) {
-			if err := w.client.QueuePolling(ctx, wjobs, pbjobs, errs, 2*time.Second, 0); err != nil {
-				log.Error("Queues polling stopped: %v", err)
-			}
-		}(ctx)
-
-		//Definition of the function which must be called to stop the worker
-		var endFunc = func() {
-			log.Info("Enter endFunc")
-			w.drainLogsAndCloseLogger(ctx)
-			registerTick.Stop()
-			w.unregister()
-			cancel()
-
-			if viper.GetBool("force_exit") {
-				log.Info("Exiting worker with force_exit true")
-				return
-			}
-
-			if w.hatchery.id > 0 {
-				log.Info("Waiting 30min to be killed by hatchery, if not killed, worker will exit")
-				time.Sleep(30 * time.Minute)
-			}
-
-			if err := ctx.Err(); err != nil {
-				log.Error("Exiting worker: %v", err)
+		toRun := true
+		for toRun {
+			execWorker()
+			if viper.GetBool("single_use") {
+				toRun = false
 			} else {
-				log.Info("Exiting worker")
+				log.Info("Restarting worker...")
 			}
 		}
+	}
+}
 
-		go func(errs chan error) {
-			for {
-				select {
-				case err := <-errs:
-					log.Error("An error has occured: %v", err)
-				}
-			}
-		}(errs)
+func execWorker() {
+	current, errExec := os.Executable()
+	if errExec != nil {
+		sdk.Exit("Error on getting current binary worker", errExec)
+	}
 
-		// main loop
+	log.Info("Current binary: %s", current)
+	args := []string{"run"}
+	args = append(args, os.Args[1:]...)
+	cmd := exec.Command(current, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		sdk.Exit("Error on starting worker (StdoutPipe)", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		sdk.Exit("Error on starting worker (StderrPipe)", err)
+	}
+
+	stdoutreader := bufio.NewReader(stdout)
+	stderrreader := bufio.NewReader(stderr)
+
+	outchan := make(chan bool)
+	go func() {
 		for {
-			if ctx.Err() != nil {
-				endFunc()
+			line, errs := stdoutreader.ReadString('\n')
+			if errs != nil {
+				stdout.Close()
+				close(outchan)
 				return
 			}
-
-			select {
-			case <-ctx.Done():
-				endFunc()
-				return
-
-			case j := <-pbjobs:
-				if j.ID == 0 {
-					continue
-				}
-
-				requirementsOK, _ := checkRequirements(w, &j.Job.Action, j.ExecGroups, j.ID)
-
-				t := ""
-				if j.ID == w.bookedPBJobID {
-					t = ", this was my booked job"
-				}
-
-				//Take the job
-				if requirementsOK {
-					log.Debug("checkQueue> Try take the PipelineBuildJob %d%s", j.ID, t)
-					canWorkOnAnotherJob := w.takePipelineBuildJob(ctx, j.ID, j.ID == w.bookedPBJobID)
-					if canWorkOnAnotherJob {
-						continue
-					}
-				} else {
-					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
-						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
-					}
-					log.Debug("Unable to run this pipeline build job, requirements not OK, let's continue %d%s", j.ID, t)
-					continue
-				}
-
-				if !viper.GetBool("single_use") {
-					//Continue
-					log.Debug("PipelineBuildJob is done. single_use to false, keep worker alive")
-					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
-						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
-					}
-					continue
-				}
-
-				// Unregister from engine and stop the register goroutine
-				log.Info("PipelineBuildJob is done. Unregistering...")
-				cancel()
-			case j := <-wjobs:
-				if j.ID == 0 {
-					continue
-				}
-
-				requirementsOK, _ := checkRequirements(w, &j.Job.Action, nil, j.ID)
-				t := ""
-				if j.ID == w.bookedWJobID {
-					t = ", this was my booked job"
-				}
-
-				//Take the job
-				if requirementsOK {
-					log.Debug("checkQueue> Try take the job %d%s", j.ID, t)
-					if canWorkOnAnotherJob, err := w.takeWorkflowJob(ctx, j); err != nil {
-						log.Info("Unable to run this job  %d%s. Take info:%s, continue:%t", j.ID, t, err, canWorkOnAnotherJob)
-						if !canWorkOnAnotherJob {
-							errs <- err
-						} else {
-							continue
-						}
-					}
-				} else {
-					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
-						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
-					}
-					log.Debug("Unable to run this workflow job, requirements not ok, let's continue %d%s", j.ID, t)
-					continue
-				}
-
-				if !viper.GetBool("single_use") {
-					//Continue
-					log.Debug("Job is done. single_use to false, keep worker alive")
-					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
-						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
-					}
-					continue
-				}
-
-				// Unregister from engine
-				log.Info("Job is done. Unregistering...")
-				cancel()
-			case <-registerTick.C:
-				w.doRegister()
+			if line != "" {
+				fmt.Printf(line)
 			}
 		}
-	}
-}
+	}()
 
-func (w *currentWorker) processBookedPBJob(pbjobs chan<- sdk.PipelineBuildJob) {
-	log.Debug("Try to take the pipeline build job %d", w.bookedPBJobID)
-	b, _, err := sdk.Request("GET", fmt.Sprintf("/queue/%d/infos", w.bookedPBJobID), nil)
-	if err != nil {
-		log.Error("Unable to load pipeline build job %d: %v on Request", w.bookedPBJobID, err)
-		return
-	}
+	errchan := make(chan bool)
+	go func() {
+		for {
+			line, errs := stderrreader.ReadString('\n')
+			if errs != nil {
+				stderr.Close()
+				close(errchan)
+				return
+			}
+			if line != "" {
+				fmt.Printf(line)
+			}
 
-	j := &sdk.PipelineBuildJob{}
-	if err := json.Unmarshal(b, j); err != nil {
-		log.Error("Unable to load pipeline build job %d: %v on Unmarshal", w.bookedPBJobID, err)
-		return
-	}
-
-	requirementsOK, errRequirements := checkRequirements(w, &j.Job.Action, j.ExecGroups, w.bookedPBJobID)
-	if !requirementsOK {
-		var details string
-		for _, r := range errRequirements {
-			details += fmt.Sprintf(" %s(%s)", r.Value, r.Type)
 		}
-		infos := []sdk.SpawnInfo{{
-			RemoteTime: time.Now(),
-			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
-		}}
-		if err := sdk.AddSpawnInfosPipelineBuildJob(j.ID, infos); err != nil {
-			log.Warning("Cannot record AddSpawnInfosPipelineBuildJob for job (err spawn): %d %s", j.ID, err)
-		}
-		return
+	}()
+
+	if err := cmd.Start(); err != nil {
+		log.Error("start err:%s", err)
 	}
 
-	// requirementsOK is ok
-	pbjobs <- *j
-}
-
-func (w *currentWorker) processBookedWJob(wjobs chan<- sdk.WorkflowNodeJobRun) {
-	log.Debug("Try to take the workflow node job %d", w.bookedWJobID)
-	wjob, err := w.client.QueueJobInfo(w.bookedWJobID)
-	if err != nil {
-		log.Error("Unable to load workflow node job %d: %v", w.bookedWJobID, err)
-		return
+	<-outchan
+	<-errchan
+	if err := cmd.Wait(); err != nil {
+		log.Error("wait err:%s", err)
 	}
-
-	requirementsOK, errRequirements := checkRequirements(w, &wjob.Job.Action, nil, wjob.ID)
-	if !requirementsOK {
-		var details string
-		for _, r := range errRequirements {
-			details += fmt.Sprintf(" %s(%s)", r.Value, r.Type)
-		}
-		infos := []sdk.SpawnInfo{{
-			RemoteTime: time.Now(),
-			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
-		}}
-		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos); err != nil {
-			log.Warning("Cannot record QueueJobSendSpawnInfo for job (err spawn): %d %s", wjob.ID, err)
-		}
-		return
-	}
-
-	// requirementsOK is ok
-	wjobs <- *wjob
-}
-
-func (w *currentWorker) doRegister() error {
-	if w.id == "" {
-		var info string
-		if w.bookedPBJobID > 0 {
-			info = fmt.Sprintf(", I was born to work on pipeline build job %d", w.bookedPBJobID)
-		}
-		if w.bookedWJobID > 0 {
-			info = fmt.Sprintf(", I was born to work on workflow node job %d", w.bookedWJobID)
-		}
-		log.Info("Registering on CDS engine%s Version:%s", info, sdk.VERSION)
-		form := sdk.WorkerRegistrationForm{
-			Name:         w.status.Name,
-			Token:        w.token,
-			Hatchery:     w.hatchery.id,
-			HatcheryName: w.hatchery.name,
-			ModelID:      w.model.ID,
-		}
-		if err := w.register(form); err != nil {
-			log.Info("Cannot register: %s", err)
-			return err
-		}
-		log.Debug("I am registered, with groupID:%d and model:%v", w.groupID, w.model)
-	}
-	return nil
 }

--- a/engine/worker/cmd_register.go
+++ b/engine/worker/cmd_register.go
@@ -30,7 +30,7 @@ func cmdRegisterRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 			ModelID:      w.model.ID,
 		}
 
-		if err := w.register(form); err != nil {
+		if err := w.register(form, viper.GetBool("auto_update")); err != nil {
 			log.Error("Unable to register worker %s: %v", w.status.Name, err)
 		}
 		if err := w.unregister(); err != nil {

--- a/engine/worker/cmd_register.go
+++ b/engine/worker/cmd_register.go
@@ -30,7 +30,7 @@ func cmdRegisterRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 			ModelID:      w.model.ID,
 		}
 
-		if err := w.register(form, viper.GetBool("auto_update")); err != nil {
+		if err := w.register(form, false); err != nil {
 			log.Error("Unable to register worker %s: %v", w.status.Name, err)
 		}
 		if err := w.unregister(); err != nil {

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -20,7 +20,8 @@ import (
 func cmdRun(w *currentWorker) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "run",
-		Short: "worker run",
+		Short: "worker run.",
+		Long:  "worker run: you should not need this command directly",
 		Run:   runCmd(w),
 	}
 

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -45,10 +45,13 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 
 		hostname, errh := os.Hostname() // no check of err here
 		if errh != nil {
-			hostname = fmt.Sprintf("error compute hostname: %s", errh)
+			sdk.Exit(fmt.Sprintf("error compute hostname: %s", errh))
 		}
-		log.Info("What a good time to be alive, I'm in version %s, my hostname is %s", sdk.VERSION, hostname)
-		log.Info("Auto-update: %t", viper.GetBool("auto_update"))
+		log.Info("CDS Worker starting")
+		log.Info("version: %s", sdk.VERSION)
+		log.Info("hostname: %s", hostname)
+		log.Info("auto-update: %t", viper.GetBool("auto_update"))
+
 		w.initServer(ctx)
 
 		// Gracefully shutdown connections

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/google/gops/agent"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
+)
+
+func cmdRun(w *currentWorker) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "run",
+		Short: "worker run",
+		Run:   runCmd(w),
+	}
+
+	initFlagsRun(c)
+	return c
+}
+
+func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		//Initliaze context
+		ctx := context.Background()
+		ctx, cancel := context.WithCancel(ctx)
+
+		initViper(w)
+
+		if viper.GetString("log_level") == "debug" {
+			if err := agent.Listen(nil); err != nil {
+				sdk.Exit("Error on starting gops agent", err)
+			}
+		}
+
+		hostname, errh := os.Hostname() // no check of err here
+		if errh != nil {
+			hostname = fmt.Sprintf("error compute hostname: %s", errh)
+		}
+		log.Info("What a good time to be alive, I'm in version %s, my hostname is %s", sdk.VERSION, hostname)
+		log.Info("Auto-update: %t", viper.GetBool("auto_update"))
+		w.initServer(ctx)
+
+		// Gracefully shutdown connections
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL)
+		defer func() {
+			log.Info("Run signal.Stop. My hostname is %s", hostname)
+			signal.Stop(c)
+			cancel()
+		}()
+
+		go func() {
+			select {
+			case <-c:
+				defer cancel()
+				return
+			case <-ctx.Done():
+				return
+			}
+		}()
+
+		time.AfterFunc(time.Duration(viper.GetInt("ttl"))*time.Minute, func() {
+			if w.nbActionsDone == 0 {
+				log.Debug("Suicide")
+				cancel()
+			}
+		})
+
+		//Register
+		t0 := time.Now()
+		for w.id == "" && ctx.Err() == nil {
+			if t0.Add(6 * time.Minute).Before(time.Now()) {
+				log.Error("Unable to register to CDS. Exiting...")
+				cancel()
+				os.Exit(1)
+			}
+			if err := w.doRegister(viper.GetBool("auto_update")); err != nil {
+				log.Error("Unable to register to CDS (%v). Retry", err)
+			}
+			time.Sleep(2 * time.Second)
+		}
+
+		//Register every 10 seconds if we have nothing to do
+		registerTick := time.NewTicker(10 * time.Second)
+
+		updateTick := time.NewTicker(5 * time.Minute)
+
+		// start logger routine with a large buffer
+		w.logger.logChan = make(chan sdk.Log, 100000)
+		go w.logProcessor(ctx)
+
+		// start queue polling
+		pbjobs := make(chan sdk.PipelineBuildJob, 1)
+		wjobs := make(chan sdk.WorkflowNodeJobRun, 1)
+		errs := make(chan error, 1)
+
+		//Before start the loop, take the bookJobID
+		if w.bookedPBJobID != 0 {
+			w.processBookedPBJob(pbjobs)
+		}
+		if w.bookedWJobID != 0 {
+			w.processBookedWJob(wjobs)
+		}
+		if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
+			log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
+		}
+
+		go func(ctx context.Context) {
+			if err := w.client.QueuePolling(ctx, wjobs, pbjobs, errs, 2*time.Second, 0); err != nil {
+				log.Error("Queues polling stopped: %v", err)
+			}
+		}(ctx)
+
+		//Definition of the function which must be called to stop the worker
+		var endFunc = func() {
+			log.Info("Enter endFunc")
+			w.drainLogsAndCloseLogger(ctx)
+			registerTick.Stop()
+			updateTick.Stop()
+			w.unregister()
+			cancel()
+
+			if viper.GetBool("force_exit") {
+				log.Info("Exiting worker with force_exit true")
+				return
+			}
+
+			if w.hatchery.id > 0 {
+				log.Info("Waiting 30min to be killed by hatchery, if not killed, worker will exit")
+				time.Sleep(30 * time.Minute)
+			}
+
+			if err := ctx.Err(); err != nil {
+				log.Error("Exiting worker: %v", err)
+			} else {
+				log.Info("Exiting worker")
+			}
+		}
+
+		go func(errs chan error) {
+			for {
+				select {
+				case err := <-errs:
+					log.Error("An error has occured: %v", err)
+				}
+			}
+		}(errs)
+
+		// main loop
+		for {
+			if ctx.Err() != nil {
+				endFunc()
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				endFunc()
+				return
+
+			case j := <-pbjobs:
+				if j.ID == 0 {
+					continue
+				}
+
+				requirementsOK, _ := checkRequirements(w, &j.Job.Action, j.ExecGroups, j.ID)
+
+				t := ""
+				if j.ID == w.bookedPBJobID {
+					t = ", this was my booked job"
+				}
+
+				//Take the job
+				if requirementsOK {
+					log.Debug("checkQueue> Try take the PipelineBuildJob %d%s", j.ID, t)
+					canWorkOnAnotherJob := w.takePipelineBuildJob(ctx, j.ID, j.ID == w.bookedPBJobID)
+					if canWorkOnAnotherJob {
+						continue
+					}
+				} else {
+					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
+						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
+					}
+					log.Debug("Unable to run this pipeline build job, requirements not OK, let's continue %d%s", j.ID, t)
+					continue
+				}
+
+				if !viper.GetBool("single_use") {
+					//Continue
+					log.Debug("PipelineBuildJob is done. single_use to false, keep worker alive")
+					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
+						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
+					}
+					continue
+				}
+
+				// Unregister from engine and stop the register goroutine
+				log.Info("PipelineBuildJob is done. Unregistering...")
+				cancel()
+			case j := <-wjobs:
+				if j.ID == 0 {
+					continue
+				}
+
+				requirementsOK, _ := checkRequirements(w, &j.Job.Action, nil, j.ID)
+				t := ""
+				if j.ID == w.bookedWJobID {
+					t = ", this was my booked job"
+				}
+
+				//Take the job
+				if requirementsOK {
+					log.Debug("checkQueue> Try take the job %d%s", j.ID, t)
+					if canWorkOnAnotherJob, err := w.takeWorkflowJob(ctx, j); err != nil {
+						log.Info("Unable to run this job  %d%s. Take info:%s, continue:%t", j.ID, t, err, canWorkOnAnotherJob)
+						if !canWorkOnAnotherJob {
+							errs <- err
+						} else {
+							continue
+						}
+					}
+				} else {
+					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
+						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
+					}
+					log.Debug("Unable to run this workflow job, requirements not ok, let's continue %d%s", j.ID, t)
+					continue
+				}
+
+				if !viper.GetBool("single_use") {
+					//Continue
+					log.Debug("Job is done. single_use to false, keep worker alive")
+					if err := w.client.WorkerSetStatus(sdk.StatusWaiting); err != nil {
+						log.Error("WorkerSetStatus> error on WorkerSetStatus(sdk.StatusWaiting): %s", err)
+					}
+					continue
+				}
+
+				// Unregister from engine
+				log.Info("Job is done. Unregistering...")
+				cancel()
+			case <-registerTick.C:
+				w.doRegister(viper.GetBool("auto_update"))
+			case <-updateTick.C:
+				w.doUpdate(viper.GetBool("auto_update"))
+			}
+		}
+	}
+}
+
+func (w *currentWorker) processBookedPBJob(pbjobs chan<- sdk.PipelineBuildJob) {
+	log.Debug("Try to take the pipeline build job %d", w.bookedPBJobID)
+	b, _, err := sdk.Request("GET", fmt.Sprintf("/queue/%d/infos", w.bookedPBJobID), nil)
+	if err != nil {
+		log.Error("Unable to load pipeline build job %d: %v on Request", w.bookedPBJobID, err)
+		return
+	}
+
+	j := &sdk.PipelineBuildJob{}
+	if err := json.Unmarshal(b, j); err != nil {
+		log.Error("Unable to load pipeline build job %d: %v on Unmarshal", w.bookedPBJobID, err)
+		return
+	}
+
+	requirementsOK, errRequirements := checkRequirements(w, &j.Job.Action, j.ExecGroups, w.bookedPBJobID)
+	if !requirementsOK {
+		var details string
+		for _, r := range errRequirements {
+			details += fmt.Sprintf(" %s(%s)", r.Value, r.Type)
+		}
+		infos := []sdk.SpawnInfo{{
+			RemoteTime: time.Now(),
+			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
+		}}
+		if err := sdk.AddSpawnInfosPipelineBuildJob(j.ID, infos); err != nil {
+			log.Warning("Cannot record AddSpawnInfosPipelineBuildJob for job (err spawn): %d %s", j.ID, err)
+		}
+		return
+	}
+
+	// requirementsOK is ok
+	pbjobs <- *j
+}
+
+func (w *currentWorker) processBookedWJob(wjobs chan<- sdk.WorkflowNodeJobRun) {
+	log.Debug("Try to take the workflow node job %d", w.bookedWJobID)
+	wjob, err := w.client.QueueJobInfo(w.bookedWJobID)
+	if err != nil {
+		log.Error("Unable to load workflow node job %d: %v", w.bookedWJobID, err)
+		return
+	}
+
+	requirementsOK, errRequirements := checkRequirements(w, &wjob.Job.Action, nil, wjob.ID)
+	if !requirementsOK {
+		var details string
+		for _, r := range errRequirements {
+			details += fmt.Sprintf(" %s(%s)", r.Value, r.Type)
+		}
+		infos := []sdk.SpawnInfo{{
+			RemoteTime: time.Now(),
+			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
+		}}
+		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos); err != nil {
+			log.Warning("Cannot record QueueJobSendSpawnInfo for job (err spawn): %d %s", wjob.ID, err)
+		}
+		return
+	}
+
+	// requirementsOK is ok
+	wjobs <- *wjob
+}
+
+func (w *currentWorker) doUpdate(autoUpdate bool) {
+	if autoUpdate {
+		version, err := w.client.Version()
+		if err != nil {
+			log.Error("Error while getting version from CDS API: %s", err)
+		}
+		if version.Version != sdk.VERSION {
+			sdk.Exit("Exiting this CDS Worker process - auto updating worker")
+		}
+	}
+}
+
+func (w *currentWorker) doRegister(autoUpdate bool) error {
+	if w.id == "" {
+		var info string
+		if w.bookedPBJobID > 0 {
+			info = fmt.Sprintf(", I was born to work on pipeline build job %d", w.bookedPBJobID)
+		}
+		if w.bookedWJobID > 0 {
+			info = fmt.Sprintf(", I was born to work on workflow node job %d", w.bookedWJobID)
+		}
+		log.Info("Registering on CDS engine%s Version:%s", info, sdk.VERSION)
+		form := sdk.WorkerRegistrationForm{
+			Name:         w.status.Name,
+			Token:        w.token,
+			Hatchery:     w.hatchery.id,
+			HatcheryName: w.hatchery.name,
+			ModelID:      w.model.ID,
+		}
+		if err := w.register(form, autoUpdate); err != nil {
+			log.Info("Cannot register: %s", err)
+			return err
+		}
+		log.Debug("I am registered, with groupID:%d and model:%v", w.groupID, w.model)
+	}
+	return nil
+}

--- a/engine/worker/cmd_update.go
+++ b/engine/worker/cmd_update.go
@@ -71,7 +71,7 @@ func updateCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		if err := update.Apply(resp.Body, update.Options{}); err != nil {
 			sdk.Exit("Error while getting updating worker from CDS API: %s\n", err)
 		}
-		fmt.Printf("Update worker done. Please restart your worker\n")
+		fmt.Println("Update worker done.")
 	}
 }
 

--- a/engine/worker/cmd_update.go
+++ b/engine/worker/cmd_update.go
@@ -29,12 +29,14 @@ func updateCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		fmt.Printf("CDS Worker version:%s os:%s architecture:%s\n", sdk.VERSION, runtime.GOOS, runtime.GOARCH)
 
-		var urlBinary string
+		viper.SetEnvPrefix("cds")
+		viper.AutomaticEnv()
 
+		var urlBinary string
 		if !cmdDownloadFromGithub {
 			w.apiEndpoint = viper.GetString("api")
 			if w.apiEndpoint == "" {
-				sdk.Exit("--api not provided, aborting.")
+				sdk.Exit("--api not provided, aborting update.")
 			}
 			w.client = cdsclient.NewWorker(w.apiEndpoint, "download")
 

--- a/engine/worker/main.go
+++ b/engine/worker/main.go
@@ -58,6 +58,7 @@ func main() {
 	cmd.AddCommand(cmdUpload(w))
 	cmd.AddCommand(cmdTmpl(w))
 	cmd.AddCommand(cmdTag(w))
+	cmd.AddCommand(cmdRun(w))
 	cmd.AddCommand(cmdUpdate(w))
 	cmd.AddCommand(cmdExit(w))
 	cmd.AddCommand(cmdVersion)

--- a/engine/worker/register.go
+++ b/engine/worker/register.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Workers need to register to main api so they can run actions
-func (w *currentWorker) register(form sdk.WorkerRegistrationForm) error {
+func (w *currentWorker) register(form sdk.WorkerRegistrationForm, autoUpdate bool) error {
 	log.Info("Registering %s on %s", form.Name, w.apiEndpoint)
 	sdk.InitEndpoint(w.apiEndpoint)
 	sdk.Authorization("")
@@ -42,6 +42,10 @@ func (w *currentWorker) register(form sdk.WorkerRegistrationForm) error {
 	log.Info("%s Registered on %s", form.Name, w.apiEndpoint)
 
 	if !uptodate {
+		if autoUpdate {
+			log.Warning("-=-=-=-=- your worker binary is not up to date %s %s %s. Auto-updating it... -=-=-=-=-", sdk.VERSION, runtime.GOOS, runtime.GOARCH)
+			sdk.Exit("Exiting this cds worker process - auto updating worker")
+		}
 		log.Warning("-=-=-=-=- Please update your worker binary - Worker Version %s %s %s -=-=-=-=-", sdk.VERSION, runtime.GOOS, runtime.GOARCH)
 	}
 


### PR DESCRIPTION
New flag on the main cmd: --auto-update

the command ./worker [args] -> internally os.exec worker run [args]. If auto-update -> update the worker before launch the run cmd. If auto-update -> the run command check each 10min the version on api. If version is != "" : sdk.Exit and the main process will relaunch the worker.

No impact on user / hatchery.

close https://github.com/ovh/cds/issues/870

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
  