### PR TITLE
fix (worker): register

### DIFF
--- a/engine/worker/cmd_register.go
+++ b/engine/worker/cmd_register.go
@@ -15,6 +15,7 @@ func cmdRegister(w *currentWorker) *cobra.Command {
 		Short: "worker register",
 		Run:   cmdRegisterRun(w),
 	}
+	initFlagsRun(cmdRegister)
 	return cmdRegister
 }
 

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -30,7 +30,7 @@ func cmdRun(w *currentWorker) *cobra.Command {
 
 func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		//Initliaze context
+		//Initialize  context
 		ctx := context.Background()
 		ctx, cancel := context.WithCancel(ctx)
 


### PR DESCRIPTION
register cmd have to use same flags as run cmd. Without this, register command does not work:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x46a0599]

goroutine 1 [running]:
main.FlagString(0xc42027fb00, 0x487d6f9, 0x4, 0x0, 0x0)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/init.go:106 +0x149
main.initFlags(0xc42027fb00, 0xc4202b7200)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/init.go:150 +0x11b
main.cmdRegisterRun.func1(0xc42027fb00, 0x4d115e0, 0x0, 0x0)
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/cmd_register.go:23 +0x54
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).execute(0xc42027fb00, 0x4d115e0, 0x0, 0x0, 0xc42027fb00, 0x4d115e0)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:750 +0x2c1
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42027e6c0, 0x0, 0xc4202c6480, 0xc4201f9060)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:831 +0x2e4
github.com/ovh/cds/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42027e6c0, 0xc420195f30, 0x1)
        /Users/yesnault/src/github.com/ovh/cds/vendor/github.com/spf13/cobra/command.go:784 +0x2b
main.main()
        /Users/yesnault/src/github.com/ovh/cds/engine/worker/main.go:76 +0x45e
```
Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>