### PR TITLE
fix (api): more logs on artifact upload err

### DIFF
--- a/engine/api/workflow_queue_artifact.go
+++ b/engine/api/workflow_queue_artifact.go
@@ -196,11 +196,11 @@ func (api *API) postWorkflowJobArtifactWithTempURLCallbackHandler() Handler {
 		cacheKey := cache.Key("workflows:artifacts", art.GetPath(), art.GetName())
 		cachedArt := sdk.WorkflowNodeRunArtifact{}
 		if !api.Cache.Get(cacheKey, &cachedArt) {
-			return sdk.WrapError(sdk.ErrNotFound, "postWorkflowJobArtifactWithTempURLCallbackHandler> Unable to find artifact")
+			return sdk.WrapError(sdk.ErrNotFound, "postWorkflowJobArtifactWithTempURLCallbackHandler> Unable to find artifact, key:%s", cacheKey)
 		}
 
 		if art != cachedArt {
-			return sdk.WrapError(sdk.ErrForbidden, "postWorkflowJobArtifactWithTempURLCallbackHandler> Submitted artifact doesn't match")
+			return sdk.WrapError(sdk.ErrForbidden, "postWorkflowJobArtifactWithTempURLCallbackHandler> Submitted artifact doesn't match, key:%s art:%v cachedArt:%v", cacheKey, art, cachedArt)
 		}
 
 		nodeRun, errR := workflow.LoadNodeRunByID(api.mustDB(), art.WorkflowNodeRunID, true)


### PR DESCRIPTION
for this kind of err:

postWorkflowJobArtifactWithTempURLCallbackHandler> Submitted artifact doesn't match: forbidden

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>