### PR TITLE
fix(tools/debpacker): do not start the service after installation

### DIFF
--- a/tools/debpacker/tmpl.go
+++ b/tools/debpacker/tmpl.go
@@ -26,9 +26,9 @@ chown -R {{.SystemdServiceConfig.User}}:{{.SystemdServiceConfig.User}} /var/lib/
 chmod 770 /var/lib/{{.PackageName}}
 chmod +x {{.SystemdServiceConfig.ExecStart}}
 
-echo "Starting service"
-systemctl start {{.PackageName}}
+echo "Service installed"
 systemctl status {{.PackageName}}
+echo "run systemctl start {{.PackageName}} to start"
 `
 
 	systemdServiceTmpl = `[Unit]


### PR DESCRIPTION
1. Description
On CDS, we need lot of manual configuration to be able to start the service. So don't try to start it after installation
1. Related issues
n/a
1. About tests
n/a
1. Mentions
@ovh/cds
