### PR TITLE
fix (cdsctl): error msg on cdsctl login

### DIFF
--- a/cli/cdsctl/login.go
+++ b/cli/cdsctl/login.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/howeyc/gopass"
 
@@ -93,7 +94,13 @@ func doLogin(url, username, password string, env bool) error {
 	client = cdsclient.New(conf)
 	ok, token, err := client.UserLogin(username, password)
 	if err != nil {
-		return err
+		if conf.Verbose {
+			fmt.Fprintf(os.Stderr, "error:%s\n", err)
+		}
+		if strings.HasSuffix(url, "/") {
+			fmt.Fprintf(os.Stderr, "Invalid URL. Remove trailing '/'\n")
+		}
+		return fmt.Errorf("Please check CDS API URL")
 	}
 	if !ok {
 		return fmt.Errorf("login failed")


### PR DESCRIPTION
```bash
cdsctl login -H https://foo/
CDS API URL: https://foo/
Username: qsf
Password:
          Error: invalid character '<' looking for beginning of value
```


with this PR:


```bash
cdsctl login -H http://foo/
CDS API URL: http://foo/
Username: qsfd
Password:
          Invalid URL. Remove trailing '/'
Error: Please check CDS API URL
```
Trailing '/' is a common user mistake

```bash
cdsctl login -H http://foo
CDS API URL: http://foo
Username: qsdf
Password:
          Error: Please check CDS API URL

```