### PR TITLE
fix(api): interpolate should not be replaced git.branch as  git__branch

### DIFF
--- a/sdk/interpolate/interpolate.go
+++ b/sdk/interpolate/interpolate.go
@@ -52,6 +52,9 @@ func Do(input string, vars map[string]string) (string, error) {
 		kAsVar := "{{." + k
 		kbAsVar := "{{." + kb
 		input = strings.Replace(input, kAsVar, kbAsVar, -1)
+		kAsVar = "{{. " + k
+		kbAsVar = "{{. " + kb
+		input = strings.Replace(input, kAsVar, kbAsVar, -1)
 	}
 
 	var helper string

--- a/sdk/interpolate/interpolate.go
+++ b/sdk/interpolate/interpolate.go
@@ -48,7 +48,10 @@ func Do(input string, vars map[string]string) (string, error) {
 		if v == "" {
 			empty[k] = k
 		}
-		input = strings.Replace(input, k, kb, -1)
+		//The key should be used as a variable to be replaced
+		kAsVar := "{{." + k
+		kbAsVar := "{{." + kb
+		input = strings.Replace(input, kAsVar, kbAsVar, -1)
 	}
 
 	var helper string

--- a/sdk/interpolate/interpolate_test.go
+++ b/sdk/interpolate/interpolate_test.go
@@ -268,6 +268,33 @@ func TestDo(t *testing.T) {
 			},
 			want: `{"HOST": "customermyprefix.lb"}`,
 		},
+		{
+			name: "git.branch in payload should not be interpolated",
+			args: args{
+				input: `
+name: "w{{.cds.pip.docker.image}}-generated"
+version: v1.0
+workflow:
+  build-go:
+    pipeline: build-go-generated
+    payload:
+      git.author: ""
+      git.branch: master`,
+				vars: map[string]string{
+					"git.branch": "master",
+					"git.author": "",
+				},
+			},
+			want: `
+name: "w{{.cds.pip.docker.image}}-generated"
+version: v1.0
+workflow:
+  build-go:
+    pipeline: build-go-generated
+    payload:
+      git.author: ""
+      git.branch: master`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
1. Description
interpolate should not be replaced git.branch as  git__branch
1. Related issues
n/a
1. About tests
unit tests passed
1. Mentions
@ovh/cds
