### PR TITLE
fix (ui): right text color on inverted sui-search

### DIFF
--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -572,9 +572,10 @@ foreignObject {
 // Ovveride of ng2-semantic-ui
 sui-search {
   .ui.input {
-    input {
+    .prompt {
       background-color: transparent;
       border-color: #233332;
+      color: rgba(255, 255, 255, 0.9);
     }
   }
 }


### PR DESCRIPTION
After searching an existing project in the top search navbar, the text color should be inverted too.

The `<sui-search>` component does not allow to override his `<input>` inner child with an 'inverted` class from semantic... 

https://github.com/edcarroll/ng2-semantic-ui/blob/master/src/modules/search/components/search.ts#L19