### PR TITLE
fix(sdk): ApplicationKeyCreate should return the ApplicationKey returned by the API

### DIFF
--- a/cli/cdsctl/application_key.go
+++ b/cli/cdsctl/application_key.go
@@ -41,7 +41,8 @@ func applicationCreateKeyRun(v cli.Values) error {
 			Type: v["key-type"],
 		},
 	}
-	return client.ApplicationKeyCreate(v[_ProjectKey], v[_ApplicationName], key)
+	_, err := client.ApplicationKeyCreate(v[_ProjectKey], v[_ApplicationName], key)
+	return err
 }
 
 var applicationKeyListCmd = cli.Command{

--- a/sdk/cdsclient/client_application_key.go
+++ b/sdk/cdsclient/client_application_key.go
@@ -14,9 +14,9 @@ func (c *client) ApplicationKeysList(key string, appName string) ([]sdk.Applicat
 	return k, nil
 }
 
-func (c *client) ApplicationKeyCreate(projectKey string, appName string, keyApplication *sdk.ApplicationKey) error {
+func (c *client) ApplicationKeyCreate(projectKey string, appName string, keyApplication *sdk.ApplicationKey) (*sdk.ApplicationKey, error) {
 	_, err := c.PostJSON("/project/"+projectKey+"/application/"+appName+"/keys", keyApplication, keyApplication)
-	return err
+	return keyApplication, err
 }
 
 func (c *client) ApplicationKeysDelete(projectKey string, appName string, keyName string) error {

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -52,7 +52,7 @@ type ApplicationClient interface {
 // ApplicationKeysClient exposes application keys related functions
 type ApplicationKeysClient interface {
 	ApplicationKeysList(projectKey string, appName string) ([]sdk.ApplicationKey, error)
-	ApplicationKeyCreate(projectKey string, appName string, keyApp *sdk.ApplicationKey) error
+	ApplicationKeyCreate(projectKey string, appName string, keyApp *sdk.ApplicationKey) (*sdk.ApplicationKey, error)
 	ApplicationKeysDelete(projectKey string, appName string, KeyAppName string) error
 }
 


### PR DESCRIPTION
close #2218

Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>