### PR TITLE
feat (ui): info on tag field with cds workflows

### DIFF
--- a/ui/src/app/shared/action/step/step.html
+++ b/ui/src/app/shared/action/step/step.html
@@ -82,6 +82,9 @@
                 <i class="info circle icon"></i>
               </span>
             </label>
+            <div *ngIf="(step.name == 'Artifact Upload' || step.name == 'Artifact Download') && p.name == 'tag'">
+                <i class="exclamation circle icon orange"></i> {{ 'action_artifact_tag_ignored' | translate }}
+            </div>
         </div>
         <div class="fourteen wide column">
             <app-parameter-value [edit]="edit" [type]="p.type" [(value)]="p.value" [editList]="false" [suggest]="suggest"

--- a/ui/src/app/shared/action/step/step.html
+++ b/ui/src/app/shared/action/step/step.html
@@ -81,10 +81,11 @@
               <span *ngIf="p.description" suiPopup [popupText]="p.description" popupPlacement="right center">
                 <i class="info circle icon"></i>
               </span>
+              <span *ngIf="(step.name ==== 'Artifact Upload' || step.name === 'Artifact Download') && p.name === 'tag'" 
+              suiPopup [popupText]="'action_artifact_tag_ignored' | translate" popupPlacement="right center">
+                <i class="exclamation circle icon orange"></i>
+              </span>
             </label>
-            <div *ngIf="(step.name == 'Artifact Upload' || step.name == 'Artifact Download') && p.name == 'tag'">
-                <i class="exclamation circle icon orange"></i> {{ 'action_artifact_tag_ignored' | translate }}
-            </div>
         </div>
         <div class="fourteen wide column">
             <app-parameter-value [edit]="edit" [type]="p.type" [(value)]="p.value" [editList]="false" [suggest]="suggest"

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -34,6 +34,7 @@
   "action_optional_details": "If checked, even if this step fails, the stage execution will continue",
   "action_always_executed": "Always executed",
   "action_always_executed_details": "If checked, this step will be executed even if previous steps fail",
+  "action_artifact_tag_ignored": "tag is ignored on CDS Workflows",
 
   "admin_migration_not_started": "Not started",
   "admin_migration_started": "Started",

--- a/ui/src/assets/i18n/fr.json
+++ b/ui/src/assets/i18n/fr.json
@@ -34,6 +34,7 @@
   "action_optional_details": "Cochée, cela signifie que même si cette étape tombe en erreur, le déroulement continue",
   "action_always_executed": "Toujours executée",
   "action_always_executed_details": "Cochée, cela signifie que cette étape sera toujours executée même si les étapes précédentes tombent en erreur",
+  "action_artifact_tag_ignored": "Le tag est ignoré par les 'CDS Workflows'",
 
   "admin_migration_not_started": "Non commencé",
   "admin_migration_started": "En cours",


### PR DESCRIPTION
This is temporary, tag field have to be removed
from action when old workflows will be removed from CDS Engine.

But this will avoid misunderstanding for users using old and new workflows.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>