### PR TITLE
feat (engine, worker, sdk): artifact tag

### DIFF
--- a/cli/cdsctl/workflow_artifact.go
+++ b/cli/cdsctl/workflow_artifact.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ovh/cds/cli"
+	"github.com/ovh/cds/sdk"
 )
 
 var (
@@ -76,8 +77,10 @@ func workflowArtifactDownloadRun(v cli.Values) error {
 		return err
 	}
 
+	artifactsFiltered := sdk.ArtifactsGetUniqueNameAndLatest(artifacts)
+
 	var ok bool
-	for _, a := range artifacts {
+	for _, a := range artifactsFiltered {
 		if v["artefact-name"] != "" && v["artefact-name"] != a.Name {
 			continue
 		}

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -222,7 +222,6 @@ func (api *API) InitRouter() {
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/runs/{number}/nodes/{nodeID}/history", r.GET(api.getWorkflowNodeRunHistoryHandler))
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/runs/{number}/{nodeName}/commits", r.GET(api.getWorkflowCommitsHandler))
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/runs/{number}/nodes/{nodeRunID}/job/{runJobId}/step/{stepOrder}", r.GET(api.getWorkflowNodeRunJobStepHandler))
-	r.Handle("/project/{key}/workflows/{permWorkflowName}/runs/{number}/nodes/{nodeRunID}/artifacts", r.GET(api.getWorkflowNodeRunArtifactsHandler))
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/artifact/{artifactId}", r.GET(api.getDownloadArtifactHandler))
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/node/{nodeID}/triggers/condition", r.GET(api.getWorkflowTriggerConditionHandler))
 	r.Handle("/project/{key}/workflows/{permWorkflowName}/runs/{number}/nodes/{nodeRunID}/release", r.POST(api.releaseApplicationWorkflowHandler))

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -704,9 +704,8 @@ func Test_postWorkflowJobArtifactHandler(t *testing.T) {
 		"key":              ctx.project.Key,
 		"permWorkflowName": ctx.workflow.Name,
 		"number":           fmt.Sprintf("%d", updatedNodeRun.Number),
-		"nodeRunID":        fmt.Sprintf("%d", wNodeJobRun.WorkflowNodeRunID),
 	}
-	uri = router.GetRoute("GET", api.getWorkflowNodeRunArtifactsHandler, vars)
+	uri = router.GetRoute("GET", api.getWorkflowRunArtifactsHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, ctx.user, ctx.password, "GET", uri, nil)
 	rec = httptest.NewRecorder()

--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -906,39 +906,6 @@ func (api *API) downloadworkflowArtifactDirectHandler() Handler {
 	}
 }
 
-func (api *API) getWorkflowNodeRunArtifactsHandler() Handler {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		vars := mux.Vars(r)
-		key := vars["key"]
-		name := vars["permWorkflowName"]
-
-		number, errNu := requestVarInt(r, "number")
-		if errNu != nil {
-			return sdk.WrapError(errNu, "getWorkflowJobArtifactsHandler> Invalid node job run ID")
-		}
-
-		id, errI := requestVarInt(r, "nodeRunID")
-		if errI != nil {
-			return sdk.WrapError(sdk.ErrInvalidID, "getWorkflowJobArtifactsHandler> Invalid node job run ID")
-		}
-		nodeRun, errR := workflow.LoadNodeRun(api.mustDB(), key, name, number, id, workflow.LoadRunOptions{WithArtifacts: true})
-		if errR != nil {
-			return sdk.WrapError(errR, "getWorkflowJobArtifactsHandler> Cannot load node run")
-		}
-
-		//Fetch artifacts
-		for i := range nodeRun.Artifacts {
-			a := &nodeRun.Artifacts[i]
-			url, _ := objectstore.FetchTempURL(a)
-			if url != "" {
-				a.TempURL = url
-			}
-		}
-
-		return WriteJSON(w, nodeRun.Artifacts, http.StatusOK)
-	}
-}
-
 func (api *API) getDownloadArtifactHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		vars := mux.Vars(r)

--- a/engine/worker/builtin_artifact_download.go
+++ b/engine/worker/builtin_artifact_download.go
@@ -119,12 +119,14 @@ func runArtifactDownload(w *currentWorker) BuiltInAction {
 			return *res
 		}
 
+		artifactsFiltered := sdk.ArtifactsGetUniqueNameAndLatest(artifacts)
+
 		regexp := regexp.MustCompile(pattern)
 		wg := new(sync.WaitGroup)
-		wg.Add(len(artifacts))
+		wg.Add(len(artifactsFiltered))
 
-		for i := range artifacts {
-			a := &artifacts[i]
+		for i := range artifactsFiltered {
+			a := &artifactsFiltered[i]
 
 			if pattern != "" && !regexp.MatchString(a.Name) {
 				sendLog(fmt.Sprintf("%s does not match pattern %s - skipped", a.Name, pattern))
@@ -166,7 +168,7 @@ func runArtifactDownload(w *currentWorker) BuiltInAction {
 					return
 				}
 			}(a)
-			if len(artifacts) > 1 {
+			if len(artifactsFiltered) > 1 {
 				time.Sleep(3 * time.Second)
 			}
 		}

--- a/engine/worker/cmd_download.go
+++ b/engine/worker/cmd_download.go
@@ -163,6 +163,8 @@ func (wk *currentWorker) downloadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	artifactsFiltered := sdk.ArtifactsGetUniqueNameAndLatest(artifacts)
+
 	regexp, errp := regexp.Compile(reqArgs.Pattern)
 	if errp != nil {
 		newError := sdk.NewError(sdk.ErrWrongRequest, fmt.Errorf("Invalid pattern %s : %s", reqArgs.Pattern, errp))
@@ -170,11 +172,13 @@ func (wk *currentWorker) downloadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	wg := new(sync.WaitGroup)
-	wg.Add(len(artifacts))
+	wg.Add(len(artifactsFiltered))
+
+	sendLog("Downloading artifacts from into current directory")
 
 	var isInError bool
-	for i := range artifacts {
-		a := &artifacts[i]
+	for i := range artifactsFiltered {
+		a := &artifactsFiltered[i]
 
 		if reqArgs.Pattern != "" && !regexp.MatchString(a.Name) {
 			sendLog(fmt.Sprintf("%s does not match pattern %s - skipped", a.Name, reqArgs.Pattern))
@@ -214,7 +218,7 @@ func (wk *currentWorker) downloadHandler(w http.ResponseWriter, r *http.Request)
 		if isInError {
 			break
 		}
-		if len(artifacts) > 1 {
+		if len(artifactsFiltered) > 1 {
 			time.Sleep(3 * time.Second)
 		}
 	}

--- a/engine/worker/cmd_upload.go
+++ b/engine/worker/cmd_upload.go
@@ -21,20 +21,20 @@ var cmdUploadTag string
 func cmdUpload(w *currentWorker) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "upload",
-		Short: "worker upload --tag=tagValue {{.cds.workspace}}/fileToUpload",
+		Short: "worker upload {{.cds.workspace}}/fileToUpload",
 		Long: `
 Inside a job, there are two ways to upload an artifact:
 
 * with a step using action Upload Artifacts
-* with a step script (https://ovh.github.io/cds/workflows/pipelines/actions/builtin/script/), using the worker command: ` + "`worker upload --tag=<tag> <path>`" + `
+* with a step script (https://ovh.github.io/cds/workflows/pipelines/actions/builtin/script/), using the worker command: ` + "`worker upload <path>`" + `
 
-	# worker upload --tag=<tag> <path>
-	worker upload --tag={{.cds.version}} {{.cds.workspace}}/files*.yml
+	# worker upload <path>
+	worker upload {{.cds.workspace}}/files*.yml
 
 		`,
 		Run: uploadCmd(w),
 	}
-	c.Flags().StringVar(&cmdUploadTag, "tag", "", "Tag for artifact Upload. Tag is mandatory")
+	c.Flags().StringVar(&cmdUploadTag, "tag", "", "Tag for artifact Upload - unused with CDS Workflows")
 	return c
 }
 
@@ -48,10 +48,6 @@ func uploadCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		port, errPort := strconv.Atoi(portS)
 		if errPort != nil {
 			sdk.Exit("cannot parse '%s' as a port number", portS)
-		}
-
-		if cmdUploadTag == "" {
-			sdk.Exit("worker upload: invalid tag. %s\n", cmd.Short)
 		}
 
 		if len(args) == 0 {

--- a/sdk/cdsclient/client_workflow.go
+++ b/sdk/cdsclient/client_workflow.go
@@ -128,15 +128,6 @@ func (c *client) WorkflowNodeRunJobStep(projectKey string, workflowName string, 
 	return &buildState, nil
 }
 
-func (c *client) WorkflowNodeRunArtifacts(projectKey string, workflowName string, number int64, nodeRunID int64) ([]sdk.WorkflowNodeRunArtifact, error) {
-	url := fmt.Sprintf("/project/%s/workflows/%s/runs/%d/nodes/%d/artifacts", projectKey, workflowName, number, nodeRunID)
-	arts := []sdk.WorkflowNodeRunArtifact{}
-	if _, err := c.GetJSON(url, &arts); err != nil {
-		return nil, err
-	}
-	return arts, nil
-}
-
 func (c *client) WorkflowNodeRunArtifactDownload(projectKey string, workflowName string, a sdk.WorkflowNodeRunArtifact, w io.Writer) error {
 	var url = fmt.Sprintf("/project/%s/workflows/%s/artifact/%d", projectKey, workflowName, a.ID)
 	var reader io.ReadCloser

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -250,7 +250,6 @@ type WorkflowClient interface {
 	WorkflowStop(projectKey string, workflowName string, number int64) (*sdk.WorkflowRun, error)
 	WorkflowNodeStop(projectKey string, workflowName string, number, fromNodeID int64) (*sdk.WorkflowNodeRun, error)
 	WorkflowNodeRun(projectKey string, name string, number int64, nodeRunID int64) (*sdk.WorkflowNodeRun, error)
-	WorkflowNodeRunArtifacts(projectKey string, name string, number int64, nodeRunID int64) ([]sdk.WorkflowNodeRunArtifact, error)
 	WorkflowNodeRunArtifactDownload(projectKey string, name string, a sdk.WorkflowNodeRunArtifact, w io.Writer) error
 	WorkflowNodeRunJobStep(projectKey string, workflowName string, number int64, nodeRunID, job int64, step int) (*sdk.BuildState, error)
 	WorkflowNodeRunRelease(projectKey string, workflowName string, runNumber int64, nodeRunID int64, release sdk.WorkflowNodeRunRelease) error

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -166,14 +167,52 @@ func (w WorkflowNodeRunArtifact) Equal(c WorkflowNodeRunArtifact) bool {
 		w.MD5sum == c.MD5sum
 }
 
+func artifactsFilter(ss []string, test func(string) bool) (ret []string) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}
+
+// ArtifactsGetUniqueNameAndLatest returns a list of artifacts, with unique names.
+// if there is two same name (as same artifact uplaoded with two differents tags),
+// we keep only the latest artifact (based on id filter, keep the max id)
+func ArtifactsGetUniqueNameAndLatest(in []WorkflowNodeRunArtifact) []WorkflowNodeRunArtifact {
+	toKeep := make(map[string]WorkflowNodeRunArtifact, len(in))
+	out := []WorkflowNodeRunArtifact{}
+	for _, a := range in {
+		var found bool
+		for _, b := range out {
+			if b.Name == a.Name {
+				found = true
+				if a.ID > b.ID {
+					toKeep[a.Name] = a
+				}
+			}
+		}
+		if !found {
+			toKeep[a.Name] = a
+		}
+	}
+	for name, a := range toKeep {
+		if name != "" {
+			out = append(out, a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
 //WorkflowNodeJobRun represents an job to be run
 type WorkflowNodeJobRun struct {
 	ID                int64       `json:"id" db:"id"`
 	WorkflowNodeRunID int64       `json:"workflow_node_run_id,omitempty" db:"workflow_node_run_id"`
 	Job               ExecutedJob `json:"job" db:"-"`
 	Parameters        []Parameter `json:"parameters,omitempty" db:"-"`
-	Status            string      `json:"status"  db:"status"`
-	Retry             int         `json:"retry"  db:"retry"`
+	Status            string      `json:"status" db:"status"`
+	Retry             int         `json:"retry" db:"retry"`
 	SpawnAttempts     []int64     `json:"spawn_attempts,omitempty"  db:"-"`
 	Queued            time.Time   `json:"queued,omitempty" db:"queued"`
 	QueuedSeconds     int64       `json:"queued_seconds,omitempty" db:"-"`
@@ -200,7 +239,6 @@ func (njr *WorkflowNodeJobRun) Translate(lang string) {
 		m := NewMessage(Messages[info.Message.ID], info.Message.Args...)
 		njr.SpawnInfos[ki].UserMessage = m.String(lang)
 	}
-
 }
 
 //WorkflowNodeRunHookEvent is an instanc of event received on a hook

--- a/sdk/workflow_run_test.go
+++ b/sdk/workflow_run_test.go
@@ -1,0 +1,35 @@
+package sdk
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestArtifactsGetUniqueNameAndLatest(t *testing.T) {
+	type args struct {
+		in []WorkflowNodeRunArtifact
+	}
+	tests := []struct {
+		name string
+		args args
+		want []WorkflowNodeRunArtifact
+	}{
+		{
+			name: "simple",
+			args: args{[]WorkflowNodeRunArtifact{{ID: 1, Name: "foo"}, {ID: 2, Name: "foo"}, {ID: 3, Name: "bar"}}},
+			want: []WorkflowNodeRunArtifact{{ID: 2, Name: "foo"}, {ID: 3, Name: "bar"}},
+		},
+		{
+			name: "simple2",
+			args: args{[]WorkflowNodeRunArtifact{{ID: 1, Name: "foo"}, {ID: 2, Name: "foo2"}, {ID: 3, Name: "bar"}}},
+			want: []WorkflowNodeRunArtifact{{ID: 1, Name: "foo"}, {ID: 2, Name: "foo2"}, {ID: 3, Name: "bar"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ArtifactsGetUniqueNameAndLatest(tt.args.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ArtifactsGetUniqueNameAndLatest() %s = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. Description

With CDS Workflows, the tag of an aritfact is now cds.run (399.0).
And to avoid download same artifact twice, we use a filter to keep
only one artifact per name, keep the latest (based on id filter)

1. Related issues
none

1. About tests
ut + manual 

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>