### PR TITLE
fix (worker): Add insecure flag to worker cmd and overrides worker ht…

### DIFF
--- a/engine/hatchery/local/local.go
+++ b/engine/hatchery/local/local.go
@@ -160,6 +160,7 @@ func (h *HatcheryLocal) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string, 
 	args = append(args, fmt.Sprintf("--name=%s", wName))
 	args = append(args, fmt.Sprintf("--hatchery=%d", h.hatch.ID))
 	args = append(args, fmt.Sprintf("--hatchery-name=%s", h.hatch.Name))
+	args = append(args, fmt.Sprintf("--insecure=%t", h.Config.API.HTTP.Insecure))
 
 	if h.Config.Provision.WorkerLogsOptions.Graylog.Host != "" {
 		args = append(args, fmt.Sprintf("--graylog-host=%s", h.Config.Provision.WorkerLogsOptions.Graylog.Host))

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -26,6 +26,9 @@ func cmdMain(w *currentWorker) *cobra.Command {
 	pflags.String("api", "", "URL of CDS API")
 	viper.BindPFlag("api", pflags.Lookup("api"))
 
+	pflags.Bool("insecure", false, `(SSL) This option explicitly allows curl to perform "insecure" SSL connections and transfers.`)
+	viper.BindPFlag("insecure", pflags.Lookup("insecure"))
+
 	pflags.String("token", "", "CDS Token")
 	viper.BindPFlag("token", pflags.Lookup("token"))
 

--- a/engine/worker/cmd_update.go
+++ b/engine/worker/cmd_update.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"runtime"
+	"time"
 
+	"github.com/facebookgo/httpcontrol"
 	"github.com/inconshreveable/go-update"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,13 +41,18 @@ func updateCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 			if w.apiEndpoint == "" {
 				sdk.Exit("--api not provided, aborting update.")
 			}
-			w.client = cdsclient.NewWorker(w.apiEndpoint, "download", viper.GetBool("insecure"))
+			w.client = cdsclient.NewWorker(w.apiEndpoint, "download", &http.Client{
+				Timeout: time.Second * 10,
+				Transport: &httpcontrol.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: viper.GetBool("insecure")},
+				},
+			})
 
 			urlBinary = w.client.DownloadURLFromAPI("worker", runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("Updating worker binary from CDS API on %s...\n", urlBinary)
 		} else {
 			// no need to have apiEndpoint here
-			w.client = cdsclient.NewWorker("", "download", false)
+			w.client = cdsclient.NewWorker("", "download", nil)
 
 			var errGH error
 			urlBinary, errGH = w.client.DownloadURLFromGithub("worker", runtime.GOOS, runtime.GOARCH)

--- a/engine/worker/cmd_update.go
+++ b/engine/worker/cmd_update.go
@@ -38,13 +38,13 @@ func updateCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 			if w.apiEndpoint == "" {
 				sdk.Exit("--api not provided, aborting update.")
 			}
-			w.client = cdsclient.NewWorker(w.apiEndpoint, "download")
+			w.client = cdsclient.NewWorker(w.apiEndpoint, "download", viper.GetBool("insecure"))
 
 			urlBinary = w.client.DownloadURLFromAPI("worker", runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("Updating worker binary from CDS API on %s...\n", urlBinary)
 		} else {
 			// no need to have apiEndpoint here
-			w.client = cdsclient.NewWorker("", "download")
+			w.client = cdsclient.NewWorker("", "download", false)
 
 			var errGH error
 			urlBinary, errGH = w.client.DownloadURLFromGithub("worker", runtime.GOOS, runtime.GOARCH)

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -83,7 +83,7 @@ func initViper(w *currentWorker) {
 	w.bookedPBJobID = viper.GetInt64("booked_pb_job_id")
 	w.bookedWJobID = viper.GetInt64("booked_workflow_job_id")
 
-	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name)
+	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name, viper.GetBool("insecure"))
 }
 
 func (w *currentWorker) initServer(c context.Context) {

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
+	"time"
 
+	"github.com/facebookgo/httpcontrol"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -83,7 +87,12 @@ func initViper(w *currentWorker) {
 	w.bookedPBJobID = viper.GetInt64("booked_pb_job_id")
 	w.bookedWJobID = viper.GetInt64("booked_workflow_job_id")
 
-	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name, viper.GetBool("insecure"))
+	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name, &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &httpcontrol.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: viper.GetBool("insecure")},
+		},
+	})
 }
 
 func (w *currentWorker) initServer(c context.Context) {

--- a/sdk/cdsclient/client.go
+++ b/sdk/cdsclient/client.go
@@ -48,7 +48,7 @@ func NewService(endpoint string, timeout time.Duration) Interface {
 }
 
 // NewWorker returns client for a worker
-func NewWorker(endpoint string, name string) Interface {
+func NewWorker(endpoint string, name string, insecureSkipVerifyTLS bool) Interface {
 	conf := Config{
 		Host:  endpoint,
 		Retry: 10,
@@ -57,7 +57,18 @@ func NewWorker(endpoint string, name string) Interface {
 	cli.config = conf
 	cli.HTTPClient = &http.Client{
 		Timeout: time.Second * 10,
+		Transport: &httpcontrol.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerifyTLS},
+		},
 	}
+
+	// need to override sdk client to take care of insecure flag
+	sdk.SetHTTPClient(&http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerifyTLS},
+		},
+	})
+
 	cli.isWorker = true
 	cli.name = name
 	cli.init()


### PR DESCRIPTION
Here it is another pull request to deal with self-signed certs.

When starting a local hatchery for a remote CDS instance with self-signed cert, jobs are taken by hatcheries but workers won't start.
 
There is a first error occurs when registering a worker because of the worker's HTTP client. Then when the worker sends job's results there is another issue with the SDK HTTP client.

It seems that I can use the CDS_SKIP_VERIFY env var to override SDK's HTTP client but all env vars that starts with CDS or HATCHERY are not given at worker startup.

This fix works well for me, maybe this is not the best way to fix the bug. Let me know!