### PR TITLE
feat(api): import keys without values but avoid regen them

### DIFF
--- a/cli/cdsctl/workflow_as_code.go
+++ b/cli/cdsctl/workflow_as_code.go
@@ -319,11 +319,11 @@ func workflowInitRun(c cli.Values) error {
 			VCSConnectionType: "ssh",
 			VCSSSHKey:         "app-ssh-" + repoManagerName,
 			VCSPGPKey:         "app-pgp-" + repoManagerName,
-			Keys: map[string]exportentities.VariableValue{
-				"app-ssh-" + repoManagerName: exportentities.VariableValue{
+			Keys: map[string]exportentities.KeyValue{
+				"app-ssh-" + repoManagerName: exportentities.KeyValue{
 					Type: sdk.KeyTypeSSH,
 				},
-				"app-pgp-" + repoManagerName: exportentities.VariableValue{
+				"app-pgp-" + repoManagerName: exportentities.KeyValue{
 					Type: sdk.KeyTypePGP,
 				},
 			},

--- a/engine/api/application_import_test.go
+++ b/engine/api/application_import_test.go
@@ -383,7 +383,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 
 	k := &sdk.ApplicationKey{
 		Key: sdk.Key{
-			Name: "mykey",
+			Name: "app-mykey",
 			Type: "pgp",
 		},
 		ApplicationID: app.ID,

--- a/sdk/application.go
+++ b/sdk/application.go
@@ -73,6 +73,16 @@ type ApplicationPipeline struct {
 	Triggers     []PipelineTrigger `json:"triggers,omitempty"`
 }
 
+// GetKey return a key by name
+func (a Application) GetKey(kname string) *ApplicationKey {
+	for i := range a.Keys {
+		if a.Keys[i].Name == kname {
+			return &a.Keys[i]
+		}
+	}
+	return nil
+}
+
 // NewApplication instanciate a new NewApplication
 func NewApplication(name string) *Application {
 	a := &Application{

--- a/sdk/environment.go
+++ b/sdk/environment.go
@@ -33,6 +33,16 @@ type EnvironmentVariableAudit struct {
 	Author         string    `json:"author" yaml:"-" db:"author"`
 }
 
+// GetKey return a key by name
+func (e Environment) GetKey(kname string) *EnvironmentKey {
+	for i := range e.Keys {
+		if e.Keys[i].Name == kname {
+			return &e.Keys[i]
+		}
+	}
+	return nil
+}
+
 // NewEnvironment instanciate a new Environment
 func NewEnvironment(name string) *Environment {
 	e := &Environment{

--- a/sdk/exportentities/application.go
+++ b/sdk/exportentities/application.go
@@ -12,7 +12,7 @@ type Application struct {
 	RepositoryName    string                   `json:"repo,omitempty" yaml:"repo,omitempty"`
 	Permissions       map[string]int           `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 	Variables         map[string]VariableValue `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Keys              map[string]VariableValue `json:"keys,omitempty" yaml:"keys,omitempty"`
+	Keys              map[string]KeyValue      `json:"keys,omitempty" yaml:"keys,omitempty"`
 	VCSConnectionType string                   `json:"vcs_connection_type,omitempty" yaml:"vcs_connection_type,omitempty"`
 	VCSSSHKey         string                   `json:"vcs_ssh_key,omitempty" yaml:"vcs_ssh_key,omitempty"`
 	VCSUser           string                   `json:"vcs_user,omitempty" yaml:"vcs_user,omitempty"`
@@ -61,9 +61,9 @@ func NewApplication(app sdk.Application, withPermissions bool, keys []EncryptedK
 		}
 	}
 
-	a.Keys = make(map[string]VariableValue, len(keys))
+	a.Keys = make(map[string]KeyValue, len(keys))
 	for _, e := range keys {
-		a.Keys[e.Name] = VariableValue{
+		a.Keys[e.Name] = KeyValue{
 			Type:  e.Type,
 			Value: e.Content,
 		}

--- a/sdk/exportentities/environment.go
+++ b/sdk/exportentities/environment.go
@@ -8,7 +8,7 @@ import (
 type Environment struct {
 	Name        string                   `json:"name" yaml:"name"`
 	Values      map[string]VariableValue `json:"values,omitempty" yaml:"values,omitempty"`
-	Keys        map[string]VariableValue `json:"keys,omitempty" yaml:"keys,omitempty"`
+	Keys        map[string]KeyValue      `json:"keys,omitempty" yaml:"keys,omitempty"`
 	Permissions map[string]int           `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 }
 
@@ -29,9 +29,9 @@ func NewEnvironment(e sdk.Environment, withPermissions bool, keys []EncryptedKey
 			env.Permissions[p.Group.Name] = p.Permission
 		}
 	}
-	env.Keys = make(map[string]VariableValue, len(keys))
+	env.Keys = make(map[string]KeyValue, len(keys))
 	for _, k := range keys {
-		env.Keys[k.Name] = VariableValue{
+		env.Keys[k.Name] = KeyValue{
 			Type:  k.Type,
 			Value: k.Content,
 		}

--- a/sdk/exportentities/types.go
+++ b/sdk/exportentities/types.go
@@ -14,6 +14,13 @@ type (
 		Value string `json:"value,omitempty" yaml:"value,omitempty"`
 	}
 
+	// KeyValue is a struct to export a value of Key
+	KeyValue struct {
+		Type  string `json:"type,omitempty" yaml:"type,omitempty"`
+		Value string `json:"value,omitempty" yaml:"value,omitempty"`
+		Regen *bool  `json:"regen,omitempty" yaml:"regen,omitempty"`
+	}
+
 	// ParameterValue is a struct to export a defautl value of Parameter
 	ParameterValue struct {
 		Type         string `json:"type,omitempty" yaml:"type,omitempty"`


### PR DESCRIPTION
close #2245

How to use:
```json
version: v1.0
name: myNewApp
keys:
  myPGPkey:
    type: pgp
    regen: false
  mySSHKey:
    type: ssh
```