### PR TITLE
fix (engine): scheduler enqueue

### DIFF
--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -46,7 +46,7 @@ func (s *Service) runScheduler(c context.Context) error {
 	return ctx.Err()
 }
 
-// Every x seconds, the scehduler try to relaunch all tasks which have never been processed, or in error
+// Every x seconds, the scheduler try to relaunch all tasks which have never been processed, or in error
 func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 	tick := time.NewTicker(time.Duration(s.Cfg.RetryDelay) * time.Second)
 	for {
@@ -86,7 +86,7 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 	}
 }
 
-// Every x seconds, the scehduler try to relaunch all tasks which have never been processed, or in error
+// Every 30 seconds, the scheduler try to launch all scheduled tasks (scheduler or repoPoller) which have never been processed
 func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error {
 	tick := time.NewTicker(time.Duration(30) * time.Second)
 	for {
@@ -112,7 +112,7 @@ func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error
 						// this will avoid to re-enqueue the same scheduled task execution if the dequeue take more than 30s (ticker of this goroutine)
 						e.Status = ""
 						s.Dao.SaveTaskExecution(&e)
-						log.Warning("Enqueing scheduler/repoPoller %s", e.UUID)
+						log.Info("Enqueing scheduler or repoPoller task %s", e.UUID)
 						s.Dao.EnqueueTaskExecution(&e)
 					}
 				}

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -181,7 +181,7 @@ func (s *Service) dequeueTaskExecutions(c context.Context) error {
 
 		task := s.Dao.FindTask(t.UUID)
 		if task == nil {
-			log.Error("Hooks> dequeueTaskExecutions failed: Task not found")
+			log.Error("Hooks> dequeueTaskExecutions failed: Task %s not found", t.UUID)
 			t.LastError = "Internal Error: Task not found"
 			t.NbErrors++
 			log.Info("Hooks> Deleting task execution %s", t.UUID)
@@ -195,7 +195,7 @@ func (s *Service) dequeueTaskExecutions(c context.Context) error {
 			restartTask = true
 			saveTaskExecution = true
 			if err := s.doTask(c, task, &t); err != nil {
-				log.Error("Hooks> dequeueTaskExecutions failed [%d]: %v", t.NbErrors, err)
+				log.Error("Hooks> dequeueTaskExecutions %s failed err[%d]: %v", t.UUID, t.NbErrors, err)
 				t.LastError = err.Error()
 				t.NbErrors++
 				saveTaskExecution = true

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -71,12 +71,12 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 						continue
 					}
 					// old hooks
-					if e.ProcessingTimestamp == 0 && e.Timestamp < time.Now().Add(-1*time.Hour).UnixNano() {
-						log.Warning("Enqueing very old hooks %s %d/%d  %s", e.UUID, e.NbErrors, s.Cfg.RetryError, e.LastError)
+					if e.ProcessingTimestamp == 0 && e.Timestamp < time.Now().Add(-2*time.Minute).UnixNano() {
+						log.Warning("Enqueing very old hooks %s %d/%d type:%s status:%s err:%s", e.UUID, e.NbErrors, s.Cfg.RetryError, e.Type, e.Status, e.LastError)
 						s.Dao.EnqueueTaskExecution(&e)
 					}
 					if e.NbErrors < s.Cfg.RetryError && e.LastError != "" {
-						log.Warning("Enqueing with lastError %s %d/%d %s len:%d status:%s", e.UUID, e.NbErrors, s.Cfg.RetryError, e.LastError, len(e.LastError), e.Status)
+						log.Warning("Enqueing with lastError %s %d/%d type:%s status:%s len:%d err:%s", e.UUID, e.NbErrors, s.Cfg.RetryError, e.Type, e.Status, len(e.LastError), e.LastError)
 						s.Dao.EnqueueTaskExecution(&e)
 						continue
 					}
@@ -112,7 +112,7 @@ func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error
 						// this will avoid to re-enqueue the same scheduled task execution if the dequeue take more than 30s (ticker of this goroutine)
 						e.Status = ""
 						s.Dao.SaveTaskExecution(&e)
-						log.Info("Enqueing scheduler or repoPoller task %s", e.UUID)
+						log.Info("Enqueing scheduler or repoPoller task %s type:%s", e.UUID, e.Type)
 						s.Dao.EnqueueTaskExecution(&e)
 					}
 				}

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -49,10 +49,10 @@ func (s *Service) runScheduler(c context.Context) error {
 // Every x seconds, the scheduler try to relaunch all tasks which have never been processed, or in error
 func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 	tick := time.NewTicker(time.Duration(s.Cfg.RetryDelay) * time.Second)
+	defer tick.Stop()
 	for {
 		select {
 		case <-c.Done():
-			defer tick.Stop()
 			return c.Err()
 		case <-tick.C:
 			tasks, err := s.Dao.FindAllTasks()
@@ -89,10 +89,10 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 // Every 30 seconds, the scheduler try to launch all scheduled tasks (scheduler or repoPoller) which have never been processed
 func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error {
 	tick := time.NewTicker(time.Duration(30) * time.Second)
+	defer tick.Stop()
 	for {
 		select {
 		case <-c.Done():
-			defer tick.Stop()
 			return c.Err()
 		case <-tick.C:
 			tasks, err := s.Dao.FindAllTasks()
@@ -124,10 +124,10 @@ func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error
 // Every 60 seconds, old executions of each task are deleted
 func (s *Service) deleteTaskExecutionsRoutine(c context.Context) error {
 	tick := time.NewTicker(time.Duration(60) * time.Second)
+	defer tick.Stop()
 	for {
 		select {
 		case <-c.Done():
-			tick.Stop()
 			return c.Err()
 		case <-tick.C:
 			tasks, err := s.Dao.FindAllTasks()

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -52,7 +52,7 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 	for {
 		select {
 		case <-c.Done():
-			tick.Stop()
+			defer tick.Stop()
 			return c.Err()
 		case <-tick.C:
 			tasks, err := s.Dao.FindAllTasks()
@@ -92,7 +92,7 @@ func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error
 	for {
 		select {
 		case <-c.Done():
-			tick.Stop()
+			defer tick.Stop()
 			return c.Err()
 		case <-tick.C:
 			tasks, err := s.Dao.FindAllTasks()

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -67,7 +67,7 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 					continue
 				}
 				for _, e := range execs {
-					if e.Status == TaskExecutionDoing {
+					if e.Status == TaskExecutionDoing || e.Status == TaskExecutionScheduled {
 						continue
 					}
 					// old hooks

--- a/engine/hooks/tasks.go
+++ b/engine/hooks/tasks.go
@@ -245,6 +245,7 @@ func (s *Service) prepareNextScheduledTaskExecution(t *sdk.Task) error {
 	//Craft a new execution
 	exec = &sdk.TaskExecution{
 		Timestamp: nextSchedule.UnixNano(),
+		Status:    TaskExecutionScheduled,
 		Type:      t.Type,
 		UUID:      t.UUID,
 		Config:    t.Config,

--- a/engine/hooks/types.go
+++ b/engine/hooks/types.go
@@ -8,8 +8,9 @@ import (
 
 // Task execution status
 const (
-	TaskExecutionDoing = "DOING"
-	TaskExecutionDone  = "DONE"
+	TaskExecutionDoing     = "DOING"
+	TaskExecutionDone      = "DONE"
+	TaskExecutionScheduled = "SCHEDULED"
 )
 
 // Service is the stuct representing a hooks µService

--- a/engine/hooks/types.go
+++ b/engine/hooks/types.go
@@ -32,7 +32,7 @@ type Configuration struct {
 	} `toml:"http" comment:"######################\n CDS Hooks HTTP Configuration \n######################"`
 	URL              string `default:"http://localhost:8083"`
 	URLPublic        string `toml:"urlPublic" comment:"Public url for external call (webhook)"`
-	RetryDelay       int64  `toml:"retryDelay" default:"1" comment:"Execution retry delay in seconds"`
+	RetryDelay       int64  `toml:"retryDelay" default:"120" comment:"Execution retry delay in seconds"`
 	RetryError       int64  `toml:"retryError" default:"3" comment:"Retry execution while this number of error is not reached"`
 	ExecutionHistory int    `toml:"executionHistory" default:"10" comment:"Number of execution to keep"`
 	Disable          bool   `toml:"disable" default:"false" comment:"Disable all hooks executions"`


### PR DESCRIPTION
1. Description
A new goroutine dedicated for enqueue scheduler, 30s
Existing goroutine (120s retry) works only on very old hooks or error

1. Related issues
n/a
1. About tests
Manual done
1. Mentions

@ovh/cds