### PR TITLE
Fix Intializing driver

### DIFF
--- a/engine/api/auth/auth.go
+++ b/engine/api/auth/auth.go
@@ -39,7 +39,7 @@ type Driver interface {
 
 //GetDriver is a factory
 func GetDriver(c context.Context, mode string, options interface{}, storeOptions sessionstore.Options, DBFunc func() *gorp.DbMap) (Driver, error) {
-	log.Info("Auth> Intializing driver (%s)", mode)
+	log.Info("Auth> Initializing driver (%s)", mode)
 	store, err := sessionstore.Get(c, storeOptions.Cache, storeOptions.TTL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get AuthDriver : %v", err)


### PR DESCRIPTION
1. Description
Typo on line 42
log.Info("Auth> Intializing driver (%s)", mode)
log.Info("Auth> Initializing driver (%s)", mode)

@ovh/cds
