### PR TITLE
fix (sdk): interpolate, replace same var prefix

### DIFF
--- a/sdk/interpolate/interpolate.go
+++ b/sdk/interpolate/interpolate.go
@@ -11,6 +11,12 @@ import (
 
 var interpolateRegex = regexp.MustCompile("({{\\.[a-zA-Z0-9._\\-µ|\\s]+}})")
 
+type reverseString []string
+
+func (p reverseString) Len() int           { return len(p) }
+func (p reverseString) Less(i, j int) bool { return p[i] > p[j] }
+func (p reverseString) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
 // Do returns interpolated input with vars
 func Do(input string, vars map[string]string) (string, error) {
 	if !strings.Contains(input, "{{") {
@@ -23,12 +29,11 @@ func Do(input string, vars map[string]string) (string, error) {
 
 	// sort key, to replace the longer variables before
 	// see "same prefix" unit test
-	var keys sort.StringSlice
+	keys := make([]string, len(vars))
 	for k := range vars {
 		keys = append(keys, k)
 	}
-	keys.Sort()                      // short to long
-	sort.Sort(sort.Reverse(keys[:])) // reverse, to get the longer before
+	sort.Sort(reverseString(keys))
 
 	for _, k := range keys {
 		v := vars[k]

--- a/sdk/interpolate/interpolate.go
+++ b/sdk/interpolate/interpolate.go
@@ -30,8 +30,10 @@ func Do(input string, vars map[string]string) (string, error) {
 	// sort key, to replace the longer variables before
 	// see "same prefix" unit test
 	keys := make([]string, len(vars))
+	var i int64
 	for k := range vars {
-		keys = append(keys, k)
+		keys[i] = k
+		i++
 	}
 	sort.Sort(reverseString(keys))
 

--- a/sdk/interpolate/interpolate.go
+++ b/sdk/interpolate/interpolate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -20,7 +21,17 @@ func Do(input string, vars map[string]string) (string, error) {
 	defaults := make(map[string]string, len(vars))
 	empty := make(map[string]string, len(vars))
 
-	for k, v := range vars {
+	// sort key, to replace the longer variables before
+	// see "same prefix" unit test
+	var keys sort.StringSlice
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	keys.Sort()                      // short to long
+	sort.Sort(sort.Reverse(keys[:])) // reverse, to get the longer before
+
+	for _, k := range keys {
+		v := vars[k]
 		kb := strings.Replace(k, ".", "__", -1)
 		// "-"" are not a valid char in go template var name
 		kb = strings.Replace(kb, "-", "µµµ", -1)
@@ -30,7 +41,6 @@ func Do(input string, vars map[string]string) (string, error) {
 		if v == "" {
 			empty[k] = k
 		}
-
 		input = strings.Replace(input, k, kb, -1)
 	}
 

--- a/sdk/interpolate/interpolate_test.go
+++ b/sdk/interpolate/interpolate_test.go
@@ -224,8 +224,7 @@ func TestDo(t *testing.T) {
 			name: "same prefix",
 			args: args{
 				input: `{"HOST": "customer{{.cds.env.lb.prefix}}.{{.cds.env.lb}}"}`,
-				//vars:  map[string]string{"cds.env.lb": "lb", "cds.env.lb.prefix": "myprefix"},
-				vars: map[string]string{"cds.env.lb": "lb", "cds.env.lb.prefix": "myprefix"},
+				vars:  map[string]string{"cds.env.lb": "lb", "cds.env.lb.prefix": "myprefix"},
 			},
 			want: `{"HOST": "customermyprefix.lb"}`,
 		},

--- a/sdk/interpolate/interpolate_test.go
+++ b/sdk/interpolate/interpolate_test.go
@@ -220,6 +220,15 @@ func TestDo(t *testing.T) {
 		}
 		}`,
 		},
+		{
+			name: "same prefix",
+			args: args{
+				input: `{"HOST": "customer{{.cds.env.lb.prefix}}.{{.cds.env.lb}}"}`,
+				//vars:  map[string]string{"cds.env.lb": "lb", "cds.env.lb.prefix": "myprefix"},
+				vars: map[string]string{"cds.env.lb": "lb", "cds.env.lb.prefix": "myprefix"},
+			},
+			want: `{"HOST": "customermyprefix.lb"}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
close #2046

before fix:
Running tool: /Users/yesnault/go/bin/go test -benchmem -run=^$ github.com/ovh/cds/sdk/interpolate -bench ^BenchmarkDo$

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk/interpolate
BenchmarkDo-4   	   10000	    170029 ns/op	   53574 B/op	     546 allocs/op
PASS
ok  	github.com/ovh/cds/sdk/interpolate	1.732s
Success: Benchmarks passed.

Running tool: /Users/yesnault/go/bin/go test -benchmem -run=^$ github.com/ovh/cds/sdk/interpolate -bench ^BenchmarkDoNothing$

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk/interpolate
BenchmarkDoNothing-4   	   50000	     30224 ns/op	   11906 B/op	     247 allocs/op
PASS
ok  	github.com/ovh/cds/sdk/interpolate	1.798s
Success: Benchmarks passed.

---
With fix:

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk/interpolate
BenchmarkDo-4   	   10000	    183572 ns/op	   55689 B/op	     556 allocs/op
PASS
ok  	github.com/ovh/cds/sdk/interpolate	1.867s
Success: Benchmarks passed.

Running tool: /Users/yesnault/go/bin/go test -benchmem -run=^$ github.com/ovh/cds/sdk/interpolate -bench ^BenchmarkDoNothing$

goos: darwin
goarch: amd64
pkg: github.com/ovh/cds/sdk/interpolate
BenchmarkDoNothing-4   	   50000	     30278 ns/op	   11904 B/op	     247 allocs/op
PASS
ok  	github.com/ovh/cds/sdk/interpolate	1.825s
Success: Benchmarks passed.

-----

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>