### PR TITLE
fix (ui): default value notif for wf

### DIFF
--- a/ui/src/app/model/notification.model.ts
+++ b/ui/src/app/model/notification.model.ts
@@ -47,7 +47,7 @@ export class UserNotificationTemplate {
         this.subject = '{{.cds.project}}/{{.cds.application}} {{.cds.pipeline}} {{.cds.environment}}#{{.cds.version}} {{.cds.status}}';
         this.body = 'Project : {{.cds.project}}\n' +
                 'Application : {{.cds.application}}\n' +
-                'Pipeline : {{.cds.pipeline}}/{{.cds.environment}}#{{.cds.buildNumber}}\n' +
+                'Pipeline : {{.cds.pipeline}}/{{.cds.environment}}#{{.cds.version}}\n' +
                 'Status : {{.cds.status}}\n' +
                 'Details : {{.cds.buildURL}}\n' +
                 'Triggered by : {{.cds.triggered_by.username}}\n' +


### PR DESCRIPTION
1. Description
cds.buildNumber does not exist anymore on workflow, use cds.version

1. Related issues
none

1. About tests
manual

1. Mentions

@ovh/cds

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>