### PR TITLE
feat(hatchery): add spawn info when no hatchery can spawn a worker for this job

### DIFF
--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -63,6 +63,7 @@ func (api *API) InitRouter() {
 
 	// Hatchery
 	r.Handle("/hatchery", r.POST(api.registerHatcheryHandler, Auth(false)))
+	r.Handle("/hatchery/count", r.GET(api.hatcheryCountHandler))
 	r.Handle("/hatchery/{id}", r.PUT(api.refreshHatcheryHandler))
 
 	// Hooks
@@ -291,6 +292,7 @@ func (api *API) InitRouter() {
 	r.Handle("/queue/workflows/requirements/errors", r.POST(api.postWorkflowJobRequirementsErrorHandler, NeedWorker()))
 	r.Handle("/queue/workflows/{id}/take", r.POST(api.postTakeWorkflowJobHandler, NeedWorker()))
 	r.Handle("/queue/workflows/{id}/book", r.POST(api.postBookWorkflowJobHandler, NeedHatchery()))
+	r.Handle("/queue/workflows/{id}/attempt", r.POST(api.postIncWorkflowJobAttemptHandler, NeedHatchery()))
 	r.Handle("/queue/workflows/{id}/infos", r.GET(api.getWorkflowJobHandler, NeedWorker()))
 	r.Handle("/queue/workflows/{id}/spawn/infos", r.POST(r.Asynchronous(api.postSpawnInfosWorkflowJobHandler, 3), NeedHatchery()))
 	r.Handle("/queue/workflows/{permID}/result", r.POSTEXECUTE(api.postWorkflowJobResultHandler, NeedWorker()))

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -63,7 +63,7 @@ func (api *API) InitRouter() {
 
 	// Hatchery
 	r.Handle("/hatchery", r.POST(api.registerHatcheryHandler, Auth(false)))
-	r.Handle("/hatchery/count", r.GET(api.hatcheryCountHandler))
+	r.Handle("/hatchery/count/{workflowNodeRunID}", r.GET(api.hatcheryCountHandler))
 	r.Handle("/hatchery/{id}", r.PUT(api.refreshHatcheryHandler))
 
 	// Hooks

--- a/engine/api/hatchery.go
+++ b/engine/api/hatchery.go
@@ -68,10 +68,10 @@ func (api *API) hatcheryCountHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		wfNodeRunID, err := requestVarInt(r, "workflowNodeRunID")
 		if err != nil {
-			return sdk.WrapError(sdk.ErrWorkflowNodeRunJobNotFound, "cannot convert workflow node run ID")
+			return sdk.WrapError(err, "cannot convert workflow node run ID")
 		}
 
-		count, err := hatchery.LoadHatcheriesCount(api.mustDB(), wfNodeRunID)
+		count, err := hatchery.CountHatcheries(api.mustDB(), wfNodeRunID)
 		if err != nil {
 			return sdk.WrapError(err, "hatcheryCountHandler> cannot get hatcheries count")
 		}

--- a/engine/api/hatchery.go
+++ b/engine/api/hatchery.go
@@ -66,10 +66,16 @@ func (api *API) refreshHatcheryHandler() Handler {
 
 func (api *API) hatcheryCountHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		count, err := hatchery.LoadHatcheriesCount(api.mustDB())
+		wfNodeRunID, err := requestVarInt(r, "workflowNodeRunID")
+		if err != nil {
+			return sdk.WrapError(sdk.ErrWorkflowNodeRunJobNotFound, "cannot convert workflow node run ID")
+		}
+
+		count, err := hatchery.LoadHatcheriesCount(api.mustDB(), wfNodeRunID)
 		if err != nil {
 			return sdk.WrapError(err, "hatcheryCountHandler> cannot get hatcheries count")
 		}
+
 		return WriteJSON(w, count, http.StatusOK)
 	}
 }

--- a/engine/api/hatchery.go
+++ b/engine/api/hatchery.go
@@ -63,3 +63,13 @@ func (api *API) refreshHatcheryHandler() Handler {
 		return nil
 	}
 }
+
+func (api *API) hatcheryCountHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		count, err := hatchery.LoadHatcheriesCount(api.mustDB())
+		if err != nil {
+			return sdk.WrapError(err, "hatcheryCountHandler> cannot get hatcheries count")
+		}
+		return WriteJSON(w, count, http.StatusOK)
+	}
+}

--- a/engine/api/hatchery/hatchery.go
+++ b/engine/api/hatchery/hatchery.go
@@ -190,6 +190,11 @@ func LoadHatcheryByNameAndToken(db gorp.SqlExecutor, name, token string) (*sdk.H
 	return &h, nil
 }
 
+// LoadHatcheriesCount retrieves in database the number of hatcheries
+func LoadHatcheriesCount(db gorp.SqlExecutor) (int64, error) {
+	return db.SelectInt("SELECT COUNT(1) FROM hatchery")
+}
+
 // LoadHatcheries retrieves in database all registered hatcheries
 func LoadHatcheries(db gorp.SqlExecutor) ([]sdk.Hatchery, error) {
 	var hatcheries []sdk.Hatchery

--- a/engine/api/hatchery/hatchery.go
+++ b/engine/api/hatchery/hatchery.go
@@ -215,6 +215,31 @@ func LoadHatcheriesCount(db gorp.SqlExecutor, wfNodeRunID int64) (int64, error) 
 	return db.SelectInt(query, wfNodeRunID, group.SharedInfraGroup.ID)
 }
 
+// LoadHatcheriesCountByNodeJobRunID retrieves in database the number of hatcheries given the node job run id
+func LoadHatcheriesCountByNodeJobRunID(db gorp.SqlExecutor, wfNodeJobRunID int64) (int64, error) {
+	query := `
+	SELECT COUNT(1)
+		FROM hatchery
+		WHERE (
+			hatchery.group_id = ANY(
+				SELECT DISTINCT(project_group.group_id)
+					FROM workflow_node_run_job
+						JOIN workflow_node_run ON workflow_node_run.id = workflow_node_run_job.workflow_node_run_id
+						JOIN workflow_run ON workflow_run.id = workflow_node_run.workflow_run_id
+						JOIN workflow ON workflow.id = workflow_run.workflow_id
+						JOIN project ON project.id = workflow.project_id
+						JOIN project_group ON project_group.project_id = project.id
+				WHERE workflow_node_run.id = $1
+				AND project_group.role >= 5
+			)
+			OR
+			hatchery.group_id = $2
+		)
+	`
+
+	return db.SelectInt(query, wfNodeJobRunID, group.SharedInfraGroup.ID)
+}
+
 // LoadHatcheries retrieves in database all registered hatcheries
 func LoadHatcheries(db gorp.SqlExecutor) ([]sdk.Hatchery, error) {
 	var hatcheries []sdk.Hatchery

--- a/engine/api/hatchery/hatchery.go
+++ b/engine/api/hatchery/hatchery.go
@@ -191,8 +191,8 @@ func LoadHatcheryByNameAndToken(db gorp.SqlExecutor, name, token string) (*sdk.H
 	return &h, nil
 }
 
-// LoadHatcheriesCount retrieves in database the number of hatcheries
-func LoadHatcheriesCount(db gorp.SqlExecutor, wfNodeRunID int64) (int64, error) {
+// CountHatcheries retrieves in database the number of hatcheries
+func CountHatcheries(db gorp.SqlExecutor, wfNodeRunID int64) (int64, error) {
 	query := `
 	SELECT COUNT(1)
 		FROM hatchery

--- a/engine/api/hatchery/hatchery.go
+++ b/engine/api/hatchery/hatchery.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-gorp/gorp"
 
+	"github.com/ovh/cds/engine/api/group"
 	"github.com/ovh/cds/engine/api/worker"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/log"
@@ -191,8 +192,27 @@ func LoadHatcheryByNameAndToken(db gorp.SqlExecutor, name, token string) (*sdk.H
 }
 
 // LoadHatcheriesCount retrieves in database the number of hatcheries
-func LoadHatcheriesCount(db gorp.SqlExecutor) (int64, error) {
-	return db.SelectInt("SELECT COUNT(1) FROM hatchery")
+func LoadHatcheriesCount(db gorp.SqlExecutor, wfNodeRunID int64) (int64, error) {
+	query := `
+	SELECT COUNT(1)
+		FROM hatchery
+		WHERE (
+			hatchery.group_id = ANY(
+				SELECT DISTINCT(project_group.group_id)
+					FROM workflow_node_run
+						JOIN workflow_run ON workflow_run.id = workflow_node_run.workflow_run_id
+						JOIN workflow ON workflow.id = workflow_run.workflow_id
+						JOIN project ON project.id = workflow.project_id
+						JOIN project_group ON project_group.project_id = project.id
+				WHERE workflow_node_run.id = $1
+				AND project_group.role >= 5
+			)
+			OR
+			hatchery.group_id = $2
+		)
+	`
+
+	return db.SelectInt(query, wfNodeRunID, group.SharedInfraGroup.ID)
 }
 
 // LoadHatcheries retrieves in database all registered hatcheries

--- a/engine/api/workflow/dao_node_run_job.go
+++ b/engine/api/workflow/dao_node_run_job.go
@@ -243,6 +243,7 @@ func (j *JobRun) PostGet(s gorp.SqlExecutor) error {
 	}
 
 	var hID int64
+	defer rows.Close()
 	for rows.Next() {
 		if err := rows.Scan(&hID); err != nil {
 			return sdk.WrapError(err, "PostGet> cannot scan spawn_attempts")

--- a/engine/api/workflow/execute_node_job_run.go
+++ b/engine/api/workflow/execute_node_job_run.go
@@ -335,6 +335,7 @@ func AddNodeJobAttempt(db gorp.SqlExecutor, id, hatcheryID int64) ([]int64, erro
 
 	rows, err := db.Query("SELECT DISTINCT unnest(spawn_attempts) FROM workflow_node_run_job WHERE id = $1", id)
 	var hID int64
+	defer rows.Close()
 	for rows.Next() {
 		if errS := rows.Scan(&hID); errS != nil {
 			return ids, sdk.WrapError(errS, "AddNodeJobAttempt> cannot scan")

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -197,6 +197,25 @@ func (api *API) postBookWorkflowJobHandler() Handler {
 	}
 }
 
+func (api *API) postIncWorkflowJobAttemptHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		id, errc := requestVarInt(r, "id")
+		if errc != nil {
+			return sdk.WrapError(errc, "postIncWorkflowJobAttemptHandler> invalid id")
+		}
+		h := getHatchery(ctx)
+		if h == nil {
+			return WriteJSON(w, nil, http.StatusUnauthorized)
+		}
+		spawnAttempts, err := workflow.AddNodeJobAttempt(api.mustDB(), id, h.ID)
+		if err != nil {
+			return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> job already booked")
+		}
+
+		return WriteJSON(w, spawnAttempts, http.StatusOK)
+	}
+}
+
 func (api *API) getWorkflowJobHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		id, errc := requestVarInt(r, "id")

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -268,7 +268,7 @@ func (api *API) postSpawnInfosWorkflowJobHandler() AsynchronousHandler {
 			}
 			defer tx.Rollback()
 
-			wfNodeJobRun, errLj := workflow.LoadAndLockNodeJobRunWait(tx, api.Cache, id)
+			wfNodeJobRun, errLj := workflow.LoadNodeJobRun(tx, api.Cache, id)
 			if errLj != nil {
 				return sdk.WrapError(errLj, "addSpawnInfosPipelineBuildJobHandler> Cannot load node job run")
 			}

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -301,18 +301,18 @@ func (api *API) postSpawnInfosWorkflowJobHandler() AsynchronousHandler {
 			return sdk.WrapError(errP, "postSpawnInfosWorkflowJobHandler> Cannot load project")
 		}
 
-		tx1, errBegin := api.mustDB().Begin()
+		tx, errBegin := api.mustDB().Begin()
 		if errBegin != nil {
 			return sdk.WrapError(errBegin, "postSpawnInfosWorkflowJobHandler> Cannot start transaction")
 		}
-		defer tx1.Rollback()
+		defer tx.Rollback()
 
-		if err := workflow.AddSpawnInfosNodeJobRun(tx1, api.Cache, p, id, s); err != nil {
+		if err := workflow.AddSpawnInfosNodeJobRun(tx, api.Cache, p, id, s); err != nil {
 			return sdk.WrapError(err, "postSpawnInfosWorkflowJobHandler> Cannot save spawn info on node job run %d", id)
 		}
 
-		if err := tx1.Commit(); err != nil {
-			return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot commit tx1")
+		if err := tx.Commit(); err != nil {
+			return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot commit tx")
 		}
 
 		return nil

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovh/venom"
 
 	"github.com/ovh/cds/engine/api/cache"
+	"github.com/ovh/cds/engine/api/hatchery"
 	"github.com/ovh/cds/engine/api/project"
 	"github.com/ovh/cds/engine/api/worker"
 	"github.com/ovh/cds/engine/api/workflow"
@@ -212,6 +213,60 @@ func (api *API) postIncWorkflowJobAttemptHandler() Handler {
 			return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> job already booked")
 		}
 
+		hCount, err := hatchery.LoadHatcheriesCountByNodeJobRunID(api.mustDB(), id)
+		if err != nil {
+			return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> cannot get hatcheries count")
+		}
+
+		if int64(len(spawnAttempts)) >= hCount {
+			infos := []sdk.SpawnInfo{
+				{
+					RemoteTime: time.Now(),
+					Message: sdk.SpawnMsg{
+						ID:   sdk.MsgSpawnInfoHatcheryCannotStartJob.ID,
+						Args: []interface{}{},
+					},
+				},
+			}
+
+			p, errP := project.LoadProjectByNodeJobRunID(api.mustDB(), api.Cache, id, getUser(ctx), project.LoadOptions.WithVariables)
+			if errP != nil {
+				return sdk.WrapError(errP, "postIncWorkflowJobAttemptHandler> Cannot load project")
+			}
+
+			tx, errBegin := api.mustDB().Begin()
+			if errBegin != nil {
+				return sdk.WrapError(errBegin, "postIncWorkflowJobAttemptHandler> Cannot start transaction")
+			}
+			defer tx.Rollback()
+
+			if err := workflow.AddSpawnInfosNodeJobRun(tx, api.Cache, p, id, infos); err != nil {
+				return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> Cannot save spawn info on node job run %d", id)
+			}
+
+			wfNodeJobRun, errLj := workflow.LoadNodeJobRun(tx, api.Cache, id)
+			if errLj != nil {
+				return sdk.WrapError(errLj, "postIncWorkflowJobAttemptHandler> Cannot load node job run")
+			}
+
+			wfNodeRun, errLr := workflow.LoadAndLockNodeRunByID(tx, wfNodeJobRun.WorkflowNodeRunID, true)
+			if errLr != nil {
+				return sdk.WrapError(errLr, "postIncWorkflowJobAttemptHandler> Cannot load node run")
+			}
+
+			if found, err := workflow.SyncNodeRunRunJob(tx, wfNodeRun, *wfNodeJobRun); err != nil || !found {
+				return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> Cannot sync run job (found=%v)", found)
+			}
+
+			if err := workflow.UpdateNodeRun(tx, wfNodeRun); err != nil {
+				return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> Cannot update node job run")
+			}
+
+			if err := tx.Commit(); err != nil {
+				return sdk.WrapError(err, "postIncWorkflowJobAttemptHandler> Cannot commit tx")
+			}
+		}
+
 		return WriteJSON(w, spawnAttempts, http.StatusOK)
 	}
 }
@@ -232,7 +287,6 @@ func (api *API) getWorkflowJobHandler() Handler {
 
 func (api *API) postSpawnInfosWorkflowJobHandler() AsynchronousHandler {
 	return func(ctx context.Context, r *http.Request) error {
-		resync := FormBool(r, "resync")
 		id, errc := requestVarInt(r, "id")
 		if errc != nil {
 			return sdk.WrapError(errc, "postSpawnInfosWorkflowJobHandler> invalid id")
@@ -259,36 +313,6 @@ func (api *API) postSpawnInfosWorkflowJobHandler() AsynchronousHandler {
 
 		if err := tx1.Commit(); err != nil {
 			return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot commit tx1")
-		}
-
-		if resync {
-			tx, errBegin := api.mustDB().Begin()
-			if errBegin != nil {
-				return sdk.WrapError(errBegin, "postSpawnInfosWorkflowJobHandler> Cannot start transaction")
-			}
-			defer tx.Rollback()
-
-			wfNodeJobRun, errLj := workflow.LoadNodeJobRun(tx, api.Cache, id)
-			if errLj != nil {
-				return sdk.WrapError(errLj, "addSpawnInfosPipelineBuildJobHandler> Cannot load node job run")
-			}
-
-			wfNodeRun, errLr := workflow.LoadAndLockNodeRunByID(tx, wfNodeJobRun.WorkflowNodeRunID, true)
-			if errLr != nil {
-				return sdk.WrapError(errLr, "addSpawnInfosPipelineBuildJobHandler> Cannot load node run")
-			}
-
-			if _, err := workflow.SyncNodeRunRunJob(tx, wfNodeRun, *wfNodeJobRun); err != nil {
-				return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot sync run job")
-			}
-
-			if err := workflow.UpdateNodeRun(tx, wfNodeRun); err != nil {
-				return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot update node job run")
-			}
-
-			if err := tx.Commit(); err != nil {
-				return sdk.WrapError(err, "addSpawnInfosPipelineBuildJobHandler> Cannot commit tx")
-			}
 		}
 
 		return nil

--- a/engine/sql/080_workflow_node_run_job_spawn_attempts.sql
+++ b/engine/sql/080_workflow_node_run_job_spawn_attempts.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE workflow_node_run_job ADD COLUMN spawn_attempts bigint[];
+
+-- +migrate Down
+ALTER TABLE workflow_node_run_job DROP COLUMN spawn_attempts;

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -315,7 +315,7 @@ func (w *currentWorker) processBookedWJob(wjobs chan<- sdk.WorkflowNodeJobRun) {
 			RemoteTime: time.Now(),
 			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
 		}}
-		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos, false); err != nil {
+		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos); err != nil {
 			log.Warning("Cannot record QueueJobSendSpawnInfo for job (err spawn): %d %s", wjob.ID, err)
 		}
 		return

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -315,7 +315,7 @@ func (w *currentWorker) processBookedWJob(wjobs chan<- sdk.WorkflowNodeJobRun) {
 			RemoteTime: time.Now(),
 			Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoWorkerForJobError.ID, Args: []interface{}{w.status.Name, details}},
 		}}
-		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos); err != nil {
+		if err := w.client.QueueJobSendSpawnInfo(true, wjob.ID, infos, false); err != nil {
 			log.Warning("Cannot record QueueJobSendSpawnInfo for job (err spawn): %d %s", wjob.ID, err)
 		}
 		return

--- a/sdk/cdsclient/client_hatchery.go
+++ b/sdk/cdsclient/client_hatchery.go
@@ -35,3 +35,14 @@ func (c *client) HatcheryRefresh(id int64) error {
 	}
 	return nil
 }
+
+func (c *client) HatcheryCount() (int64, error) {
+	var hatcheriesCount int64
+	code, err := c.GetJSON("/hatchery/count", &hatcheriesCount)
+	if code > 300 && err == nil {
+		return hatcheriesCount, fmt.Errorf("HatcheryCount> HTTP %d", code)
+	} else if err != nil {
+		return hatcheriesCount, sdk.WrapError(err, "HatcheryCount> Error")
+	}
+	return hatcheriesCount, nil
+}

--- a/sdk/cdsclient/client_hatchery.go
+++ b/sdk/cdsclient/client_hatchery.go
@@ -36,9 +36,9 @@ func (c *client) HatcheryRefresh(id int64) error {
 	return nil
 }
 
-func (c *client) HatcheryCount() (int64, error) {
+func (c *client) HatcheryCount(workflowNodeRunID int64) (int64, error) {
 	var hatcheriesCount int64
-	code, err := c.GetJSON("/hatchery/count", &hatcheriesCount)
+	code, err := c.GetJSON(fmt.Sprintf("/hatchery/count/%d", workflowNodeRunID), &hatcheriesCount)
 	if code > 300 && err == nil {
 		return hatcheriesCount, fmt.Errorf("HatcheryCount> HTTP %d", code)
 	} else if err != nil {

--- a/sdk/cdsclient/client_queue.go
+++ b/sdk/cdsclient/client_queue.go
@@ -162,12 +162,17 @@ func (c *client) QueueJobInfo(id int64) (*sdk.WorkflowNodeJobRun, error) {
 }
 
 // QueueJobSendSpawnInfo sends a spawn info on a job
-func (c *client) QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo) error {
+func (c *client) QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo, resync bool) error {
 	path := fmt.Sprintf("/queue/workflows/%d/spawn/infos", id)
 	if !isWorkflowJob {
 		// DEPRECATED code -> it's for pipelineBuildJob
 		path = fmt.Sprintf("/queue/%d/spawn/infos", id)
 	}
+
+	if resync {
+		path += "?resync=true"
+	}
+
 	_, err := c.PostJSON(path, &in, nil)
 	return err
 }

--- a/sdk/cdsclient/client_queue.go
+++ b/sdk/cdsclient/client_queue.go
@@ -172,6 +172,14 @@ func (c *client) QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.Sp
 	return err
 }
 
+// QueueJobIncAttemps add hatcheryID that cannot run this job and return the spawn attempts list
+func (c *client) QueueJobIncAttemps(jobID int64) ([]int64, error) {
+	var spawnAttempts []int64
+	path := fmt.Sprintf("/queue/workflows/%d/attempt", jobID)
+	_, err := c.PostJSON(path, nil, &spawnAttempts)
+	return spawnAttempts, err
+}
+
 // QueueJobBook books a job for a Hatchery
 func (c *client) QueueJobBook(isWorkflowJob bool, id int64) error {
 	path := fmt.Sprintf("/queue/workflows/%d/book", id)

--- a/sdk/cdsclient/client_queue.go
+++ b/sdk/cdsclient/client_queue.go
@@ -162,23 +162,19 @@ func (c *client) QueueJobInfo(id int64) (*sdk.WorkflowNodeJobRun, error) {
 }
 
 // QueueJobSendSpawnInfo sends a spawn info on a job
-func (c *client) QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo, resync bool) error {
+func (c *client) QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo) error {
 	path := fmt.Sprintf("/queue/workflows/%d/spawn/infos", id)
 	if !isWorkflowJob {
 		// DEPRECATED code -> it's for pipelineBuildJob
 		path = fmt.Sprintf("/queue/%d/spawn/infos", id)
 	}
 
-	if resync {
-		path += "?resync=true"
-	}
-
 	_, err := c.PostJSON(path, &in, nil)
 	return err
 }
 
-// QueueJobIncAttemps add hatcheryID that cannot run this job and return the spawn attempts list
-func (c *client) QueueJobIncAttemps(jobID int64) ([]int64, error) {
+// QueueJobIncAttempts add hatcheryID that cannot run this job and return the spawn attempts list
+func (c *client) QueueJobIncAttempts(jobID int64) ([]int64, error) {
 	var spawnAttempts []int64
 	path := fmt.Sprintf("/queue/workflows/%d/attempt", jobID)
 	_, err := c.PostJSON(path, nil, &spawnAttempts)

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -127,6 +127,7 @@ type GroupClient interface {
 type HatcheryClient interface {
 	HatcheryRefresh(int64) error
 	HatcheryRegister(sdk.Hatchery) (*sdk.Hatchery, bool, error)
+	HatcheryCount() (int64, error)
 }
 
 // PipelineClient exposes pipelines related functions
@@ -178,6 +179,7 @@ type QueueClient interface {
 	QueueSendResult(int64, sdk.Result) error
 	QueueArtifactUpload(id int64, tag, filePath string) (bool, time.Duration, error)
 	QueueJobTag(jobID int64, tags []sdk.WorkflowRunTag) error
+	QueueJobIncAttemps(jobID int64) ([]int64, error)
 }
 
 // UserClient exposes users functions

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -175,11 +175,11 @@ type QueueClient interface {
 	QueueTakeJob(sdk.WorkflowNodeJobRun, bool) (*worker.WorkflowNodeJobRunInfo, error)
 	QueueJobBook(isWorkflowJob bool, id int64) error
 	QueueJobInfo(id int64) (*sdk.WorkflowNodeJobRun, error)
-	QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo, resync bool) error
+	QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo) error
 	QueueSendResult(int64, sdk.Result) error
 	QueueArtifactUpload(id int64, tag, filePath string) (bool, time.Duration, error)
 	QueueJobTag(jobID int64, tags []sdk.WorkflowRunTag) error
-	QueueJobIncAttemps(jobID int64) ([]int64, error)
+	QueueJobIncAttempts(jobID int64) ([]int64, error)
 }
 
 // UserClient exposes users functions

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -127,7 +127,7 @@ type GroupClient interface {
 type HatcheryClient interface {
 	HatcheryRefresh(int64) error
 	HatcheryRegister(sdk.Hatchery) (*sdk.Hatchery, bool, error)
-	HatcheryCount() (int64, error)
+	HatcheryCount(wfNodeRunID int64) (int64, error)
 }
 
 // PipelineClient exposes pipelines related functions
@@ -175,7 +175,7 @@ type QueueClient interface {
 	QueueTakeJob(sdk.WorkflowNodeJobRun, bool) (*worker.WorkflowNodeJobRunInfo, error)
 	QueueJobBook(isWorkflowJob bool, id int64) error
 	QueueJobInfo(id int64) (*sdk.WorkflowNodeJobRun, error)
-	QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo) error
+	QueueJobSendSpawnInfo(isWorkflowJob bool, id int64, in []sdk.SpawnInfo, resync bool) error
 	QueueSendResult(int64, sdk.Result) error
 	QueueArtifactUpload(id int64, tag, filePath string) (bool, time.Duration, error)
 	QueueJobTag(jobID int64, tags []sdk.WorkflowRunTag) error

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -114,25 +114,25 @@ func CheckRequirement(r sdk.Requirement) (bool, error) {
 	}
 }
 
-func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID int64, jobQueuedSeconds int64, jobSpawnAttempts []int64, jobBookedBy sdk.Hatchery, requirements []sdk.Requirement, models []sdk.Model, nRoutines *int64, spawnIDs *cache.Cache, hostname string) bool {
+func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID int64, jobQueuedSeconds int64, jobSpawnAttempts []int64, jobBookedBy sdk.Hatchery, requirements []sdk.Requirement, models []sdk.Model, nRoutines *int64, spawnIDs *cache.Cache, hostname string) (bool, error) {
 	if jobID == 0 {
-		return false
+		return false, nil
 	}
 
 	n := atomic.LoadInt64(nRoutines)
 	if n > 10 {
 		log.Info("too many routines in same time %d", n)
-		return false
+		return false, nil
 	}
 
 	if _, exist := spawnIDs.Get(string(jobID)); exist {
 		log.Debug("job %d already spawned in previous routine", jobID)
-		return false
+		return false, nil
 	}
 
 	if jobQueuedSeconds < int64(h.Configuration().Provision.GraceTimeQueued) {
 		log.Debug("job %d is too fresh, queued since %d seconds, let existing waiting worker check it", jobID, jobQueuedSeconds)
-		return false
+		return false, nil
 	}
 
 	log.Debug("work on job %d queued since %d seconds", jobID, jobQueuedSeconds)
@@ -142,7 +142,7 @@ func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID i
 			t = "another hatchery"
 		}
 		log.Debug("job %d already booked by %s %s (%d)", jobID, t, jobBookedBy.Name, jobBookedBy.ID)
-		return false
+		return false, nil
 	}
 
 	atomic.AddInt64(nRoutines, 1)
@@ -150,9 +150,9 @@ func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID i
 	isSpawned, errR := routine(h, isWorkflowJob, models, execGroups, jobID, requirements, hostname, time.Now().Unix())
 	if errR != nil {
 		log.Warning("Error on routine: %s", errR)
-		return false
+		return false, errR
 	}
-	return isSpawned
+	return isSpawned, nil
 }
 
 func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []sdk.Group, jobID int64, requirements []sdk.Requirement, hostname string, timestamp int64) (bool, error) {
@@ -192,7 +192,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 					RemoteTime: time.Now(),
 					Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoHatcheryErrorSpawn.ID, Args: []interface{}{fmt.Sprintf("%s", h.Hatchery().Name), fmt.Sprintf("%d", h.Hatchery().ID), model.Name, sdk.Round(time.Since(start), time.Second).String(), errSpawn.Error()}},
 				})
-				if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos); err != nil {
+				if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos, false); err != nil {
 					log.Warning("routine> %d - cannot client.QueueJobSendSpawnInfo for job (err spawn)%d: %s", timestamp, jobID, err)
 				}
 				if err := h.Client().WorkerModelSpawnError(model.ID, fmt.Sprintf("routine> cannot spawn worker %s for job %d: %s", model.Name, jobID, errSpawn)); err != nil {
@@ -212,7 +212,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 				},
 			})
 
-			if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos); err != nil {
+			if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos, false); err != nil {
 				log.Warning("routine> %d - cannot client.QueueJobSendSpawnInfo for job %d: %s", timestamp, jobID, err)
 			}
 			return true, nil // ok for this job

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -114,7 +114,7 @@ func CheckRequirement(r sdk.Requirement) (bool, error) {
 	}
 }
 
-func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID int64, jobQueuedSeconds int64, jobBookedBy sdk.Hatchery, requirements []sdk.Requirement, models []sdk.Model, nRoutines *int64, spawnIDs *cache.Cache, hostname string) bool {
+func receiveJob(h Interface, isWorkflowJob bool, execGroups []sdk.Group, jobID int64, jobQueuedSeconds int64, jobSpawnAttempts []int64, jobBookedBy sdk.Hatchery, requirements []sdk.Requirement, models []sdk.Model, nRoutines *int64, spawnIDs *cache.Cache, hostname string) bool {
 	if jobID == 0 {
 		return false
 	}

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -192,7 +192,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 					RemoteTime: time.Now(),
 					Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoHatcheryErrorSpawn.ID, Args: []interface{}{fmt.Sprintf("%s", h.Hatchery().Name), fmt.Sprintf("%d", h.Hatchery().ID), model.Name, sdk.Round(time.Since(start), time.Second).String(), errSpawn.Error()}},
 				})
-				if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos, false); err != nil {
+				if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos); err != nil {
 					log.Warning("routine> %d - cannot client.QueueJobSendSpawnInfo for job (err spawn)%d: %s", timestamp, jobID, err)
 				}
 				if err := h.Client().WorkerModelSpawnError(model.ID, fmt.Sprintf("routine> cannot spawn worker %s for job %d: %s", model.Name, jobID, errSpawn)); err != nil {
@@ -212,7 +212,7 @@ func routine(h Interface, isWorkflowJob bool, models []sdk.Model, execGroups []s
 				},
 			})
 
-			if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos, false); err != nil {
+			if err := h.Client().QueueJobSendSpawnInfo(isWorkflowJob, jobID, infos); err != nil {
 				log.Warning("routine> %d - cannot client.QueueJobSendSpawnInfo for job %d: %s", timestamp, jobID, err)
 			}
 			return true, nil // ok for this job

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -110,7 +110,7 @@ func Create(h Interface) {
 			}
 			go func(job sdk.PipelineBuildJob) {
 				atomic.AddInt64(&workersStarted, 1)
-				if isRun := receiveJob(h, false, job.ExecGroups, job.ID, job.QueuedSeconds, job.BookedBy, job.Job.Action.Requirements, models, &nRoutines, spawnIDs, hostname); isRun {
+				if isRun := receiveJob(h, false, job.ExecGroups, job.ID, job.QueuedSeconds, []int64{}, job.BookedBy, job.Job.Action.Requirements, models, &nRoutines, spawnIDs, hostname); isRun {
 					spawnIDs.SetDefault(string(job.ID), job.ID)
 				} else {
 					atomic.AddInt64(&workersStarted, -1)
@@ -125,11 +125,34 @@ func Create(h Interface) {
 				// count + 1 here, and remove -1 if worker is not started
 				// this avoid to spawn to many workers compare
 				atomic.AddInt64(&workersStarted, 1)
-				if isRun := receiveJob(h, true, nil, job.ID, job.QueuedSeconds, job.BookedBy, job.Job.Action.Requirements, models, &nRoutines, spawnIDs, hostname); isRun {
+				if isRun := receiveJob(h, true, nil, job.ID, job.QueuedSeconds, job.SpawnAttempts, job.BookedBy, job.Job.Action.Requirements, models, &nRoutines, spawnIDs, hostname); isRun {
 					atomic.AddInt64(&workersStarted, 1)
 					spawnIDs.SetDefault(string(job.ID), job.ID)
 				} else {
 					atomic.AddInt64(&workersStarted, -1)
+
+					if hCount, err := h.Client().HatcheryCount(); err == nil {
+						if int64(len(job.SpawnAttempts)) < hCount {
+							spawnAttempts, errQ := h.Client().QueueJobIncAttemps(job.ID)
+							if errQ == nil && int64(len(spawnAttempts)) >= hCount {
+								infos := []sdk.SpawnInfo{
+									{
+										RemoteTime: time.Now(),
+										Message: sdk.SpawnMsg{
+											ID:   sdk.MsgSpawnInfoHatcheryCannotStartJob.ID,
+											Args: []interface{}{},
+										},
+									},
+								}
+
+								if errS := h.Client().QueueJobSendSpawnInfo(true, job.ID, infos); errS != nil {
+									log.Warning("Hatchery> Create> cannot client.QueueJobSendSpawnInfo for job %d: %s", job.ID, errS)
+								}
+							}
+						}
+					} else {
+						log.Warning("Hatchery> Create> cannot get hatchery count %s", err)
+					}
 				}
 			}(j)
 		case err := <-errs:

--- a/sdk/messages.go
+++ b/sdk/messages.go
@@ -74,7 +74,7 @@ var (
 	MsgWorkflowNodeMutexRelease            = &Message{"MsgWorkflowNodeMutexRelease", trad{FR: "Lancement du pipeline %s", EN: "Triggering pipeline %s"}, nil}
 	MsgWorkflowImportedUpdated             = &Message{"MsgWorkflowImportedUpdated", trad{FR: "Le workflow %s a été mis à jour", EN: "Workflow %s has been updated"}, nil}
 	MsgWorkflowImportedInserted            = &Message{"MsgWorkflowImportedInserted", trad{FR: "Le workflow %s a été créé", EN: "Workflow %s has been created"}, nil}
-	MsgSpawnInfoHatcheryCannotStartJob     = &Message{"MsgSpawnInfoHatcheryCannotStart", trad{FR: "Aucune hatchery n'a pu démarrer de worker correspondant à vos pré-requis de job. Vérifiez que vos pré-requis de job soient corrects.", EN: "No hatchery can spawn a worker corresponding your job's requirements. Please check your job's requirements."}, nil}
+	MsgSpawnInfoHatcheryCannotStartJob     = &Message{"MsgSpawnInfoHatcheryCannotStart", trad{FR: "Aucune hatchery n'a pu démarrer de worker respectant vos pré-requis de job, merci de les vérifier.", EN: "No hatchery can spawn a worker corresponding your job's requirements. Please check your job's requirements."}, nil}
 )
 
 // Messages contains all sdk Messages

--- a/sdk/messages.go
+++ b/sdk/messages.go
@@ -74,6 +74,7 @@ var (
 	MsgWorkflowNodeMutexRelease            = &Message{"MsgWorkflowNodeMutexRelease", trad{FR: "Lancement du pipeline %s", EN: "Triggering pipeline %s"}, nil}
 	MsgWorkflowImportedUpdated             = &Message{"MsgWorkflowImportedUpdated", trad{FR: "Le workflow %s a été mis à jour", EN: "Workflow %s has been updated"}, nil}
 	MsgWorkflowImportedInserted            = &Message{"MsgWorkflowImportedInserted", trad{FR: "Le workflow %s a été créé", EN: "Workflow %s has been created"}, nil}
+	MsgSpawnInfoHatcheryCannotStartJob     = &Message{"MsgSpawnInfoHatcheryCannotStart", trad{FR: "Aucune hatchery n'a pu démarrer de worker correspondant à vos pré-requis de job. Vérifiez que vos pré-requis de job soient corrects.", EN: "No hatchery can spawn a worker corresponding your job's requirements. Please check your job's requirements."}, nil}
 )
 
 // Messages contains all sdk Messages
@@ -130,6 +131,7 @@ var Messages = map[string]*Message{
 	MsgWorkflowImportedInserted.ID:            MsgWorkflowImportedInserted,
 	MsgWorkflowNodeMutex.ID:                   MsgWorkflowNodeMutex,
 	MsgWorkflowNodeMutexRelease.ID:            MsgWorkflowNodeMutexRelease,
+	MsgSpawnInfoHatcheryCannotStartJob.ID:     MsgSpawnInfoHatcheryCannotStartJob,
 }
 
 //Message represent a struc format translated messages

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -164,6 +164,7 @@ type WorkflowNodeJobRun struct {
 	Parameters        []Parameter `json:"parameters,omitempty" db:"-"`
 	Status            string      `json:"status"  db:"status"`
 	Retry             int         `json:"retry"  db:"retry"`
+	SpawnAttempts     []int64     `json:"spawn_attempts,omitempty"  db:"-"`
 	Queued            time.Time   `json:"queued,omitempty" db:"queued"`
 	QueuedSeconds     int64       `json:"queued_seconds,omitempty" db:"-"`
 	Start             time.Time   `json:"start,omitempty" db:"start"`


### PR DESCRIPTION
Useful to inform user that no hatchery can spawn his worker.

The logic behind is that I count the number of hatchery, if each hatchery tried to spawn the worker but without success then I push a spawn info to inform user that we can't spawn his worker.

Signed-off-by: Benjamin Coenen <benjamin.coenen@hotmail.com>