### PR TITLE
feat (engine): status on all services, api too

### DIFF
--- a/cli/cdsctl/admin_hooks.go
+++ b/cli/cdsctl/admin_hooks.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -25,28 +24,10 @@ var (
 var adminHooksTaskListCmd = cli.Command{
 	Name:  "list",
 	Short: "List CDS Hooks Tasks",
-	Flags: []cli.Flag{
-		{
-			Kind:      reflect.String,
-			Name:      "name",
-			ShortHand: "t",
-			Usage:     "get task from a hook service with this name. Optional if you have only one hooks service",
-			Default:   "",
-		},
-	},
 }
 
 func adminHooksTaskListRun(v cli.Values) (cli.ListResult, error) {
-
-	if v.GetString("name") == "" {
-		srvs, err := client.Services()
-		if err != nil {
-			return nil, err
-		}
-		return cli.AsListResult(srvs), nil
-	}
-
-	btes, err := client.ServiceCallGET("hooks", "", "/task")
+	btes, err := client.ServiceCallGET("hooks", "/task")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cdsctl/admin_hooks.go
+++ b/cli/cdsctl/admin_hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -24,10 +25,28 @@ var (
 var adminHooksTaskListCmd = cli.Command{
 	Name:  "list",
 	Short: "List CDS Hooks Tasks",
+	Flags: []cli.Flag{
+		{
+			Kind:      reflect.String,
+			Name:      "name",
+			ShortHand: "t",
+			Usage:     "get task from a hook service with this name. Optional if you have only one hooks service",
+			Default:   "",
+		},
+	},
 }
 
 func adminHooksTaskListRun(v cli.Values) (cli.ListResult, error) {
-	btes, err := client.ServiceCallGET("hooks", "/task")
+
+	if v.GetString("name") == "" {
+		srvs, err := client.Services()
+		if err != nil {
+			return nil, err
+		}
+		return cli.AsListResult(srvs), nil
+	}
+
+	btes, err := client.ServiceCallGET("hooks", "", "/task")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cdsctl/admin_services.go
+++ b/cli/cdsctl/admin_services.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -38,19 +37,7 @@ var adminServiceListCmd = cli.Command{
 }
 
 func adminServiceListRun(v cli.Values) (cli.ListResult, error) {
-	name := v.GetString("name")
-	if name == "" {
-		srvs, err := client.ServicesByType(v.GetString("type"))
-		if err != nil {
-			return nil, err
-		}
-		if len(srvs) != 1 {
-			return nil, fmt.Errorf("Please use --name argument")
-		}
-		name = srvs[0].Name
-	}
-
-	srvs, err := client.ServicesByName(name)
+	srvs, err := client.ServicesByType(v.GetString("type"))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cdsctl/admin_services.go
+++ b/cli/cdsctl/admin_services.go
@@ -74,6 +74,12 @@ func adminServiceStatusRun(v cli.Values) (cli.ListResult, error) {
 		for _, l := range srv.MonitoringStatus.Lines {
 			lines = append(lines, l)
 		}
+	} else if v.GetString("type") == "" {
+		s, err := client.MonStatus()
+		if err != nil {
+			return nil, err
+		}
+		return cli.AsListResult(s.Lines), nil
 	} else {
 		srvs, err := client.ServicesByType(v.GetString("type"))
 		if err != nil {

--- a/cli/cdsctl/admin_services.go
+++ b/cli/cdsctl/admin_services.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 
-	"github.com/ovh/cds/cli"
-
 	"github.com/spf13/cobra"
+
+	"github.com/ovh/cds/cli"
+	"github.com/ovh/cds/sdk"
 )
 
 var (
@@ -17,6 +19,7 @@ var (
 	adminServices = cli.NewCommand(adminServicesCmd, nil,
 		[]*cobra.Command{
 			cli.NewListCommand(adminServiceListCmd, adminServiceListRun, nil),
+			cli.NewListCommand(adminServiceStatusCmd, adminServiceStatusRun, nil),
 		})
 )
 
@@ -28,24 +31,74 @@ var adminServiceListCmd = cli.Command{
 			Kind:      reflect.String,
 			Name:      "type",
 			ShortHand: "t",
-			Usage:     "Filter service by type",
+			Usage:     "Filter service by type: api, hatchery, hook, repository, vcs",
 			Default:   "",
 		},
 	},
 }
 
 func adminServiceListRun(v cli.Values) (cli.ListResult, error) {
-	if v.GetString("type") == "" {
-		srvs, err := client.Services()
+	name := v.GetString("name")
+	if name == "" {
+		srvs, err := client.ServicesByType(v.GetString("type"))
 		if err != nil {
 			return nil, err
 		}
-		return cli.AsListResult(srvs), nil
+		if len(srvs) != 1 {
+			return nil, fmt.Errorf("Please use --name argument")
+		}
+		name = srvs[0].Name
 	}
 
-	srvs, err := client.ServicesByType(v.GetString("type"))
+	srvs, err := client.ServicesByName(name)
 	if err != nil {
 		return nil, err
 	}
 	return cli.AsListResult(srvs), nil
+}
+
+var adminServiceStatusCmd = cli.Command{
+	Name:  "status",
+	Short: "Status CDS services",
+	Flags: []cli.Flag{
+		{
+			Kind:      reflect.String,
+			Name:      "type",
+			ShortHand: "t",
+			Usage:     "Filter service by type: api, hatchery, hook, repository, vcs",
+			Default:   "",
+		},
+		{
+			Kind:    reflect.String,
+			Name:    "name",
+			Usage:   "Filter service by name",
+			Default: "",
+		},
+	},
+}
+
+func adminServiceStatusRun(v cli.Values) (cli.ListResult, error) {
+	lines := []sdk.MonitoringStatusLine{}
+	if v.GetString("name") != "" {
+		srv, err := client.ServicesByName(v.GetString("name"))
+		if err != nil {
+			return nil, err
+		}
+		for _, l := range srv.MonitoringStatus.Lines {
+			lines = append(lines, l)
+		}
+	} else {
+		srvs, err := client.ServicesByType(v.GetString("type"))
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range srvs {
+			for i := range s.MonitoringStatus.Lines {
+				l := s.MonitoringStatus.Lines[i]
+				lines = append(lines, l)
+			}
+		}
+	}
+
+	return cli.AsListResult(lines), nil
 }

--- a/cli/cdsctl/monitoring.go
+++ b/cli/cdsctl/monitoring.go
@@ -336,7 +336,7 @@ func (ui *Termui) updateStatus() string {
 	for _, l := range statusEngine.Lines {
 		if l.Status != sdk.MonitoringStatusOK {
 			items = append(items, fmt.Sprintf("[%s](bg-red)", l.String()))
-		} else {
+		} else if strings.Contains(l.Status, "Version") {
 			items = append(items, fmt.Sprintf("[%s](%s)", l.String(), selected))
 		}
 	}

--- a/engine/api/admin.go
+++ b/engine/api/admin.go
@@ -43,19 +43,6 @@ func (api *API) deleteAdminMaintenanceHandler() Handler {
 	}
 }
 
-func (api *API) getAdminServiceHandler() Handler {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		vars := mux.Vars(r)
-		name := vars["name"]
-		q := services.Querier(api.mustDB(), api.Cache)
-		srv, err := q.FindByName(name)
-		if err != nil {
-			return sdk.WrapError(err, "getAdminServiceHandler")
-		}
-		return WriteJSON(w, srv, http.StatusOK)
-	}
-}
-
 func (api *API) getAdminServicesHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		q := services.Querier(api.mustDB(), api.Cache)
@@ -71,6 +58,19 @@ func (api *API) getAdminServicesHandler() Handler {
 			return sdk.WrapError(err, "getAdminServicesHandler")
 		}
 		return WriteJSON(w, srvs, http.StatusOK)
+	}
+}
+
+func (api *API) getAdminServiceHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		vars := mux.Vars(r)
+		name := vars["name"]
+		q := services.Querier(api.mustDB(), api.Cache)
+		srv, err := q.FindByName(name)
+		if err != nil {
+			return sdk.WrapError(err, "getAdminServiceHandler")
+		}
+		return WriteJSON(w, srv, http.StatusOK)
 	}
 }
 

--- a/engine/api/admin.go
+++ b/engine/api/admin.go
@@ -43,25 +43,32 @@ func (api *API) deleteAdminMaintenanceHandler() Handler {
 	}
 }
 
-func (api *API) getAdminServicesHandler() Handler {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		q := services.Querier(api.mustDB(), api.Cache)
-		srvs, err := q.All()
-		if err != nil {
-			return sdk.WrapError(err, "getAdminServicesHandler")
-		}
-		return WriteJSON(w, srvs, http.StatusOK)
-	}
-}
-
 func (api *API) getAdminServiceHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		vars := mux.Vars(r)
-		s := vars["service"]
+		name := vars["name"]
 		q := services.Querier(api.mustDB(), api.Cache)
-		srvs, err := q.FindByType(s)
+		srv, err := q.FindByName(name)
 		if err != nil {
 			return sdk.WrapError(err, "getAdminServiceHandler")
+		}
+		return WriteJSON(w, srv, http.StatusOK)
+	}
+}
+
+func (api *API) getAdminServicesHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		q := services.Querier(api.mustDB(), api.Cache)
+		srvs := []sdk.Service{}
+		var err error
+		if r.FormValue("type") != "" {
+			srvs, err = q.FindByType(r.FormValue("type"))
+		} else {
+			srvs, err = q.All()
+		}
+
+		if err != nil {
+			return sdk.WrapError(err, "getAdminServicesHandler")
 		}
 		return WriteJSON(w, srvs, http.StatusOK)
 	}
@@ -85,10 +92,8 @@ func (api *API) putAdminServiceCallHandler() Handler {
 
 func selectDeleteAdminServiceCallHandler(api *API, method string) Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		vars := mux.Vars(r)
-		s := vars["service"]
 		q := services.Querier(api.mustDB(), api.Cache)
-		srvs, err := q.FindByType(s)
+		srvs, err := q.FindByType(r.FormValue("type"))
 		if err != nil {
 			return sdk.WrapError(err, "selectDeleteAdminServiceCallHandler")
 		}
@@ -112,10 +117,8 @@ func selectDeleteAdminServiceCallHandler(api *API, method string) Handler {
 
 func putPostAdminServiceCallHandler(api *API, method string) Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		vars := mux.Vars(r)
-		s := vars["service"]
 		q := services.Querier(api.mustDB(), api.Cache)
-		srvs, err := q.FindByType(s)
+		srvs, err := q.FindByType(r.FormValue("type"))
 		if err != nil {
 			return sdk.WrapError(err, "putPostAdminServiceCallHandler")
 		}

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -191,6 +191,8 @@ func (a *API) ApplyConfiguration(config interface{}) error {
 		return fmt.Errorf("Invalid configuration")
 	}
 
+	a.Type = services.TypeAPI
+
 	return nil
 }
 
@@ -538,6 +540,7 @@ func (a *API) Serve(ctx context.Context) error {
 	go migrate.KeyMigration(a.Cache, a.DBConnectionFactory.GetDBMap, &sdk.User{Admin: true})
 	go migrate.DefaultPayloadMigration(a.Cache, a.DBConnectionFactory.GetDBMap, &sdk.User{Admin: true})
 	go migrate.DefaultTagsMigration(a.Cache, a.DBConnectionFactory.GetDBMap, &sdk.User{Admin: true})
+	go a.serviceAPIHeartbeat(ctx)
 
 	//Temporary migration code
 	if os.Getenv("CDS_MIGRATE_ENABLE") == "true" {

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -40,9 +40,11 @@ func (api *API) InitRouter() {
 	r.Handle("/admin/debug/trace", r.POST(api.getTraceHandler, NeedAdmin(true)))
 	r.Handle("/admin/debug/cpu", r.POST(api.getCPUProfileHandler, NeedAdmin(true)))
 	r.Handle("/admin/debug/{name}", r.POST(api.getProfileHandler, NeedAdmin(true)))
+
+	// Admin service
+	r.Handle("/admin/service/{name}", r.GET(api.getAdminServiceHandler, NeedAdmin(true)))
 	r.Handle("/admin/services", r.GET(api.getAdminServicesHandler, NeedAdmin(true)))
-	r.Handle("/admin/services/{service}", r.GET(api.getAdminServiceHandler, NeedAdmin(true)))
-	r.Handle("/admin/services/{service}/call", r.GET(api.getAdminServiceCallHandler, NeedAdmin(true)), r.POST(api.postAdminServiceCallHandler, NeedAdmin(true)), r.PUT(api.putAdminServiceCallHandler, NeedAdmin(true)), r.DELETE(api.deleteAdminServiceCallHandler, NeedAdmin(true)))
+	r.Handle("/admin/services/call", r.GET(api.getAdminServiceCallHandler, NeedAdmin(true)), r.POST(api.postAdminServiceCallHandler, NeedAdmin(true)), r.PUT(api.putAdminServiceCallHandler, NeedAdmin(true)), r.DELETE(api.deleteAdminServiceCallHandler, NeedAdmin(true)))
 
 	// Action plugin
 	r.Handle("/plugin", r.POST(api.addPluginHandler, NeedAdmin(true)), r.PUT(api.updatePluginHandler, NeedAdmin(true)))

--- a/engine/api/event/event.go
+++ b/engine/api/event/event.go
@@ -45,7 +45,15 @@ func Initialize(k KafkaConfig) error {
 	if err != nil {
 		hostname = fmt.Sprintf("Error while getting Hostname: %s", err.Error())
 	}
-	cdsname = namesgenerator.GetRandomName(0)
+	// generates an API name. api_foo_bar, only 3 first letters to have a readable status
+	cdsname = "api_"
+	for _, v := range strings.Split(namesgenerator.GetRandomName(0), "_") {
+		if len(v) > 3 {
+			cdsname += v[:3]
+		} else {
+			cdsname += v
+		}
+	}
 
 	brokers = []Broker{}
 	if k.Enabled {

--- a/engine/api/services.go
+++ b/engine/api/services.go
@@ -110,7 +110,8 @@ func (api *API) serviceAPIHeartbeat(c context.Context) {
 			//Try to find the service, and keep; else generate a new one
 			oldSrv, errOldSrv := repo.FindByName(srv.Name)
 			if errOldSrv != nil && errOldSrv != sdk.ErrNotFound {
-				log.Error("serviceAPIHeartbeat:%v", errOldSrv)
+				log.Error("serviceAPIHeartbeat> Unable to find by name:%v", errOldSrv)
+				repo.Rollback()
 				continue
 			}
 

--- a/engine/api/services.go
+++ b/engine/api/services.go
@@ -37,7 +37,7 @@ func (api *API) postServiceRegisterHandler() Handler {
 		}
 
 		//Try to find the service, and keep; else generate a new one
-		oldSrv, errOldSrv := repo.Find(srv.Name)
+		oldSrv, errOldSrv := repo.FindByName(srv.Name)
 		if oldSrv != nil {
 			srv.Hash = oldSrv.Hash
 		} else if errOldSrv == sdk.ErrNotFound {

--- a/engine/api/services/dao.go
+++ b/engine/api/services/dao.go
@@ -202,6 +202,7 @@ func (r *Repository) PostGet(s *service) error {
 	}
 	for i := range m.Lines {
 		m.Lines[i].Component = fmt.Sprintf("%s/%s", s.Name, m.Lines[i].Component)
+		m.Lines[i].Type = s.Type
 	}
 	s.MonitoringStatus = m
 	return nil

--- a/engine/api/services/dao.go
+++ b/engine/api/services/dao.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-gorp/gorp"
@@ -70,8 +72,8 @@ func (r *Repository) Rollback() error {
 	return err
 }
 
-// Find a service by its name
-func (r *Repository) Find(name string) (*sdk.Service, error) {
+// FindByName a service by its name
+func (r *Repository) FindByName(name string) (*sdk.Service, error) {
 	query := "SELECT name, type, http_url, last_heartbeat, hash FROM services WHERE name = $1"
 	return r.findOne(query, name)
 }
@@ -101,7 +103,7 @@ func (r *Repository) FindByType(t string) ([]sdk.Service, error) {
 // All returns all registered services
 func (r *Repository) All() ([]sdk.Service, error) {
 	query := `
-	SELECT name, type, http_url, last_heartbeat, hash 
+	SELECT name, type, http_url, last_heartbeat, hash
 	FROM services`
 	services, err := r.findAll(query)
 	if err != nil {
@@ -121,6 +123,9 @@ func (r *Repository) findOne(query string, args ...interface{}) (*sdk.Service, e
 		}
 		return nil, sdk.WrapError(err, "findOne> service not found")
 	}
+	if err := r.PostGet(&sdb); err != nil {
+		return nil, sdk.WrapError(err, "findOne> postGet")
+	}
 	s := sdk.Service(sdb)
 	if s.Name == "" {
 		return nil, sdk.ErrNotFound
@@ -138,6 +143,9 @@ func (r *Repository) findAll(query string, args ...interface{}) ([]sdk.Service, 
 	}
 	ss := make([]sdk.Service, len(sdbs))
 	for i := 0; i < len(sdbs); i++ {
+		if err := r.PostGet(&sdbs[i]); err != nil {
+			return nil, sdk.WrapError(err, "findAll> postGet")
+		}
 		ss[i] = sdk.Service(sdbs[i])
 	}
 	return ss, nil
@@ -148,6 +156,9 @@ func (r *Repository) Insert(s *sdk.Service) error {
 	sdb := service(*s)
 	if err := r.Tx().Insert(&sdb); err != nil {
 		return sdk.WrapError(err, "Insert> unable to insert service %s", s.Name)
+	}
+	if err := r.PostUpdate(&sdb); err != nil {
+		return sdk.WrapError(err, "Insert> error on PostUpdate")
 	}
 	*s = sdk.Service(sdb)
 	return nil
@@ -161,6 +172,9 @@ func (r *Repository) Update(s *sdk.Service) error {
 	} else if n == 0 {
 		return sdk.WrapError(sdk.ErrNotFound, "Update> unable to update service %s", s.Name)
 	}
+	if err := r.PostUpdate(&sdb); err != nil {
+		return sdk.WrapError(err, "Update> error on PostUpdate")
+	}
 	*s = sdk.Service(sdb)
 	return nil
 }
@@ -170,6 +184,39 @@ func (r *Repository) Delete(s *sdk.Service) error {
 	sdb := service(*s)
 	if _, err := r.Tx().Delete(&sdb); err != nil {
 		return sdk.WrapError(err, "Delete> unable to delete service %s", s.Name)
+	}
+	return nil
+}
+
+// PostGet is a dbHook on Select to get json column
+func (r *Repository) PostGet(s *service) error {
+	query := "SELECT monitoring_status FROM services WHERE name = $1"
+	var content []byte
+	if err := r.Tx().QueryRow(query, s.Name).Scan(&content); err != nil {
+		return sdk.WrapError(err, "PostGet> error on queryRow")
+	}
+
+	m := sdk.MonitoringStatus{}
+	if err := json.Unmarshal(content, &m); err != nil {
+		return sdk.WrapError(err, "PostGet> error on unmarshal job")
+	}
+	for i := range m.Lines {
+		m.Lines[i].Component = fmt.Sprintf("%s/%s", s.Name, m.Lines[i].Component)
+	}
+	s.MonitoringStatus = m
+	return nil
+}
+
+// PostUpdate is a DB Hook on PostUpdate to store monitoring_status JSON in DB
+func (r *Repository) PostUpdate(s *service) error {
+	content, err := json.Marshal(s.MonitoringStatus)
+	if err != nil {
+		return err
+	}
+
+	query := "update services set monitoring_status = $1 where name = $2"
+	if _, err := r.Tx().Exec(query, content, s.Name); err != nil {
+		return sdk.WrapError(err, "PostUpdate> err on update sql")
 	}
 	return nil
 }

--- a/engine/api/status.go
+++ b/engine/api/status.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"time"
 
 	"github.com/ovh/cds/engine/api/event"
 	"github.com/ovh/cds/engine/api/mail"
@@ -33,14 +32,10 @@ func VersionHandler() Handler {
 
 // Status returns status, implements interface service.Service
 func (api *API) Status() sdk.MonitoringStatus {
-	t := time.Now()
-	m := sdk.MonitoringStatus{Now: t}
+	m := api.CommonMonitoring()
 
-	m.Lines = append(m.Lines, getStatusLine(sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK}))
-	m.Lines = append(m.Lines, getStatusLine(sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(api.StartupTime)), Status: sdk.MonitoringStatusOK}))
 	m.Lines = append(m.Lines, getStatusLine(sdk.MonitoringStatusLine{Component: "Hostname", Value: event.GetHostname(), Status: sdk.MonitoringStatusOK}))
 	m.Lines = append(m.Lines, getStatusLine(sdk.MonitoringStatusLine{Component: "CDSName", Value: event.GetCDSName(), Status: sdk.MonitoringStatusOK}))
-	m.Lines = append(m.Lines, getStatusLine(sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK}))
 	m.Lines = append(m.Lines, getStatusLine(api.Router.StatusPanic()))
 	m.Lines = append(m.Lines, getStatusLine(scheduler.Status()))
 	m.Lines = append(m.Lines, getStatusLine(event.Status()))

--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -72,6 +72,13 @@ func (h *HatcheryKubernetes) ApplyConfiguration(cfg interface{}) error {
 	return nil
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcheryKubernetes) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
+}
+
 // getStartingConfig implements ConfigAccess
 func (h *HatcheryKubernetes) getStartingConfig() (*clientcmdapi.Config, error) {
 	defaultClientConfigRules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -61,7 +61,19 @@ func (h *HatcheryKubernetes) ApplyConfiguration(cfg interface{}) error {
 		}
 	}
 
-	// h.Client = cdsclient.NewService(h.Config.API.HTTP.URL, 60*time.Second)
+	h.hatch = &sdk.Hatchery{
+		Name:    h.Configuration().Name,
+		Version: sdk.VERSION,
+	}
+
+	h.Client = cdsclient.NewHatchery(
+		h.Configuration().API.HTTP.URL,
+		h.Configuration().API.Token,
+		h.Configuration().Provision.RegisterFrequency,
+		h.Configuration().API.HTTP.Insecure,
+		h.hatch.Name,
+	)
+
 	// h.API = h.Config.API.HTTP.URL
 	// h.Name = h.Config.Name
 	// h.HTTPURL = h.Config.URL
@@ -150,9 +162,9 @@ func (h *HatcheryKubernetes) Hatchery() *sdk.Hatchery {
 	return h.hatch
 }
 
-//Client returns cdsclient instance
-func (h *HatcheryKubernetes) Client() cdsclient.Interface {
-	return h.client
+//CDSClient returns cdsclient instance
+func (h *HatcheryKubernetes) CDSClient() cdsclient.Interface {
+	return h.Client
 }
 
 //Configuration returns Hatchery CommonConfiguration
@@ -291,18 +303,6 @@ func (h *HatcheryKubernetes) WorkersStartedByModel(model *sdk.Model) int {
 
 // Init register local hatchery with its worker model
 func (h *HatcheryKubernetes) Init() error {
-	h.hatch = &sdk.Hatchery{
-		Name:    h.Configuration().Name,
-		Version: sdk.VERSION,
-	}
-
-	h.client = cdsclient.NewHatchery(
-		h.Configuration().API.HTTP.URL,
-		h.Configuration().API.Token,
-		h.Configuration().Provision.RegisterFrequency,
-		h.Configuration().API.HTTP.Insecure,
-		h.hatch.Name,
-	)
 
 	if err := hatchery.Register(h); err != nil {
 		return fmt.Errorf("Cannot register: %s", err)

--- a/engine/hatchery/kubernetes/types.go
+++ b/engine/hatchery/kubernetes/types.go
@@ -5,7 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
@@ -41,8 +42,9 @@ type HatcheryConfiguration struct {
 
 // HatcheryKubernetes implements HatcheryMode interface for local usage
 type HatcheryKubernetes struct {
-	service.Common
+	hatcheryCommon.Common
 	Config HatcheryConfiguration
+	Router *api.Router
 	sync.Mutex
 	hatch     *sdk.Hatchery
 	workers   map[string]workerCmd

--- a/engine/hatchery/local/local.go
+++ b/engine/hatchery/local/local.go
@@ -44,6 +44,13 @@ func (h *HatcheryLocal) ApplyConfiguration(cfg interface{}) error {
 	return nil
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcheryLocal) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
+}
+
 // CheckConfiguration checks the validity of the configuration object
 func (h *HatcheryLocal) CheckConfiguration(cfg interface{}) error {
 	hconfig, ok := cfg.(HatcheryConfiguration)

--- a/engine/hatchery/local/types.go
+++ b/engine/hatchery/local/types.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ovh/cds/engine/service"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 )
@@ -19,7 +19,7 @@ type HatcheryConfiguration struct {
 
 // HatcheryLocal implements HatcheryMode interface for local usage
 type HatcheryLocal struct {
-	service.Common
+	hatcheryCommon.Common
 	Config HatcheryConfiguration
 	sync.Mutex
 	hatch   *sdk.Hatchery

--- a/engine/hatchery/local/types.go
+++ b/engine/hatchery/local/types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
@@ -25,7 +24,6 @@ type HatcheryLocal struct {
 	sync.Mutex
 	hatch   *sdk.Hatchery
 	workers map[string]workerCmd
-	client  cdsclient.Interface
 	os      string
 	arch    string
 }

--- a/engine/hatchery/marathon/marathon.go
+++ b/engine/hatchery/marathon/marathon.go
@@ -15,7 +15,6 @@ import (
 	"github.com/facebookgo/httpcontrol"
 	"github.com/gambol99/go-marathon"
 	"github.com/gorilla/mux"
-	"github.com/ovh/cds/sdk/namesgenerator"
 
 	"github.com/ovh/cds/engine/api"
 	"github.com/ovh/cds/engine/api/services"
@@ -23,6 +22,7 @@ import (
 	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 	"github.com/ovh/cds/sdk/log"
+	"github.com/ovh/cds/sdk/namesgenerator"
 )
 
 // New instanciates a new Hatchery Marathon

--- a/engine/hatchery/marathon/marathon.go
+++ b/engine/hatchery/marathon/marathon.go
@@ -50,6 +50,13 @@ func (h *HatcheryMarathon) ApplyConfiguration(cfg interface{}) error {
 	return nil
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcheryMarathon) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
+}
+
 // CheckConfiguration checks the validity of the configuration object
 func (h *HatcheryMarathon) CheckConfiguration(cfg interface{}) error {
 	hconfig, ok := cfg.(HatcheryConfiguration)

--- a/engine/hatchery/marathon/types.go
+++ b/engine/hatchery/marathon/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
@@ -45,7 +44,6 @@ type HatcheryMarathon struct {
 	hatch  *sdk.Hatchery
 
 	marathonClient marathon.Marathon
-	client         cdsclient.Interface
 
 	marathonLabels map[string]string
 }

--- a/engine/hatchery/marathon/types.go
+++ b/engine/hatchery/marathon/types.go
@@ -3,7 +3,8 @@ package marathon
 import (
 	"github.com/gambol99/go-marathon"
 
-	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 )
@@ -39,11 +40,10 @@ type HatcheryConfiguration struct {
 
 // HatcheryMarathon implements HatcheryMode interface for mesos mode
 type HatcheryMarathon struct {
-	service.Common
-	Config HatcheryConfiguration
-	hatch  *sdk.Hatchery
-
+	hatcheryCommon.Common
+	Config         HatcheryConfiguration
+	Router         *api.Router
+	hatch          *sdk.Hatchery
 	marathonClient marathon.Marathon
-
 	marathonLabels map[string]string
 }

--- a/engine/hatchery/openstack/init.go
+++ b/engine/hatchery/openstack/init.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/tenantnetworks"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 
-	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 	"github.com/ovh/cds/sdk/log"
 )
@@ -18,18 +16,6 @@ import (
 // then list available models
 // then list available images
 func (h *HatcheryOpenstack) Init() error {
-	h.hatch = &sdk.Hatchery{
-		Name:    h.Configuration().Name,
-		Version: sdk.VERSION,
-	}
-
-	h.client = cdsclient.NewHatchery(
-		h.Configuration().API.HTTP.URL,
-		h.Configuration().API.Token,
-		h.Configuration().Provision.RegisterFrequency,
-		h.Configuration().API.HTTP.Insecure,
-		h.hatch.Name,
-	)
 	if err := hatchery.Register(h); err != nil {
 		return fmt.Errorf("Cannot register: %s", err)
 	}

--- a/engine/hatchery/openstack/openstack.go
+++ b/engine/hatchery/openstack/openstack.go
@@ -58,6 +58,13 @@ func (h *HatcheryOpenstack) ApplyConfiguration(cfg interface{}) error {
 	return nil
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcheryOpenstack) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
+}
+
 // CheckConfiguration checks the validity of the configuration object
 func (h *HatcheryOpenstack) CheckConfiguration(cfg interface{}) error {
 	hconfig, ok := cfg.(HatcheryConfiguration)

--- a/engine/hatchery/openstack/openstack.go
+++ b/engine/hatchery/openstack/openstack.go
@@ -47,7 +47,19 @@ func (h *HatcheryOpenstack) ApplyConfiguration(cfg interface{}) error {
 		return fmt.Errorf("Invalid configuration")
 	}
 
-	// h.Client = cdsclient.NewService(h.Config.API.HTTP.URL, 60*time.Second)
+	h.hatch = &sdk.Hatchery{
+		Name:    h.Configuration().Name,
+		Version: sdk.VERSION,
+	}
+
+	h.Client = cdsclient.NewHatchery(
+		h.Configuration().API.HTTP.URL,
+		h.Configuration().API.Token,
+		h.Configuration().Provision.RegisterFrequency,
+		h.Configuration().API.HTTP.Insecure,
+		h.hatch.Name,
+	)
+
 	// h.API = h.Config.API.HTTP.URL
 	// h.Name = h.Config.Name
 	// h.HTTPURL = h.Config.URL
@@ -135,9 +147,9 @@ func (h *HatcheryOpenstack) Hatchery() *sdk.Hatchery {
 	return h.hatch
 }
 
-//Client returns cdsclient instance
-func (h *HatcheryOpenstack) Client() cdsclient.Interface {
-	return h.client
+//CDSClient returns cdsclient instance
+func (h *HatcheryOpenstack) CDSClient() cdsclient.Interface {
+	return h.Client
 }
 
 //Configuration returns Hatchery CommonConfiguration
@@ -210,7 +222,7 @@ func (h *HatcheryOpenstack) updateServerList() {
 }
 
 func (h *HatcheryOpenstack) killAwolServers() {
-	workers, err := h.Client().WorkerList()
+	workers, err := h.CDSClient().WorkerList()
 	now := time.Now().Unix()
 	if err != nil {
 		log.Warning("killAwolServers> Cannot fetch worker list: %s", err)
@@ -385,7 +397,7 @@ func (h *HatcheryOpenstack) killErrorServers() {
 }
 
 func (h *HatcheryOpenstack) killDisabledWorkers() {
-	workers, err := h.Client().WorkerList()
+	workers, err := h.CDSClient().WorkerList()
 	if err != nil {
 		log.Warning("killDisabledWorkers> Cannot fetch worker list: %s", err)
 		return

--- a/engine/hatchery/openstack/types.go
+++ b/engine/hatchery/openstack/types.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
@@ -59,7 +58,6 @@ type HatcheryOpenstack struct {
 	networks        []tenantnetworks.Network
 	images          []images.Image
 	openstackClient *gophercloud.ServiceClient
-	client          cdsclient.Interface
 
 	networkID string // computed from networkString
 }

--- a/engine/hatchery/openstack/types.go
+++ b/engine/hatchery/openstack/types.go
@@ -8,7 +8,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 
-	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 )
@@ -51,8 +52,9 @@ type HatcheryConfiguration struct {
 // HatcheryOpenstack spawns instances of worker model with type 'ISO'
 // by startup up virtual machines on /cloud
 type HatcheryOpenstack struct {
-	service.Common
+	hatcheryCommon.Common
 	Config          HatcheryConfiguration
+	Router          *api.Router
 	hatch           *sdk.Hatchery
 	flavors         []flavors.Flavor
 	networks        []tenantnetworks.Network

--- a/engine/hatchery/serve.go
+++ b/engine/hatchery/serve.go
@@ -57,14 +57,14 @@ func (c *Common) CommonServe(ctx context.Context, h hatchery.Interface) error {
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	//Start the http server
-	log.Info("%s> Starting HTTP Server on port %d", c.Name, h.Configuration().HTTP.Port)
-	if err := server.ListenAndServe(); err != nil {
-		log.Error("%s> Listen and serve failed: %s", c.Name, err)
-	}
-
-	//Gracefully shutdown the http server
 	go func() {
+		//Start the http server
+		log.Info("%s> Starting HTTP Server on port %d", c.Name, h.Configuration().HTTP.Port)
+		if err := server.ListenAndServe(); err != nil {
+			log.Error("%s> Listen and serve failed: %s", c.Name, err)
+		}
+
+		//Gracefully shutdown the http server
 		select {
 		case <-ctx.Done():
 			log.Info("%s> Shutdown HTTP Server", c.Name)

--- a/engine/hatchery/serve.go
+++ b/engine/hatchery/serve.go
@@ -1,0 +1,91 @@
+package hatchery
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ovh/cds/engine/api"
+	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/cdsclient"
+	"github.com/ovh/cds/sdk/hatchery"
+	"github.com/ovh/cds/sdk/log"
+)
+
+type Common struct {
+	service.Common
+	Router *api.Router
+}
+
+func (c *Common) AuthMiddleware(ctx context.Context, w http.ResponseWriter, req *http.Request, rc *api.HandlerConfig) (context.Context, error) {
+	if rc.Options["auth"] != "true" {
+		return ctx, nil
+	}
+
+	hash, err := base64.StdEncoding.DecodeString(req.Header.Get(sdk.AuthHeader))
+	if err != nil {
+		return ctx, fmt.Errorf("bad header syntax: %s", err)
+	}
+
+	if c.Hash == string(hash) {
+		return ctx, nil
+	}
+
+	return ctx, sdk.ErrUnauthorized
+}
+
+//CDSClient returns cdsclient instance
+func (c *Common) CDSClient() cdsclient.Interface {
+	return c.Client
+}
+
+// CommonServe start the HatcheryLocal server
+func (c *Common) CommonServe(ctx context.Context, h hatchery.Interface) error {
+	log.Info("%s> Starting service %s...", c.Name, sdk.VERSION)
+	c.StartupTime = time.Now()
+
+	//Init the http server
+	c.initRouter(ctx, h)
+	server := &http.Server{
+		Addr:           fmt.Sprintf("%s:%d", h.Configuration().HTTP.Addr, h.Configuration().HTTP.Port),
+		Handler:        c.Router.Mux,
+		ReadTimeout:    10 * time.Minute,
+		WriteTimeout:   10 * time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	//Start the http server
+	log.Info("%s> Starting HTTP Server on port %d", c.Name, h.Configuration().HTTP.Port)
+	if err := server.ListenAndServe(); err != nil {
+		log.Error("%s> Listen and serve failed: %s", c.Name, err)
+	}
+
+	//Gracefully shutdown the http server
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Info("%s> Shutdown HTTP Server", c.Name)
+			server.Shutdown(ctx)
+		}
+	}()
+
+	if err := hatchery.Create(h); err != nil {
+		return err
+	}
+
+	return ctx.Err()
+}
+
+func (c *Common) initRouter(ctx context.Context, h hatchery.Interface) {
+	log.Debug("%s> Router initialized", c.Name)
+	r := c.Router
+	r.Background = ctx
+	r.URL = h.Configuration().URL
+	r.SetHeaderFunc = api.DefaultHeaders
+	r.Middlewares = append(r.Middlewares, c.AuthMiddleware)
+
+	r.Handle("/mon/version", r.GET(api.VersionHandler, api.Auth(false)))
+}

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -29,18 +29,6 @@ func (h *HatcherySwarm) Serve(ctx context.Context) error {
 
 //Init connect the hatchery to the docker api
 func (h *HatcherySwarm) Init() error {
-	h.hatch = &sdk.Hatchery{
-		Name:    h.Configuration().Name,
-		Version: sdk.VERSION,
-	}
-
-	h.client = cdsclient.NewHatchery(
-		h.Configuration().API.HTTP.URL,
-		h.Configuration().API.Token,
-		h.Configuration().Provision.RegisterFrequency,
-		h.Configuration().API.HTTP.Insecure,
-		h.hatch.Name,
-	)
 	if err := hatchery.Register(h); err != nil {
 		return fmt.Errorf("Cannot register: %s", err)
 	}
@@ -155,7 +143,7 @@ func (h *HatcherySwarm) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string, 
 	}
 
 	//cmd is the command to start the worker (we need curl to download current version of the worker binary)
-	cmd := []string{"sh", "-c", fmt.Sprintf("curl %s/download/worker/linux/`uname -m` -o worker && echo chmod worker && chmod +x worker && echo starting worker && ./worker%s", h.Client().APIURL(), registerCmd)}
+	cmd := []string{"sh", "-c", fmt.Sprintf("curl %s/download/worker/linux/`uname -m` -o worker && echo chmod worker && chmod +x worker && echo starting worker && ./worker%s", h.CDSClient().APIURL(), registerCmd)}
 
 	//CDS env needed by the worker binary
 	env := []string{
@@ -423,9 +411,9 @@ func (h *HatcherySwarm) Hatchery() *sdk.Hatchery {
 	return h.hatch
 }
 
-//Client returns cdsclient instance
-func (h *HatcherySwarm) Client() cdsclient.Interface {
-	return h.client
+//CDSClient returns cdsclient instance
+func (h *HatcherySwarm) CDSClient() cdsclient.Interface {
+	return h.Client
 }
 
 //Configuration returns Hatchery CommonConfiguration
@@ -449,7 +437,7 @@ func (h *HatcherySwarm) killAwolWorkerRoutine() {
 }
 
 func (h *HatcherySwarm) listAwolWorkers() ([]types.Container, error) {
-	apiworkers, err := h.Client().WorkerList()
+	apiworkers, err := h.CDSClient().WorkerList()
 	if err != nil {
 		return nil, sdk.WrapError(err, "listAwolWorkers> Cannot get workers")
 	}

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -8,10 +8,11 @@ import (
 
 	types "github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
+	"github.com/gorilla/mux"
 	context "golang.org/x/net/context"
 
+	"github.com/ovh/cds/engine/api"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 	"github.com/ovh/cds/sdk/log"
 	"github.com/ovh/cds/sdk/namesgenerator"
@@ -19,12 +20,11 @@ import (
 
 // New instanciates a new Hatchery Swarm
 func New() *HatcherySwarm {
-	return new(HatcherySwarm)
-}
-
-// Serve start the HatcherySwarm server
-func (h *HatcherySwarm) Serve(ctx context.Context) error {
-	return hatchery.Create(h)
+	s := new(HatcherySwarm)
+	s.Router = &api.Router{
+		Mux: mux.NewRouter(),
+	}
+	return s
 }
 
 //Init connect the hatchery to the docker api
@@ -411,9 +411,9 @@ func (h *HatcherySwarm) Hatchery() *sdk.Hatchery {
 	return h.hatch
 }
 
-//CDSClient returns cdsclient instance
-func (h *HatcherySwarm) CDSClient() cdsclient.Interface {
-	return h.Client
+// Serve start the hatchery server
+func (h *HatcherySwarm) Serve(ctx context.Context) error {
+	return h.CommonServe(ctx, h)
 }
 
 //Configuration returns Hatchery CommonConfiguration

--- a/engine/hatchery/swarm/swarm_conf.go
+++ b/engine/hatchery/swarm/swarm_conf.go
@@ -3,6 +3,9 @@ package swarm
 import (
 	"fmt"
 	"os"
+	"time"
+
+	"github.com/ovh/cds/sdk"
 )
 
 // ApplyConfiguration apply an object of type HatcheryConfiguration after checking it
@@ -26,6 +29,13 @@ func (h *HatcherySwarm) ApplyConfiguration(cfg interface{}) error {
 	// h.MaxHeartbeatFailures = h.Config.API.MaxHeartbeatFailures
 
 	return nil
+}
+
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcherySwarm) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
 }
 
 // CheckConfiguration checks the validity of the configuration object

--- a/engine/hatchery/swarm/swarm_conf.go
+++ b/engine/hatchery/swarm/swarm_conf.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/cdsclient"
 )
 
 // ApplyConfiguration apply an object of type HatcheryConfiguration after checking it
@@ -20,7 +21,19 @@ func (h *HatcherySwarm) ApplyConfiguration(cfg interface{}) error {
 		return fmt.Errorf("Invalid configuration")
 	}
 
-	// h.Client = cdsclient.NewService(h.Config.API.HTTP.URL, 60*time.Second)
+	h.hatch = &sdk.Hatchery{
+		Name:    h.Configuration().Name,
+		Version: sdk.VERSION,
+	}
+
+	h.Client = cdsclient.NewHatchery(
+		h.Configuration().API.HTTP.URL,
+		h.Configuration().API.Token,
+		h.Configuration().Provision.RegisterFrequency,
+		h.Configuration().API.HTTP.Insecure,
+		h.hatch.Name,
+	)
+
 	// h.API = h.Config.API.HTTP.URL
 	// h.Name = h.Config.Name
 	// h.HTTPURL = h.Config.URL

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
@@ -32,5 +31,4 @@ type HatcherySwarm struct {
 	Config       HatcheryConfiguration
 	hatch        *sdk.Hatchery
 	dockerClient *docker.Client
-	client       cdsclient.Interface
 }

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -3,7 +3,8 @@ package swarm
 import (
 	docker "github.com/docker/docker/client"
 
-	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 )
@@ -27,8 +28,9 @@ type HatcheryConfiguration struct {
 
 // HatcherySwarm is a hatchery which can be connected to a remote to a docker remote api
 type HatcherySwarm struct {
-	service.Common
+	hatcheryCommon.Common
 	Config       HatcheryConfiguration
+	Router       *api.Router
 	hatch        *sdk.Hatchery
 	dockerClient *docker.Client
 }

--- a/engine/hatchery/vsphere/init.go
+++ b/engine/hatchery/vsphere/init.go
@@ -9,24 +9,11 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
 // Init create new client for vsphere
 func (h *HatcheryVSphere) Init() error {
-	h.hatch = &sdk.Hatchery{
-		Name:    h.Configuration().Name,
-		Version: sdk.VERSION,
-	}
-
-	h.client = cdsclient.NewHatchery(
-		h.Configuration().API.HTTP.URL,
-		h.Configuration().API.Token,
-		h.Configuration().Provision.RegisterFrequency,
-		h.Configuration().API.HTTP.Insecure,
-		h.hatch.Name,
-	)
 	if err := hatchery.Register(h); err != nil {
 		return fmt.Errorf("Cannot register: %s", err)
 	}

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -5,7 +5,8 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 
-	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 )
@@ -47,8 +48,9 @@ type HatcheryConfiguration struct {
 
 // HatcheryVSphere spawns vm
 type HatcheryVSphere struct {
-	service.Common
+	hatcheryCommon.Common
 	Config     HatcheryConfiguration
+	Router     *api.Router
 	hatch      *sdk.Hatchery
 	images     []string
 	datacenter *object.Datacenter

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 )
 
@@ -56,7 +55,6 @@ type HatcheryVSphere struct {
 	finder     *find.Finder
 	network    object.NetworkReference
 	vclient    *govmomi.Client
-	client     cdsclient.Interface
 
 	// User provided parameters
 	endpoint           string

--- a/engine/hatchery/vsphere/vsphere.go
+++ b/engine/hatchery/vsphere/vsphere.go
@@ -43,6 +43,13 @@ func (h *HatcheryVSphere) ApplyConfiguration(cfg interface{}) error {
 	return nil
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (h *HatcheryVSphere) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+	return m
+}
+
 // CheckConfiguration checks the validity of the configuration object
 func (h *HatcheryVSphere) CheckConfiguration(cfg interface{}) error {
 	hconfig, ok := cfg.(HatcheryConfiguration)

--- a/engine/hatchery/vsphere/vsphere.go
+++ b/engine/hatchery/vsphere/vsphere.go
@@ -32,7 +32,19 @@ func (h *HatcheryVSphere) ApplyConfiguration(cfg interface{}) error {
 		return fmt.Errorf("Invalid configuration")
 	}
 
-	// h.Client = cdsclient.NewService(h.Config.API.HTTP.URL, 60*time.Second)
+	h.hatch = &sdk.Hatchery{
+		Name:    h.Configuration().Name,
+		Version: sdk.VERSION,
+	}
+
+	h.Client = cdsclient.NewHatchery(
+		h.Configuration().API.HTTP.URL,
+		h.Configuration().API.Token,
+		h.Configuration().Provision.RegisterFrequency,
+		h.Configuration().API.HTTP.Insecure,
+		h.hatch.Name,
+	)
+
 	// h.API = h.Config.API.HTTP.URL
 	// h.Name = h.Config.Name
 	// h.HTTPURL = h.Config.URL
@@ -104,9 +116,9 @@ func (h *HatcheryVSphere) CanSpawn(model *sdk.Model, jobID int64, requirements [
 	return true
 }
 
-//Client returns cdsclient instance
-func (h *HatcheryVSphere) Client() cdsclient.Interface {
-	return h.client
+//CDSClient returns cdsclient instance
+func (h *HatcheryVSphere) CDSClient() cdsclient.Interface {
+	return h.Client
 }
 
 //Configuration returns Hatchery CommonConfiguration
@@ -219,7 +231,7 @@ func (h *HatcheryVSphere) updateServerList() {
 
 // killDisabledWorkers kill workers which are disabled
 func (h *HatcheryVSphere) killDisabledWorkers() {
-	workers, err := h.Client().WorkerList()
+	workers, err := h.CDSClient().WorkerList()
 	if err != nil {
 		log.Warning("killDisabledWorkers> Cannot fetch worker list: %s", err)
 		return

--- a/engine/hooks/hooks_handlers.go
+++ b/engine/hooks/hooks_handlers.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -259,12 +258,7 @@ func (s *Service) addTask(ctx context.Context, h *sdk.WorkflowNodeHook) error {
 
 // Status returns sdk.MonitoringStatus, implements interface service.Service
 func (s *Service) Status() sdk.MonitoringStatus {
-	t := time.Now()
-	m := sdk.MonitoringStatus{Now: t}
-
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+	m := s.CommonMonitoring()
 
 	return m
 }

--- a/engine/hooks/types.go
+++ b/engine/hooks/types.go
@@ -27,7 +27,7 @@ type Configuration struct {
 	Name string `toml:"name" comment:"Name of this CDS Hooks Service"`
 	HTTP struct {
 		Addr string `toml:"addr" default:"" commented:"true" comment:"Listen address without port, example: 127.0.0.1"`
-		Port int    `toml:"port" default:"8083" toml:"name"`
+		Port int    `toml:"port" default:"8083"`
 	} `toml:"http" comment:"######################\n CDS Hooks HTTP Configuration \n######################"`
 	URL              string `default:"http://localhost:8083"`
 	URLPublic        string `toml:"urlPublic" comment:"Public url for external call (webhook)"`

--- a/engine/main.go
+++ b/engine/main.go
@@ -427,7 +427,7 @@ func serve(c context.Context, s service.Service, serviceName string) error {
 	}
 
 	//First register(heartbeat)
-	if _, err := s.DoHeartbeat(); err != nil {
+	if _, err := s.DoHeartbeat(s.Status); err != nil {
 		log.Error("%s> Unable to register: %v", serviceName, err)
 		return err
 	}
@@ -435,7 +435,7 @@ func serve(c context.Context, s service.Service, serviceName string) error {
 
 	//Start the heartbeat goroutine
 	go func() {
-		if err := s.Heartbeat(ctx); err != nil {
+		if err := s.Heartbeat(ctx, s.Status); err != nil {
 			log.Error("%v", err)
 			cancel()
 		}

--- a/engine/main.go
+++ b/engine/main.go
@@ -419,13 +419,6 @@ func serve(c context.Context, s service.Service, serviceName string) error {
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	// no heartbeat for api for now
-	if serviceName == "api" || strings.HasPrefix(serviceName, "hatchery") {
-		if err := s.Serve(c); err != nil {
-			return err
-		}
-	}
-
 	//First register(heartbeat)
 	if _, err := s.DoHeartbeat(s.Status); err != nil {
 		log.Error("%s> Unable to register: %v", serviceName, err)

--- a/engine/repositories/repositories_handlers.go
+++ b/engine/repositories/repositories_handlers.go
@@ -50,16 +50,20 @@ func (s *Service) getOperationsHandler() api.Handler {
 	}
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (s *Service) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+	return m
+}
+
 func (s *Service) getStatusHandler() api.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		t := time.Now()
-		output := sdk.MonitoringStatus{Now: t}
-
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
-
 		var status = http.StatusOK
-		return api.WriteJSON(w, output, status)
+		return api.WriteJSON(w, s.Status(), status)
 	}
 }

--- a/engine/repositories/repositories_handlers.go
+++ b/engine/repositories/repositories_handlers.go
@@ -2,7 +2,6 @@ package repositories
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -52,12 +51,7 @@ func (s *Service) getOperationsHandler() api.Handler {
 
 // Status returns sdk.MonitoringStatus, implements interface service.Service
 func (s *Service) Status() sdk.MonitoringStatus {
-	t := time.Now()
-	m := sdk.MonitoringStatus{Now: t}
-
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+	m := s.CommonMonitoring()
 	return m
 }
 

--- a/engine/repositories/types.go
+++ b/engine/repositories/types.go
@@ -27,7 +27,7 @@ type Configuration struct {
 	RepositoriesRentention int    `toml:"repositories_retention" comment:"Re retention on the filesystem (in days)" default:"10"`
 	HTTP                   struct {
 		Addr string `toml:"addr" default:"" commented:"true" comment:"Listen address without port, example: 127.0.0.1"`
-		Port int    `toml:"port" default:"8085" toml:"name"`
+		Port int    `toml:"port" default:"8085"`
 	} `toml:"http" comment:"######################\n CDS Repositories HTTP Configuration \n######################"`
 	URL string `default:"http://localhost:8085"`
 	API struct {

--- a/engine/service/heartbeat.go
+++ b/engine/service/heartbeat.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ovh/cds/sdk/log"
 )
 
-func (c *Common) Heartbeat(ctx context.Context) error {
+// Heartbeat have to be launch as a goroutine, call DoHeartBeat each 30s
+func (c *Common) Heartbeat(ctx context.Context, status func() sdk.MonitoringStatus) error {
 	ticker := time.NewTicker(30 * time.Second)
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
@@ -21,11 +22,11 @@ func (c *Common) Heartbeat(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if maxHeartbeatFailures, err := c.DoHeartbeat(); err != nil {
-				log.Error("VCS> heartbeat> Heartbeat failed")
+			if maxHeartbeatFailures, err := c.DoHeartbeat(status); err != nil {
+				log.Error("%s> Heartbeat> Heartbeat failed", c.Name)
 				heartbeatFailures++
 				if heartbeatFailures > maxHeartbeatFailures {
-					return fmt.Errorf("Heartbeat failed excedeed")
+					return fmt.Errorf("%s> Heartbeat> failed excedeed", c.Name)
 				}
 			}
 			heartbeatFailures = 0
@@ -34,18 +35,19 @@ func (c *Common) Heartbeat(ctx context.Context) error {
 }
 
 // DoHeartbeat registers the service for heartbeat
-func (c *Common) DoHeartbeat() (int, error) {
+func (c *Common) DoHeartbeat(status func() sdk.MonitoringStatus) (int, error) {
 	srv := sdk.Service{
-		Name:          c.Name,
-		HTTPURL:       c.HTTPURL,
-		LastHeartbeat: time.Time{},
-		Token:         c.Token,
-		Type:          c.Type,
+		Name:             c.Name,
+		HTTPURL:          c.HTTPURL,
+		LastHeartbeat:    time.Time{},
+		Token:            c.Token,
+		Type:             c.Type,
+		MonitoringStatus: status(),
 	}
-	log.Debug("%s> doHeartbeat: %+v", c.Name, srv)
+	log.Debug("%s> DoHeartbeat> %+v", c.Name, srv)
 	hash, err := c.Client.ServiceRegister(srv)
 	if err != nil {
-		return 0, sdk.WrapError(err, "doHeartbeat")
+		return 0, sdk.WrapError(err, "DoHeartbeat>")
 	}
 	c.Hash = hash
 	return c.MaxHeartbeatFailures, nil

--- a/engine/service/heartbeat.go
+++ b/engine/service/heartbeat.go
@@ -9,6 +9,18 @@ import (
 	"github.com/ovh/cds/sdk/log"
 )
 
+// CommonMonitoring returns common part of MonitoringStatus
+func (c *Common) CommonMonitoring() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(c.StartupTime)), Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+
+	return m
+}
+
 // Heartbeat have to be launch as a goroutine, call DoHeartBeat each 30s
 func (c *Common) Heartbeat(ctx context.Context, status func() sdk.MonitoringStatus) error {
 	ticker := time.NewTicker(30 * time.Second)
@@ -36,6 +48,11 @@ func (c *Common) Heartbeat(ctx context.Context, status func() sdk.MonitoringStat
 
 // DoHeartbeat registers the service for heartbeat
 func (c *Common) DoHeartbeat(status func() sdk.MonitoringStatus) (int, error) {
+	// no heartbeat for api
+	if c.Type == "api" {
+		return 0, nil
+	}
+
 	srv := sdk.Service{
 		Name:             c.Name,
 		HTTPURL:          c.HTTPURL,

--- a/engine/service/heartbeat.go
+++ b/engine/service/heartbeat.go
@@ -61,7 +61,7 @@ func (c *Common) DoHeartbeat(status func() sdk.MonitoringStatus) (int, error) {
 		Type:             c.Type,
 		MonitoringStatus: status(),
 	}
-	log.Debug("%s> DoHeartbeat> %+v", c.Name, srv)
+	log.Debug("%s> DoHeartbeat", c.Name)
 	hash, err := c.Client.ServiceRegister(srv)
 	if err != nil {
 		return 0, sdk.WrapError(err, "DoHeartbeat>")

--- a/engine/service/service.go
+++ b/engine/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
 )
 
@@ -24,6 +25,7 @@ type Service interface {
 	ApplyConfiguration(cfg interface{}) error
 	Serve(ctx context.Context) error
 	CheckConfiguration(cfg interface{}) error
-	Heartbeat(ctx context.Context) error
-	DoHeartbeat() (int, error)
+	Heartbeat(ctx context.Context, status func() sdk.MonitoringStatus) error
+	DoHeartbeat(status func() sdk.MonitoringStatus) (int, error)
+	Status() sdk.MonitoringStatus
 }

--- a/engine/sql/089_service_status.sql
+++ b/engine/sql/089_service_status.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE services ADD COLUMN monitoring_status JSONB;
+
+-- +migrate Down
+ALTER TABLE services DROP COLUMN monitoring_status;

--- a/engine/vcs/types.go
+++ b/engine/vcs/types.go
@@ -23,7 +23,7 @@ type Configuration struct {
 	Name string `toml:"name" comment:"Name of this CDS VCS Service"`
 	HTTP struct {
 		Addr string `toml:"addr" default:"" commented:"true" comment:"Listen address without port, example: 127.0.0.1"`
-		Port int    `toml:"port" default:"8084" toml:"name"`
+		Port int    `toml:"port" default:"8084"`
 	} `toml:"http" comment:"######################\n CDS VCS HTTP Configuration \n######################"`
 	URL string `default:"http://localhost:8084"`
 	UI  struct {

--- a/engine/vcs/vcs_handlers.go
+++ b/engine/vcs/vcs_handlers.go
@@ -747,12 +747,7 @@ func (s *Service) getListForks() api.Handler {
 
 // Status returns sdk.MonitoringStatus, implements interface service.Service
 func (s *Service) Status() sdk.MonitoringStatus {
-	t := time.Now()
-	m := sdk.MonitoringStatus{Now: t}
-
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
-	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+	m := s.CommonMonitoring()
 	m.Lines = append(m.Lines, github.GetStatus()...)
 	return m
 }

--- a/engine/vcs/vcs_handlers.go
+++ b/engine/vcs/vcs_handlers.go
@@ -745,18 +745,21 @@ func (s *Service) getListForks() api.Handler {
 	}
 }
 
+// Status returns sdk.MonitoringStatus, implements interface service.Service
+func (s *Service) Status() sdk.MonitoringStatus {
+	t := time.Now()
+	m := sdk.MonitoringStatus{Now: t}
+
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
+	m.Lines = append(m.Lines, github.GetStatus()...)
+	return m
+}
+
 func (s *Service) statusHandler() api.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		t := time.Now()
-		output := sdk.MonitoringStatus{Now: t}
-
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Version", Value: sdk.VERSION, Status: sdk.MonitoringStatusOK})
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Uptime", Value: fmt.Sprintf("%s", time.Since(s.StartupTime)), Status: sdk.MonitoringStatusOK})
-		output.Lines = append(output.Lines, sdk.MonitoringStatusLine{Component: "Time", Value: fmt.Sprintf("%dh%dm%ds", t.Hour(), t.Minute(), t.Second()), Status: sdk.MonitoringStatusOK})
-
-		output.Lines = append(github.GetStatus())
-
 		var status = http.StatusOK
-		return api.WriteJSON(w, output, status)
+		return api.WriteJSON(w, s.Status(), status)
 	}
 }

--- a/engine/vcs/vcs_router.go
+++ b/engine/vcs/vcs_router.go
@@ -40,5 +40,4 @@ func (s *Service) initRouter(ctx context.Context) {
 	r.Handle("/vcs/{name}/repos/{owner}/{repo}/forks", r.GET(s.getListForks))
 
 	r.Handle("/vcs/{name}/status", r.POST(s.postStatusHandler))
-
 }

--- a/sdk/cdsclient/client_admin.go
+++ b/sdk/cdsclient/client_admin.go
@@ -15,32 +15,40 @@ func (c *client) Services() ([]sdk.Service, error) {
 	return srvs, nil
 }
 
-func (c *client) ServicesByType(s string) ([]sdk.Service, error) {
+func (c *client) ServicesByName(name string) (*sdk.Service, error) {
+	srv := sdk.Service{}
+	if _, err := c.GetJSON("/admin/service/"+name, &srv); err != nil {
+		return nil, err
+	}
+	return &srv, nil
+}
+
+func (c *client) ServicesByType(stype string) ([]sdk.Service, error) {
 	srvs := []sdk.Service{}
-	if _, err := c.GetJSON("/admin/services/"+s, &srvs); err != nil {
+	if _, err := c.GetJSON("/admin/services?type="+stype, &srvs); err != nil {
 		return nil, err
 	}
 	return srvs, nil
 }
 
-func (c *client) ServiceCallGET(s string, query string) ([]byte, error) {
-	btes, _, _, err := c.Request("GET", "/admin/services/"+s+"/call?query="+url.QueryEscape(query), nil)
+func (c *client) ServiceCallGET(stype string, sname string, query string) ([]byte, error) {
+	btes, _, _, err := c.Request("GET", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), nil)
 	return btes, err
 }
 
-func (c *client) ServiceCallPOST(s string, query string, body []byte) ([]byte, error) {
+func (c *client) ServiceCallPOST(stype string, sname string, query string, body []byte) ([]byte, error) {
 	rBody := bytes.NewReader(body)
-	btes, _, _, err := c.Request("POST", "/admin/services/"+s+"/call?query="+url.QueryEscape(query), rBody)
+	btes, _, _, err := c.Request("POST", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), rBody)
 	return btes, err
 }
 
-func (c *client) ServiceCallPUT(s string, query string, body []byte) ([]byte, error) {
+func (c *client) ServiceCallPUT(stype string, sname string, query string, body []byte) ([]byte, error) {
 	rBody := bytes.NewReader(body)
-	btes, _, _, err := c.Request("PUT", "/admin/services/"+s+"/call?query="+url.QueryEscape(query), rBody)
+	btes, _, _, err := c.Request("PUT", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), rBody)
 	return btes, err
 }
 
-func (c *client) ServiceCallDELETE(s string, query string) error {
-	_, _, _, err := c.Request("DELETE", "/admin/services/"+s+"/call?query="+url.QueryEscape(query), nil)
+func (c *client) ServiceCallDELETE(stype string, sname string, query string) error {
+	_, _, _, err := c.Request("DELETE", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), nil)
 	return err
 }

--- a/sdk/cdsclient/client_admin.go
+++ b/sdk/cdsclient/client_admin.go
@@ -31,24 +31,24 @@ func (c *client) ServicesByType(stype string) ([]sdk.Service, error) {
 	return srvs, nil
 }
 
-func (c *client) ServiceCallGET(stype string, sname string, query string) ([]byte, error) {
-	btes, _, _, err := c.Request("GET", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), nil)
+func (c *client) ServiceCallGET(stype string, query string) ([]byte, error) {
+	btes, _, _, err := c.Request("GET", "/admin/services/call?type="+stype+"&query="+url.QueryEscape(query), nil)
 	return btes, err
 }
 
-func (c *client) ServiceCallPOST(stype string, sname string, query string, body []byte) ([]byte, error) {
+func (c *client) ServiceCallPOST(stype string, query string, body []byte) ([]byte, error) {
 	rBody := bytes.NewReader(body)
-	btes, _, _, err := c.Request("POST", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), rBody)
+	btes, _, _, err := c.Request("POST", "/admin/services/call?type="+stype+"&query="+url.QueryEscape(query), rBody)
 	return btes, err
 }
 
-func (c *client) ServiceCallPUT(stype string, sname string, query string, body []byte) ([]byte, error) {
+func (c *client) ServiceCallPUT(stype string, query string, body []byte) ([]byte, error) {
 	rBody := bytes.NewReader(body)
-	btes, _, _, err := c.Request("PUT", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), rBody)
+	btes, _, _, err := c.Request("PUT", "/admin/services/call?type="+stype+"&query="+url.QueryEscape(query), rBody)
 	return btes, err
 }
 
-func (c *client) ServiceCallDELETE(stype string, sname string, query string) error {
-	_, _, _, err := c.Request("DELETE", "/admin/services/call?type="+stype+"&name="+sname+"&query="+url.QueryEscape(query), nil)
+func (c *client) ServiceCallDELETE(stype string, query string) error {
+	_, _, _, err := c.Request("DELETE", "/admin/services/call?type="+stype+"&query="+url.QueryEscape(query), nil)
 	return err
 }

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -18,11 +18,12 @@ type Filter struct {
 // AdminService expose all function to CDS services
 type AdminService interface {
 	Services() ([]sdk.Service, error)
-	ServicesByType(s string) ([]sdk.Service, error)
-	ServiceCallGET(s string, url string) ([]byte, error)
-	ServiceCallPOST(s string, url string, body []byte) ([]byte, error)
-	ServiceCallPUT(s string, url string, body []byte) ([]byte, error)
-	ServiceCallDELETE(s string, url string) error
+	ServicesByName(name string) (*sdk.Service, error)
+	ServicesByType(stype string) ([]sdk.Service, error)
+	ServiceCallGET(stype string, name string, url string) ([]byte, error)
+	ServiceCallPOST(stype string, name string, url string, body []byte) ([]byte, error)
+	ServiceCallPUT(stype string, name string, url string, body []byte) ([]byte, error)
+	ServiceCallDELETE(stype string, name string, url string) error
 }
 
 // ExportImportInterface exposes pipeline and application export and import function

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -20,10 +20,10 @@ type AdminService interface {
 	Services() ([]sdk.Service, error)
 	ServicesByName(name string) (*sdk.Service, error)
 	ServicesByType(stype string) ([]sdk.Service, error)
-	ServiceCallGET(stype string, name string, url string) ([]byte, error)
-	ServiceCallPOST(stype string, name string, url string, body []byte) ([]byte, error)
-	ServiceCallPUT(stype string, name string, url string, body []byte) ([]byte, error)
-	ServiceCallDELETE(stype string, name string, url string) error
+	ServiceCallGET(stype string, url string) ([]byte, error)
+	ServiceCallPOST(stype string, url string, body []byte) ([]byte, error)
+	ServiceCallPUT(stype string, url string, body []byte) ([]byte, error)
+	ServiceCallDELETE(stype string, url string) error
 }
 
 // ExportImportInterface exposes pipeline and application export and import function

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -18,7 +18,12 @@ import (
 // CommonConfiguration is the base configuration for all hatcheries
 type CommonConfiguration struct {
 	Name string `toml:"name" default:"" comment:"Name of Hatchery"`
-	API  struct {
+	HTTP struct {
+		Addr string `toml:"addr" default:"" commented:"true" comment:"Listen address without port, example: 127.0.0.1"`
+		Port int    `toml:"port" default:"8086"`
+	} `toml:"http" comment:"######################\n CDS Hatchery HTTP Configuration \n######################"`
+	URL string `toml:"url" default:"http://localhost:8086" comment:"URL of this Hatchery"`
+	API struct {
 		HTTP struct {
 			URL      string `toml:"url" default:"http://localhost:8081" commented:"true" comment:"CDS API URL"`
 			Insecure bool   `toml:"insecure" default:"false" commented:"true" comment:"sslInsecureSkipVerify, set to true if you use a self-signed SSL on CDS API"`

--- a/sdk/hatchery/register.go
+++ b/sdk/hatchery/register.go
@@ -56,7 +56,7 @@ func Create(h Interface) error {
 	var nRoutines, workersStarted, nRegister int64
 
 	go func(ctx context.Context) {
-		if err := h.Client().QueuePolling(ctx, wjobs, pbjobs, errs, 2*time.Second, h.Configuration().Provision.GraceTimeQueued); err != nil {
+		if err := h.CDSClient().QueuePolling(ctx, wjobs, pbjobs, errs, 2*time.Second, h.Configuration().Provision.GraceTimeQueued); err != nil {
 			log.Error("Queues polling stopped: %v", err)
 			cancel()
 		}
@@ -81,9 +81,9 @@ func Create(h Interface) error {
 
 	// Call WorkerModel Enabled first
 	var errwm error
-	models, errwm = h.Client().WorkerModelsEnabled()
+	models, errwm = h.CDSClient().WorkerModelsEnabled()
 	if errwm != nil {
-		log.Error("error on h.Client().WorkerModelsEnabled() (init call): %v", errwm)
+		log.Error("error on h.CDSClient().WorkerModelsEnabled() (init call): %v", errwm)
 	}
 
 	for {
@@ -98,9 +98,9 @@ func Create(h Interface) error {
 			log.Debug("workers already started:%d", workersStarted)
 		case <-tickerGetModels.C:
 			var errwm error
-			models, errwm = h.Client().WorkerModelsEnabled()
+			models, errwm = h.CDSClient().WorkerModelsEnabled()
 			if errwm != nil {
-				log.Error("error on h.Client().WorkerModelsEnabled(): %v", errwm)
+				log.Error("error on h.CDSClient().WorkerModelsEnabled(): %v", errwm)
 			}
 		case j := <-pbjobs:
 			if workersStarted > int64(h.Configuration().Provision.MaxWorker) {
@@ -137,9 +137,9 @@ func Create(h Interface) error {
 					}
 
 					if !found {
-						if hCount, err := h.Client().HatcheryCount(job.WorkflowNodeRunID); err == nil {
+						if hCount, err := h.CDSClient().HatcheryCount(job.WorkflowNodeRunID); err == nil {
 							if int64(len(job.SpawnAttempts)) < hCount {
-								if _, errQ := h.Client().QueueJobIncAttempts(job.ID); errQ != nil {
+								if _, errQ := h.CDSClient().QueueJobIncAttempts(job.ID); errQ != nil {
 									log.Warning("Hatchery> Create> cannot inc spawn attempts %s", errQ)
 								}
 							}
@@ -166,7 +166,7 @@ func Create(h Interface) error {
 
 // Register calls CDS API to register current hatchery
 func Register(h Interface) error {
-	newHatchery, uptodate, err := h.Client().HatcheryRegister(*h.Hatchery())
+	newHatchery, uptodate, err := h.CDSClient().HatcheryRegister(*h.Hatchery())
 	if err != nil {
 		return sdk.WrapError(err, "register> Got HTTP exiting")
 	}
@@ -203,7 +203,7 @@ func hearbeat(m Interface, token string, maxFailures int) {
 			log.Info("hearbeat> %s Registered back: ID %d with model ID %d", m.Hatchery().Name, m.Hatchery().ID, m.Hatchery().Model.ID)
 		}
 
-		if err := m.Client().HatcheryRefresh(m.Hatchery().ID); err != nil {
+		if err := m.CDSClient().HatcheryRefresh(m.Hatchery().ID); err != nil {
 			log.Info("heartbeat> %s cannot refresh beat: %s", m.Hatchery().Name, err)
 			m.Hatchery().ID = 0
 			checkFailures(maxFailures, failures)
@@ -251,7 +251,7 @@ func workerRegister(h Interface, models []sdk.Model, nRegister *int64) error {
 		}
 
 		if h.NeedRegistration(&models[k]) {
-			if err := h.Client().WorkerModelBook(models[k].ID); err != nil {
+			if err := h.CDSClient().WorkerModelBook(models[k].ID); err != nil {
 				log.Debug("workerRegister> WorkerModelBook on model %s err: %s", models[k].Name, err)
 			} else {
 				log.Info("workerRegister> spawning model %s (%d)", models[k].Name, models[k].ID)
@@ -260,7 +260,7 @@ func workerRegister(h Interface, models []sdk.Model, nRegister *int64) error {
 				go func(m sdk.Model) {
 					if _, errSpawn := h.SpawnWorker(SpawnArguments{Model: m, IsWorkflowJob: false, JobID: 0, Requirements: nil, RegisterOnly: true, LogInfo: "spawn for register"}); errSpawn != nil {
 						log.Warning("workerRegister> cannot spawn worker for register:%s err:%v", m.Name, errSpawn)
-						if err := h.Client().WorkerModelSpawnError(m.ID, fmt.Sprintf("workerRegister> cannot spawn worker for register: %s", errSpawn)); err != nil {
+						if err := h.CDSClient().WorkerModelSpawnError(m.ID, fmt.Sprintf("workerRegister> cannot spawn worker for register: %s", errSpawn)); err != nil {
 							log.Error("workerRegister> error on call client.WorkerModelSpawnError on worker model %s for register: %s", m.Name, err)
 						}
 					}

--- a/sdk/services.go
+++ b/sdk/services.go
@@ -1,13 +1,16 @@
 package sdk
 
-import "time"
+import (
+	"time"
+)
 
 // Service is a µService registered on CDS API
 type Service struct {
-	Name          string    `json:"name" db:"name" cli:"name,key"`
-	Type          string    `json:"type" db:"type" cli:"type"`
-	HTTPURL       string    `json:"http_url" db:"http_url" cli:"url"`
-	LastHeartbeat time.Time `json:"last_heartbeat" db:"last_heartbeat" cli:"heartbeat"`
-	Hash          string    `json:"hash" db:"hash"`
-	Token         string    `json:"token" db:"-"`
+	Name             string           `json:"name" db:"name" cli:"name,key"`
+	Type             string           `json:"type" db:"type" cli:"type"`
+	HTTPURL          string           `json:"http_url" db:"http_url" cli:"url"`
+	LastHeartbeat    time.Time        `json:"last_heartbeat" db:"last_heartbeat" cli:"heartbeat"`
+	Hash             string           `json:"hash" db:"hash"`
+	Token            string           `json:"token" db:"-"`
+	MonitoringStatus MonitoringStatus `json:"monitoring_status" db:"-"`
 }

--- a/sdk/services.go
+++ b/sdk/services.go
@@ -12,5 +12,5 @@ type Service struct {
 	LastHeartbeat    time.Time        `json:"last_heartbeat" db:"last_heartbeat" cli:"heartbeat"`
 	Hash             string           `json:"hash" db:"hash"`
 	Token            string           `json:"token" db:"-"`
-	MonitoringStatus MonitoringStatus `json:"monitoring_status" db:"-"`
+	MonitoringStatus MonitoringStatus `json:"monitoring_status" db:"-" cli:"-"`
 }

--- a/sdk/status.go
+++ b/sdk/status.go
@@ -24,6 +24,7 @@ type MonitoringStatusLine struct {
 	Status    string `json:"status" cli:"status"`
 	Component string `json:"component" cli:"component"`
 	Value     string `json:"value" cli:"value"`
+	Type      string `json:"type" cli:"type"`
 }
 
 func (m MonitoringStatusLine) String() string {

--- a/tests/clictl_admin_services.yml
+++ b/tests/clictl_admin_services.yml
@@ -1,0 +1,18 @@
+name: Action Command TestSuite with cdsctl
+testcases:
+- name: cdsctl admin services list
+  steps:
+  - script: {{.cds.build.cdsctl}} admin services list
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring api
+      - result.systemout ShouldContainSubstring hatchery
+  - script: {{.cds.build.cdsctl}} admin services status
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring Global/Version
+  - script: {{.cds.build.cdsctl}} admin services status --type api
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldNotContainSubstring hatchery
+      - result.systemout ShouldContainSubstring api

--- a/tests/clictl_admin_services.yml
+++ b/tests/clictl_admin_services.yml
@@ -7,6 +7,8 @@ testcases:
       - result.code ShouldEqual 0
       - result.systemout ShouldContainSubstring api
       - result.systemout ShouldContainSubstring hatchery
+    retry: 10
+    delay: 10  
   - script: {{.cds.build.cdsctl}} admin services status
     assertions:
       - result.code ShouldEqual 0


### PR DESCRIPTION
hatcheries -> services (old heartbeat on hatchery is keep for now)
api -> service too
status is stored in service table 

so, cdsctl admin services status [-t]

with type :
-t, --type string     Filter service by type: api, hatchery, hook, repository, vcs