### PR TITLE
Add DisableTempURL for the ability to disable temporary URL use in Swift

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -118,6 +118,7 @@ type Configuration struct {
 			Tenant          string `toml:"tenant" comment:"Openstack Tenant, generally value of $OS_TENANT_NAME"`
 			Region          string `toml:"region" comment:"Region, generally value of $OS_REGION_NAME"`
 			ContainerPrefix string `toml:"containerPrefix" comment:"Use if your want to prefix containers for CDS Artifacts"`
+			DisableTempURL  bool   `toml:"disableTempURL" default:"false" commented:"true" comment:"True if you want to disable Temporary URL in file upload"`
 		} `toml:"openstack"`
 	} `toml:"artifact" comment:"Either filesystem local storage or Openstack Swift Storage are supported"`
 	Events struct {
@@ -415,6 +416,7 @@ func (a *API) Serve(ctx context.Context) error {
 				Tenant:          a.Config.Artifact.Openstack.Tenant,
 				Region:          a.Config.Artifact.Openstack.Region,
 				ContainerPrefix: a.Config.Artifact.Openstack.ContainerPrefix,
+				DisableTempURL:  a.Config.Artifact.Openstack.DisableTempURL,
 			},
 			Filesystem: objectstore.ConfigOptionsFilesystem{
 				Basedir: a.Config.Artifact.Local.BaseDirectory,

--- a/engine/api/objectstore/objectstore.go
+++ b/engine/api/objectstore/objectstore.go
@@ -154,6 +154,7 @@ type ConfigOptionsOpenstack struct {
 	Tenant          string
 	Region          string
 	ContainerPrefix string
+	DisableTempURL  bool
 }
 
 // ConfigOptionsFilesystem is used by ConfigOptions
@@ -168,7 +169,7 @@ func New(c context.Context, cfg Config) (Driver, error) {
 		instance = sdk.ArtifactsStore{
 			Name:                  "Swift",
 			Private:               false,
-			TemporaryURLSupported: true,
+			TemporaryURLSupported: !cfg.Options.Openstack.DisableTempURL,
 		}
 		return NewSwiftStore(cfg.Options.Openstack.Address,
 			cfg.Options.Openstack.Username,


### PR DESCRIPTION
1. Description
Add DisableTempURL in config for the ability to disable temporary URL usage in Swift

1. Related issues
If Swift does support temporary URL. You can disable usage in CDS

1. About tests
Nope

1. Mentions
Thanks to @yesnault for the track

@ovh/cds