### PR TITLE
Add BindDN to ldap configuration & bind before search if needed

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -92,6 +92,8 @@ type Configuration struct {
 			Base     string `toml:"base" default:"dc=myorganization,dc=com"`
 			DN       string `toml:"dn" default:"uid=%s,ou=people,dc=myorganization,dc=com"`
 			Fullname string `toml:"fullname" default:"{{.givenName}} {{.sn}}"`
+			BindDN   string `toml:"bindDN" default:"" comment:"Define it if ldapsearch need to be authenticated"`
+			BindPwd  string `toml:"bindPwd" default:"" comment:"Define it if ldapsearch need to be authenticated"`
 		} `toml:"ldap"`
 		Local struct {
 			SignupAllowedDomains string `toml:"signupAllowedDomains" default:"" comment:"Allow signup from selected domains only - comma separated. Example: your-domain.com,another-domain.com" commented:"true"`
@@ -153,6 +155,8 @@ type DefaultValues struct {
 	LDAPBase  string
 	GivenName string
 	SN        string
+	BindDN    string
+	BindPwd   string
 }
 
 // New instanciates a new API object
@@ -501,6 +505,8 @@ func (a *API) Serve(ctx context.Context) error {
 			DN:           a.Config.Auth.LDAP.DN,
 			SSL:          a.Config.Auth.LDAP.SSL,
 			UserFullname: a.Config.Auth.LDAP.Fullname,
+			BindDN:       a.Config.Auth.LDAP.BindDN,
+			BindPwd:      a.Config.Auth.LDAP.BindPwd,
 		}
 	default:
 		authMode = "local"


### PR DESCRIPTION
1. Description
If LDAP auth is enabled on LDAP need bind before the search, users are disconnected after API restart.
With their logs:
```
2018-05-03 15:30:23 [WARN] LDAP> Search error (uid=nico): LDAP Result Code 50 "Insufficient Access Rights": INSUFFICIENT_ACCESS_RIGHTS: failed for MessageType : SEARCH_REQUEST
Message ID : 3
    SearchRequest
        baseDn : 'dc=fr,dc=world,dc=company'
        filter : '(uid=nico)'
        scope : whole subtree
        typesOnly : false
        Size Limit : no limit
        Time Limit : no limit
        Deref Aliases : never Deref Aliases
        attributes : 'uid', 'cn', 'ou', 'givenName', 'sn', 'mail', 'dn'
org.apache.directory.api.ldap.model.message.SearchRequestImpl@41843e7f: ERR_5 Attempted operation SEARCH_REQUEST by unauthenticated caller.
```

1. Related issues
1. About tests
Use an LDAP need bind before the search.
If bindDN and bindPwd are empty, we have same issue (no regression)
Provide right credentials in bindDN and bindPwd. You can restart API and keep you http session

1. Mentions

@ovh/cds
