### PR TITLE
fix (api, hatchery): provision only for same group

### DIFF
--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -404,15 +404,18 @@ func SetToBuilding(db gorp.SqlExecutor, workerID string, actionBuildID int64, jo
 // LoadWorkerModelsUsableOnGroup returns worker models for a group
 func LoadWorkerModelsUsableOnGroup(db gorp.SqlExecutor, groupID, sharedinfraGroupID int64) ([]sdk.Model, error) {
 	ms := []WorkerModel{}
-	if _, err := db.Select(&ms, `
-		SELECT * from worker_model
-		WHERE disabled = FALSE
-		AND (group_id = $1 OR group_id = $2 OR $1 = $2)
-		ORDER by name
-		`, groupID, sharedinfraGroupID); err != nil {
+	var err error
+	models := []sdk.Model{}
+
+	if sharedinfraGroupID == groupID { // shared infra, return all models
+		_, err = db.Select(&ms, `SELECT * from worker_model WHERE disabled = FALSE ORDER by name`)
+	} else { // not shared infra, returns only selected worker models
+		_, err = db.Select(&ms, `SELECT * from worker_model WHERE disabled = FALSE AND group_id = $1 ORDER by name`, groupID)
+	}
+	if err != nil {
 		return nil, err
 	}
-	models := []sdk.Model{}
+
 	for i := range ms {
 		if err := ms[i].PostSelect(db); err != nil {
 			return nil, err

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -233,6 +233,13 @@ func provisioning(h Interface, provisionDisabled bool, models []sdk.Model) {
 	}
 
 	for k := range models {
+		// for a shared.infra hatchery, all models are here (group shared.infra or not)
+		// but, a shared.infra hatchery can provision only a shared.infra model
+		// others hatcheries (not shared.infra): only worker models with same group are here
+		// DO NOT provision if hatchery group is not the same as model
+		if models[k].GroupID != h.Hatchery().GroupID {
+			continue
+		}
 		if models[k].Type == h.ModelType() {
 			existing := h.WorkersStartedByModel(&models[k])
 			for i := existing; i < int(models[k].Provision); i++ {


### PR DESCRIPTION
and a shared.infra hatchery can't provision a worker model not shared.infra too

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>