### PR TITLE
fix (cli): allow insecure also for login and signup

### DIFF
--- a/cli/cds/main.go
+++ b/cli/cds/main.go
@@ -63,6 +63,13 @@ func main() {
 		//Set the config file
 		sdk.CDSConfigFile = internal.ConfigFile
 
+		//Set http client
+		c := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: internal.InsecureSkipVerifyTLS},
+			}}
+		sdk.SetHTTPClient(c)
+
 		//On login command: do nothing
 		if cmd == login.CmdLogin || cmd == login.CmdSignup {
 			return
@@ -81,13 +88,6 @@ func main() {
 
 		//Just one try
 		sdk.SetRetry(1)
-
-		//Set http client
-		c := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: internal.InsecureSkipVerifyTLS},
-			}}
-		sdk.SetHTTPClient(c)
 
 		//Manage warnings
 		if !internal.NoWarnings && cmd != user.Cmd {

--- a/ui/README.md
+++ b/ui/README.md
@@ -5,7 +5,7 @@ CDS/UI is a webclient for CDS
 This project was generated with [angular-cli](https://github.com/angular/angular-cli).
 
 ## Development server
-Run npm start for a dev serveur. 
+Run npm start for a dev server. 
 
 Navigate to `http://localhost:4200/`.
 

--- a/ui/src/assets/i18n/fr.json
+++ b/ui/src/assets/i18n/fr.json
@@ -430,7 +430,7 @@
   "project_added": "Projet créé",
   "project_add_ssh_key": "Générer une clé ssh",
   "project_add_ssh_key_help": "Une clé ssh est généralement utile lorsque vous souhaitez cloner un dépôt Git. CDS peut générer une paire de clé, il ne vous restera qu'à copier / coller la clé publique fournie par CDS dans les clés autorisées sur vos dépôts.",
-  "project_add_group_help": "Les persmissions de Lecture / Écriture / Exécution doivent être positionnées sur ce nouveau projet. Vous pouvez choisir un groupe d'utilisateurs existant ou laisser vide pour que CDS créé automatiquement un nouveau groupe, vous en serez l'administrateur.",
+  "project_add_group_help": "Les permissions de Lecture / Écriture / Exécution doivent être positionnées sur ce nouveau projet. Vous pouvez choisir un groupe d'utilisateurs existant ou laisser vide pour que CDS créé automatiquement un nouveau groupe, vous en serez l'administrateur.",
   "project_applications_list": "Liste des applications du projet : ",
   "project_create": "Création d'un projet",
   "project_deleted": "Projet supprimé",


### PR DESCRIPTION
I can't login to an insecure (self-signed cert) CDS with the cli.

It looks like the code that overrides the http config was added after a check that returns immediately for login or signup (PR #173).

Is there a problem doing that also for login or signup command ?