### PR TITLE
fix(api): workflow queue permissions

### DIFF
--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -345,11 +345,6 @@ func loadWorkflowRoot(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, u
 
 // Insert inserts a new workflow
 func Insert(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, p *sdk.Project, u *sdk.User) error {
-	// If the workflow has no permission, inherit from the project
-	if len(w.Groups) == 0 {
-		w.Groups = p.ProjectGroups
-	}
-
 	if err := IsValid(w, p); err != nil {
 		return err
 	}

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -396,10 +396,6 @@ func Insert(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, p *sdk.Proj
 		}
 	}
 
-	if err := upsertAllGroups(db, w, w.Groups); err != nil {
-		return sdk.WrapError(err, "Insert> Unable to insert workflow(%d) permissions (%#v)", w.ID, w.Groups)
-	}
-
 	return updateLastModified(db, store, w, u)
 }
 
@@ -549,10 +545,6 @@ func Update(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, oldWorkflow
 		return sdk.WrapError(err, "Update> Unable to update workflow")
 	}
 
-	if err := upsertAllGroups(db, w, w.Groups); err != nil {
-		return sdk.WrapError(err, "Update> Unable to update workflow(%d) permissions (%#v)", w.ID, w.Groups)
-	}
-
 	return updateLastModified(db, store, w, u)
 }
 
@@ -610,10 +602,6 @@ func HasAccessTo(db gorp.SqlExecutor, w *sdk.Workflow, u *sdk.User) (bool, error
 
 // IsValid cheks workflow validity
 func IsValid(w *sdk.Workflow, proj *sdk.Project) error {
-	if len(w.Groups) == 0 {
-		return sdk.NewError(sdk.ErrWorkflowInvalid, fmt.Errorf("The workflow should have at least one granted group"))
-	}
-
 	//Check project is not empty
 	if w.ProjectKey == "" {
 		return sdk.NewError(sdk.ErrWorkflowInvalid, fmt.Errorf("Invalid project key"))

--- a/engine/api/workflow/dao_node_run_job.go
+++ b/engine/api/workflow/dao_node_run_job.go
@@ -17,7 +17,7 @@ import (
 )
 
 const loadNodeJobRun = `from workflow_node_run_job
-and workflow_node_run_job.queued >= $1
+where workflow_node_run_job.queued >= $1
 and workflow_node_run_job.status = ANY(string_to_array($2, ','))`
 
 // loadPrepareGroup returns true if groupsID contains shareInfraGroup

--- a/engine/api/workflow/dao_node_run_job.go
+++ b/engine/api/workflow/dao_node_run_job.go
@@ -59,7 +59,7 @@ func LoadNodeJobRunQueue(db gorp.SqlExecutor, store cache.Store, rights int, gro
 
 	query := `select distinct workflow_node_run_job.* 
 	from workflow_node_run_job
-	and workflow_node_run_job.queued >= $1
+	where workflow_node_run_job.queued >= $1
 	and workflow_node_run_job.status = ANY(string_to_array($2, ','))`
 
 	isSharedInfraGroup := isSharedInfraGroup(groupsID)

--- a/engine/api/workflow/run_workflow_test.go
+++ b/engine/api/workflow/run_workflow_test.go
@@ -86,6 +86,8 @@ func TestManualRun1(t *testing.T) {
 	}
 
 	test.NoError(t, workflow.Insert(db, cache, &w, proj, u))
+	test.NoError(t, workflow.AddGroup(db, &w, proj.ProjectGroups[0]))
+
 	w1, err := workflow.Load(db, cache, key, "test_1", u, workflow.LoadOptions{
 		DeepPipeline: true,
 	})
@@ -206,6 +208,8 @@ func TestManualRun2(t *testing.T) {
 	}
 
 	test.NoError(t, workflow.Insert(db, cache, &w, proj, u))
+	test.NoError(t, workflow.AddGroup(db, &w, proj.ProjectGroups[0]))
+
 	w1, err := workflow.Load(db, cache, key, "test_1", u, workflow.LoadOptions{
 		DeepPipeline: true,
 	})
@@ -302,6 +306,8 @@ func TestManualRun3(t *testing.T) {
 	proj, _ = project.LoadByID(db, cache, proj.ID, u, project.LoadOptions.WithApplications, project.LoadOptions.WithPipelines, project.LoadOptions.WithEnvironments, project.LoadOptions.WithGroups, project.LoadOptions.WithVariablesWithClearPassword, project.LoadOptions.WithKeys)
 
 	test.NoError(t, workflow.Insert(db, cache, &w, proj, u))
+	test.NoError(t, workflow.AddGroup(db, &w, proj.ProjectGroups[0]))
+
 	w1, err := workflow.Load(db, cache, key, "test_1", u, workflow.LoadOptions{
 		DeepPipeline: true,
 	})

--- a/engine/api/workflow/run_workflow_test.go
+++ b/engine/api/workflow/run_workflow_test.go
@@ -110,6 +110,7 @@ func TestManualRun1(t *testing.T) {
 	//TestLoadNodeRun
 	nodeRun, err := workflow.LoadNodeRun(db, proj.Key, "test_1", 2, lastrun.WorkflowNodeRuns[w1.RootID][0].ID, true)
 	test.NoError(t, err)
+	nodeRun.Stages[0].RunJobs[0].QueuedSeconds = 0
 	test.Equal(t, lastrun.WorkflowNodeRuns[w1.RootID][0], nodeRun)
 
 	//TestLoadNodeJobRun

--- a/engine/api/workflow/run_workflow_test.go
+++ b/engine/api/workflow/run_workflow_test.go
@@ -112,7 +112,10 @@ func TestManualRun1(t *testing.T) {
 	//TestLoadNodeRun
 	nodeRun, err := workflow.LoadNodeRun(db, proj.Key, "test_1", 2, lastrun.WorkflowNodeRuns[w1.RootID][0].ID, true)
 	test.NoError(t, err)
+	//don't want to compare queueSeconds attributes
 	nodeRun.Stages[0].RunJobs[0].QueuedSeconds = 0
+	lastrun.WorkflowNodeRuns[w1.RootID][0].Stages[0].RunJobs[0].QueuedSeconds = 0
+
 	test.Equal(t, lastrun.WorkflowNodeRuns[w1.RootID][0], nodeRun)
 
 	//TestLoadNodeJobRun

--- a/engine/api/workflow_export_test.go
+++ b/engine/api/workflow_export_test.go
@@ -70,7 +70,7 @@ func Test_getWorkflowExportHandler(t *testing.T) {
 		},
 	}
 
-	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj, u))
 	w1, err := workflow.Load(api.mustDB(), api.Cache, key, "test_1", u, workflow.LoadOptions{})
@@ -163,7 +163,7 @@ func Test_getWorkflowExportHandlerWithPermissions(t *testing.T) {
 		},
 	}
 
-	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj, u))
 
@@ -258,7 +258,7 @@ func Test_getWorkflowPullHandler(t *testing.T) {
 		},
 	}
 
-	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj, _ = project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj, u))
 	w1, err := workflow.Load(api.mustDB(), api.Cache, key, "test_1", u, workflow.LoadOptions{})

--- a/engine/api/workflow_group_test.go
+++ b/engine/api/workflow_group_test.go
@@ -42,7 +42,7 @@ func Test_postWorkflowGroupHandler(t *testing.T) {
 		ProjectKey: proj.Key,
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -99,7 +99,7 @@ func Test_putWorkflowGroupHandler(t *testing.T) {
 		ProjectKey: proj.Key,
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -172,7 +172,7 @@ func Test_deleteWorkflowGroupHandler(t *testing.T) {
 		ProjectKey: proj.Key,
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -86,7 +86,7 @@ func testRunWorkflow(t *testing.T, api *API, router *Router, db *gorp.DbMap) tes
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -93,8 +93,6 @@ func testRunWorkflow(t *testing.T, api *API, router *Router, db *gorp.DbMap) tes
 	w1, err := workflow.Load(api.mustDB(), api.Cache, key, "test_1", u, workflow.LoadOptions{})
 	test.NoError(t, err)
 
-	test.NoError(t, workflow.AddGroup(api.mustDB(), &w, sdk.GroupPermission{Group: proj.ProjectGroups[0].Group, Permission: permission.PermissionReadExecute}))
-
 	//Prepare request
 	vars := map[string]string{
 		"key":              proj.Key,

--- a/engine/api/workflow_run_test.go
+++ b/engine/api/workflow_run_test.go
@@ -196,7 +196,7 @@ func Test_getWorkflowRunsHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))

--- a/engine/api/workflow_run_test.go
+++ b/engine/api/workflow_run_test.go
@@ -87,7 +87,7 @@ func Test_getWorkflowNodeRunHistoryHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(db, api.Cache, &w, proj2, u))
@@ -342,7 +342,7 @@ func Test_getWorkflowRunsHandlerWithFilter(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -442,7 +442,7 @@ func Test_getLatestWorkflowRunHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -562,7 +562,7 @@ func Test_getWorkflowRunHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -663,7 +663,7 @@ func Test_getWorkflowNodeRunHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -750,7 +750,7 @@ func Test_resyncWorkflowRunHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(db, api.Cache, &w, proj2, u))
@@ -870,7 +870,7 @@ func Test_postWorkflowRunHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))
@@ -1033,7 +1033,7 @@ func Test_getWorkflowNodeRunJobStepHandler(t *testing.T) {
 		},
 	}
 
-	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines)
+	proj2, errP := project.Load(api.mustDB(), api.Cache, proj.Key, u, project.LoadOptions.WithPipelines, project.LoadOptions.WithGroups)
 	test.NoError(t, errP)
 
 	test.NoError(t, workflow.Insert(api.mustDB(), api.Cache, &w, proj2, u))


### PR DESCRIPTION
Refactor workflow queue sql statement, to only relies on "execGroups" and fixing the "empty jobs" bug

I guess we could optimize it to check execgroups on sql side to avoid to much.
Fixing the "count" function because it wasn't the same behavior than the queue.

Side effect... a regular can see all the queue... i think we can live with this - btw our users ask for it

and fixing a lot of tests

i hope all of this will fix the "invisible jobs" bugs