### PR TITLE
fix(ui): change french translation for 'navbar_downloads'

### DIFF
--- a/ui/src/assets/i18n/fr.json
+++ b/ui/src/assets/i18n/fr.json
@@ -358,7 +358,7 @@
   "navbar_admin_migration": "Migration vers les workflows",
   "navbar_admin_status": "CDS Engine - Statut",
   "navbar_documentation": "Documentation",
-  "navbar_downloads": "Téléchargements",
+  "navbar_downloads": "Télécharger",
   "navbar_groups": "Groupes",
   "navbar_home": "Accueil",
   "navbar_profile": "Votre Compte",


### PR DESCRIPTION
From 'Téléchargement' to 'Télécharger' which no longer exceeds the limits of the sidebar and match more (I think) the semantic of the panel (links to donwloads cds binaries)
