### PR TITLE
fix (worker): auto-update

### DIFF
--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -30,7 +30,7 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		log.Initialize(&log.Conf{})
 
 		if autoUpdate {
-			log.Info("api=", FlagString(cmd, flagAPI))
+			log.Info("api=%s", FlagString(cmd, flagAPI))
 			updateCmd(w)(cmd, args)
 		}
 

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -30,7 +30,6 @@ func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		log.Initialize(&log.Conf{})
 
 		if autoUpdate {
-			log.Info("api=%s", FlagString(cmd, flagAPI))
 			updateCmd(w)(cmd, args)
 		}
 

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -24,6 +24,7 @@ const (
 	envFlagPrefix           = "cds_"
 	flagSingleUse           = "single-use"
 	flagAutoUpdate          = "auto-update"
+	flagFromGithub          = "from-github"
 	flagForceExit           = "force-exit"
 	flagBaseDir             = "basedir"
 	flagTTL                 = "ttl"
@@ -51,6 +52,7 @@ func initFlagsRun(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.Bool(flagSingleUse, false, "Exit after executing an action")
 	flags.Bool(flagAutoUpdate, false, "Auto update worker binary from CDS API")
+	flags.Bool(flagFromGithub, false, "Update binary from latest github release")
 	flags.Bool(flagForceExit, false, "If single_use=true, force exit. This is useful if it's spawned by an Hatchery (default: worker wait 30min for being killed by hatchery)")
 	flags.String(flagBaseDir, "", "This directory (default TMPDIR os environment var) will contains worker working directory and temporary files")
 	flags.Int(flagTTL, 30, "Worker time to live (minutes)")

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -84,7 +84,7 @@ func FlagBool(cmd *cobra.Command, key string) bool {
 		if os.Getenv(envKey) == "true" || os.Getenv(envKey) == "1" {
 			return true
 		}
-	} else if cmd.Flag(key).Value.String() == "true" {
+	} else if cmd.Flag(key) != nil && cmd.Flag(key).Value.String() == "true" {
 		return true
 	}
 


### PR DESCRIPTION
this will avoid this stack:

```
worker  --api http://localhost:8081 --token foo --auto-update
2018-03-13 23:48:18 [INFO] api=%!!(MISSING)(EXTRA string=http://localhost:8081)
CDS Worker version:snapshot os:darwin architecture:amd64
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x46a06b5]

goroutine 1 [running]:
main.FlagBool(0xc4202426c0, 0x48846f8, 0xb, 0x3)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/init.go:87 +0x195
main.updateCmd.func1(0xc4202426c0, 0xc4201e0780, 0x0, 0x5)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_update.go:34 +0x122
main.mainCommandRun.func1(0xc4202426c0, 0xc4201e0780, 0x0, 0x5)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_main.go:34 +0x229
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).execute(0xc4202426c0, 0xc4200300d0, 0x5, 0x5, 0xc4202426c0, 0xc4200300d0)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:750 +0x2c1
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4202426c0, 0x0, 0xc42028a480, 0xc4201cb090)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:831 +0x2e4
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4202426c0, 0xc420161f30, 0x1)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:784 +0x2b
main.main()
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/main.go:76 +0x45e
```
Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>