### PR TITLE
feat (engine,ui): allow provisioning for restricted wm 

### DIFF
--- a/engine/api/migrate/default_payload.go
+++ b/engine/api/migrate/default_payload.go
@@ -17,7 +17,7 @@ func DefaultPayloadMigration(store cache.Store, DBFunc func() *gorp.DbMap, u *sd
 
 	projs, errP := project.LoadAll(db, store, u)
 	if errP != nil {
-		log.Warning("DefaultPayloadMigration> Cannot load all project")
+		log.Warning("DefaultPayloadMigration> Cannot load all project: %s", errP)
 		return
 	}
 

--- a/engine/api/worker_model.go
+++ b/engine/api/worker_model.go
@@ -34,9 +34,13 @@ func (api *API) addWorkerModelHandler() Handler {
 			return sdk.WrapError(sdk.ErrWrongRequest, "addWorkerModel> groupID should be set")
 		}
 
+		if group.IsDefaultGroupID(model.GroupID) {
+			return sdk.WrapError(sdk.ErrWrongRequest, "addWorkerModel> this group can't be owner of a worker model")
+		}
+
 		// check if worker model already exists
 		if _, err := worker.LoadWorkerModelByName(api.mustDB(), model.Name); err == nil {
-			return sdk.WrapError(sdk.ErrModelNameExist, "getWorkerModel> worker model already exists")
+			return sdk.WrapError(sdk.ErrModelNameExist, "addWorkerModel> worker model already exists")
 		}
 
 		//User must be admin of the group set in the model
@@ -97,7 +101,7 @@ func (api *API) spawnErrorWorkerModelHandler() Handler {
 
 		workerModelID, errr := requestVarInt(r, "permModelID")
 		if errr != nil {
-			return sdk.WrapError(errr, "updateWorkerModel> Invalid permModelID")
+			return sdk.WrapError(errr, "spawnErrorWorkerModelHandler> Invalid permModelID")
 		}
 
 		tx, errBegin := api.mustDB().Begin()
@@ -152,7 +156,7 @@ func (api *API) updateWorkerModelHandler() Handler {
 			renamed = true
 			// check if worker model already exists
 			if _, err := worker.LoadWorkerModelByName(api.mustDB(), model.Name); err == nil {
-				return sdk.WrapError(sdk.ErrModelNameExist, "getWorkerModel> worker model already exists")
+				return sdk.WrapError(sdk.ErrModelNameExist, "updateWorkerModel> worker model already exists")
 			}
 		}
 
@@ -169,6 +173,11 @@ func (api *API) updateWorkerModelHandler() Handler {
 		//If the model GroupID has not been set, keep the old GroupID
 		if model.GroupID == 0 {
 			model.GroupID = old.GroupID
+		}
+
+		// we can't select the default group
+		if group.IsDefaultGroupID(model.GroupID) {
+			return sdk.WrapError(sdk.ErrWrongRequest, "updateWorkerModel> this group can't be owner of a worker model")
 		}
 
 		//If the model Type has not been set, keep the old Type
@@ -302,7 +311,7 @@ func (api *API) getWorkerModelsEnabledHandler() Handler {
 		}
 		models, errgroup := worker.LoadWorkerModelsUsableOnGroup(api.mustDB(), getHatchery(ctx).GroupID, group.SharedInfraGroup.ID)
 		if errgroup != nil {
-			return sdk.WrapError(errgroup, "getWorkerModels> cannot load worker models for hatchery %d with group %d", getHatchery(ctx).ID, getHatchery(ctx).GroupID)
+			return sdk.WrapError(errgroup, "getWorkerModelsEnabled> cannot load worker models for hatchery %d with group %d", getHatchery(ctx).ID, getHatchery(ctx).GroupID)
 		}
 		return WriteJSON(w, models, http.StatusOK)
 	}

--- a/engine/api/worker_model.go
+++ b/engine/api/worker_model.go
@@ -58,7 +58,12 @@ func (api *API) addWorkerModelHandler() Handler {
 		//User should have the right permission or be admin
 		if !getUser(ctx).Admin && !ok {
 			return sdk.ErrForbidden
+		}
 
+		// provision is allowed only for CDS Admin
+		// or by user with a restricted model
+		if !getUser(ctx).Admin && !model.Restricted {
+			model.Provision = 0
 		}
 
 		model.CreatedBy = sdk.User{
@@ -190,12 +195,7 @@ func (api *API) updateWorkerModelHandler() Handler {
 			model.ID = old.ID
 		}
 
-		// provision is allowed only for CDS Admin
-		if !getUser(ctx).Admin && model.Provision > 0 {
-			model.Provision = 0
-		}
-
-		//User must be admin of the group set in the new model
+		//User must be admin of the group set in the model
 		var ok bool
 		for _, g := range getUser(ctx).Groups {
 			if g.ID == model.GroupID {
@@ -210,6 +210,12 @@ func (api *API) updateWorkerModelHandler() Handler {
 		//User should have the right permission or be admin
 		if !getUser(ctx).Admin && !ok {
 			return sdk.ErrForbidden
+		}
+
+		// provision is allowed only for CDS Admin
+		// or by user with a restricted model
+		if !getUser(ctx).Admin && !model.Restricted {
+			model.Provision = 0
 		}
 
 		if workerModelID != model.ID {

--- a/ui/src/app/views/settings/worker-model/add/worker-model.add.component.ts
+++ b/ui/src/app/views/settings/worker-model/add/worker-model.add.component.ts
@@ -32,7 +32,7 @@ export class WorkerModelAddComponent implements OnInit {
                 private _route: ActivatedRoute, private _router: Router,
                 private _authentificationStore: AuthentificationStore) {
         this.currentUser = this._authentificationStore.getUser();
-        this._groupService.getGroups().subscribe( groups => {
+        this._groupService.getGroups(true).subscribe( groups => {
             this.workerModelGroups = groups;
         });
     }

--- a/ui/src/app/views/settings/worker-model/add/worker-model.add.html
+++ b/ui/src/app/views/settings/worker-model/add/worker-model.add.html
@@ -64,7 +64,7 @@
                     <option *ngFor="let communication of workerModelCommunications" [value]="communication">{{communication}}</option>
                 </sm-select>
               </div>
-              <div class="four wide field" *ngIf="currentUser.admin">
+              <div class="four wide field" *ngIf="currentUser.admin || workerModel.restricted">
                   <label>{{'worker_model_provision' | translate}}</label>
                   <input class="ui input" type="number" name="provision" [(ngModel)]="workerModel.provision" [disabled]="loading">
               </div>

--- a/ui/src/app/views/settings/worker-model/edit/worker-model.edit.component.ts
+++ b/ui/src/app/views/settings/worker-model/edit/worker-model.edit.component.ts
@@ -34,7 +34,7 @@ export class WorkerModelEditComponent implements OnInit {
                 private _route: ActivatedRoute, private _router: Router,
                 private _authentificationStore: AuthentificationStore) {
         this.currentUser = this._authentificationStore.getUser();
-        this._groupService.getGroups().subscribe( groups => {
+        this._groupService.getGroups(true).subscribe( groups => {
             this.workerModelGroups = groups;
         });
     }

--- a/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
+++ b/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
@@ -101,7 +101,7 @@
                     <option *ngFor="let communication of workerModelCommunications" [value]="communication">{{communication}}</option>
                 </sm-select>
               </div>
-              <div class="four wide field" *ngIf="currentUser.admin">
+              <div class="four wide field" *ngIf="currentUser.admin || workerModel.restricted">
                   <label>{{'worker_model_provision' | translate}}</label>
                   <input class="ui input" type="number" name="provision" [(ngModel)]="workerModel.provision" [disabled]="loading">
               </div>


### PR DESCRIPTION
1. Description
- user is allowed to set provision on a restricted worker model
- a default group can be a owner of a worker model

1. Related issues
n/a

1. About tests
Manual done

1. Mentions
it's for you @henyxia