### PR TITLE
refactor(ui): modify css for tables + remove "tall stacked" from tips…

### DIFF
--- a/ui/src/app/shared/variable/list/variable.scss
+++ b/ui/src/app/shared/variable/list/variable.scss
@@ -3,3 +3,7 @@
   position: inherit;
 }
 
+.ui.table tbody tr td {
+  vertical-align: top;
+}
+

--- a/ui/src/app/views/admin/admin.scss
+++ b/ui/src/app/views/admin/admin.scss
@@ -4,5 +4,7 @@
   flex-direction: column;
   align-content: stretch;
   height: 100%;
-  padding: 20px;
+  .scrollingContent {
+    padding: 20px;
+  }
 }

--- a/ui/src/app/views/admin/broadcast/add/broadcast.add.html
+++ b/ui/src/app/views/admin/broadcast/add/broadcast.add.html
@@ -1,8 +1,8 @@
 <h2>
     <a href="#" [routerLink]="['/admin', 'broadcast']">
         {{ 'broadcast_list_title' | translate }}
-    </a> 
-    <i class="chevron right icon"></i> 
+    </a>
+    <i class="chevron right icon"></i>
     {{ 'broadcast_new_title' | translate }}
 </h2>
 
@@ -65,7 +65,7 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
+          <div class="ui segment">
             <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
             <p>{{'broadcast_help_line_1' | translate}}</p>
             <p>{{'broadcast_help_line_2' | translate}}</p>

--- a/ui/src/app/views/admin/broadcast/edit/broadcast.edit.html
+++ b/ui/src/app/views/admin/broadcast/edit/broadcast.edit.html
@@ -3,8 +3,8 @@
   <h2>
       <a href="#" [routerLink]="['/admin', 'broadcast']">
           {{ 'broadcast_list_title' | translate }}
-      </a> 
-      <i class="chevron right icon"></i> 
+      </a>
+      <i class="chevron right icon"></i>
       {{ 'broadcast_edit_title' | translate }} {{broadcast.id}}
   </h2>
   <div id="BroadcastEdit">
@@ -66,7 +66,7 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
+          <div class="ui segment">
             <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
             <p>{{'broadcast_help_line_1' | translate}}</p>
             <p>{{'broadcast_help_line_2' | translate}}</p>

--- a/ui/src/app/views/settings/action/add/action.add.html
+++ b/ui/src/app/views/settings/action/add/action.add.html
@@ -8,7 +8,7 @@
       </div>
 
       <div class="three wide column">
-        <div class="ui tall stacked segment">
+        <div class="ui segment">
           <h4 class="ui header"><i class="fa fa-book fa-x4"></i> Documentation</h4>
 
           <div class="ui list">

--- a/ui/src/app/views/settings/action/edit/action.edit.html
+++ b/ui/src/app/views/settings/action/edit/action.edit.html
@@ -27,7 +27,7 @@
       </div>
 
       <div class="three wide column">
-        <div class="ui tall stacked segment">
+        <div class="ui segment">
           <h4 class="ui header"><i class="fa fa-book fa-x4"></i> Documentation</h4>
 
           <div class="ui list">

--- a/ui/src/app/views/settings/action/list/action.list.html
+++ b/ui/src/app/views/settings/action/list/action.list.html
@@ -26,10 +26,10 @@
           </thead>
           <tbody>
           <tr *ngFor="let v of getDataForCurrentPage()">
-              <td>
+              <td class="border">
                   <a class="ui" [routerLink]="[v.name]"><div class="ui">{{v.name}}</div></a>
               </td>
-              <td>
+              <td class="border">
                   <a class="ui" [routerLink]="[v.name]"><div class="ui">{{v.type}}</div></a>
               </td>
           </tr>

--- a/ui/src/app/views/settings/download/download.html
+++ b/ui/src/app/views/settings/download/download.html
@@ -3,19 +3,19 @@
 
     <div *ngIf="loading" class="ui active text loader">{{ 'common_loading' | translate }}</div>
 
-    <table class="ui definition table" *ngIf="downloads && !loading">
+    <table class="ui definition celled table" *ngIf="downloads && !loading">
         <tbody>
         <tr *ngFor="let line of downloads">
-            <td>
-                    {{line.name}}
+            <td class="center aligned">
+                {{line.name}}
             </td>
             <td>
 
                 <div class="ui grid" *ngFor="let osArch of line.osArchs">
                     <div class="four wide column">{{osArch.os}}</div>
                     <div class="four wide column"  *ngFor="let a of osArch.archs">
-                            <a *ngIf="a.available" href="{{apiURL}}/download/{{line.name}}/{{osArch.os}}/{{a.arch}}">[{{a.arch}}]</a> 
-                            <span *ngIf="!a.available" title="{{'common_ask_cds_administrator' | translate}}">{{a.arch}}: n.a</span>
+                            <a *ngIf="a.available" href="{{apiURL}}/download/{{line.name}}/{{osArch.os}}/{{a.arch}}">[{{a.arch}}]</a>
+                            <span *ngIf="!a.available" title="{{'common_ask_cds_administrator' | translate}}">{{a.arch}}: <strong>n.a</strong></span>
                     </div>
                 </div>
             </td>

--- a/ui/src/app/views/settings/download/download.scss
+++ b/ui/src/app/views/settings/download/download.scss
@@ -1,0 +1,8 @@
+.table tbody tr {
+    &:last-child td {
+        border-bottom: none;
+    }
+    td:last-child {
+        border-right: none;
+    }
+}

--- a/ui/src/app/views/settings/group/edit/group.edit.html
+++ b/ui/src/app/views/settings/group/edit/group.edit.html
@@ -91,9 +91,9 @@
           </div>
 
         <div class="six wide column">
-          <div class="ui tall stacked segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
-            <a href="https://ovh.github.io/cds" target="_blank">https://ovh.github.io/cds</a>
+          <div class="ui center aligned segment">
+            <h4 class="ui header"><i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
+            <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
           </div>
         </div>
 

--- a/ui/src/app/views/settings/group/list/group.list.html
+++ b/ui/src/app/views/settings/group/list/group.list.html
@@ -25,7 +25,7 @@
           </thead>
           <tbody>
           <tr *ngFor="let v of getDataForCurrentPage()">
-              <td>
+              <td class="border">
                   <a class="ui" [routerLink]="[v.name]">
                     <div class="ui">{{v.name}}</div>
                   </a>

--- a/ui/src/app/views/settings/settings.component.scss
+++ b/ui/src/app/views/settings/settings.component.scss
@@ -4,5 +4,7 @@
   flex-direction: column;
   align-content: stretch;
   height: 100%;
-  padding: 20px;
+  .scrollingContent {
+    padding: 20px;
+  }
 }

--- a/ui/src/app/views/settings/sidebar/settings-sidebar.scss
+++ b/ui/src/app/views/settings/sidebar/settings-sidebar.scss
@@ -2,6 +2,8 @@
 #settings-sidebar {
   width: 8rem;
   text-align: center;
+  margin-left: auto;
+  margin-right: auto;
   .ui.header .icon:only-child {
     margin-right: 0rem;
   }

--- a/ui/src/app/views/settings/user/edit/user.edit.html
+++ b/ui/src/app/views/settings/user/edit/user.edit.html
@@ -34,7 +34,7 @@
                 </div>
 
                 <h3>{{ 'group_list_title' | translate }}</h3>
-                <table class="ui fixed celled table" *ngIf="groups || groupsAdmin">
+                <table class="ui selectable fixed celled table" *ngIf="groups || groupsAdmin">
                     <thead>
                     <tr>
                         <th class="three wide">{{ 'group_name' | translate }}</th>
@@ -42,17 +42,19 @@
                     </thead>
                     <tbody>
                     <tr *ngFor="let v of groupsAdmin">
-                        <td>
+                        <td class="border">
                             <a class="ui" [routerLink]="['/settings', 'group', v?.name]">
-                              <i class="fa fa-user-circle-o" title="{{ 'group_user_is_admin' | translate }}"></i>
-                              {{v?.name}}
+                              <div class="ui">
+                                <i class="fa fa-user-circle-o" title="{{ 'group_user_is_admin' | translate }}"></i>
+                                {{v?.name}}
+                              </div>
                             </a>
                         </td>
                     </tr>
                     <tr *ngFor="let v of groups">
-                        <td>
+                        <td class="border">
                             <a class="ui" [routerLink]="['/settings', 'group', v?.name]">
-                              {{v?.name}}
+                            <div class="ui">{{v?.name}}</div>
                             </a>
                         </td>
                     </tr>
@@ -62,10 +64,11 @@
             </div>
 
             <div class="six wide column">
-              <div class="ui tall stacked segment">
-                <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
-                <a href="https://ovh.github.io/cds" target="_blank">https://ovh.github.io/cds</a>
-              </div>
+                <div class="ui center aligned segment">
+                    <h4 class="ui header">
+                        <i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
+                    <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
+                </div>
             </div>
         </div>
         <div class="ui row" *ngIf="username === this.currentUser.username">

--- a/ui/src/app/views/settings/worker-model/add/worker-model.add.html
+++ b/ui/src/app/views/settings/worker-model/add/worker-model.add.html
@@ -81,7 +81,7 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
+          <div class="ui segment">
             <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>

--- a/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
+++ b/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
@@ -119,8 +119,8 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+          <div class="ui segment">
+            <h4 class="ui header"><i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>
 

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -600,6 +600,8 @@
   "scheduler_updated": "Scheduler updated",
   "scheduler_workflow_label": "Scheduler: ",
 
+  "settings_tips": "Tips",
+
   "stage_add_label": "Add stage",
   "stage_added": "Stage added",
   "stage_deleted": "Stage deleted",

--- a/ui/src/assets/i18n/fr.json
+++ b/ui/src/assets/i18n/fr.json
@@ -600,6 +600,8 @@
   "scheduler_updated": "Scheduler mis à jour",
   "scheduler_workflow_label": "Scheduler : ",
 
+  "settings_tips": "Conseils",
+
   "stage_add_label": "Ajouter un stage",
   "stage_added": "Stage ajouté",
   "stage_deleted": "Stage supprimé",

--- a/ui/src/common.scss
+++ b/ui/src/common.scss
@@ -96,36 +96,31 @@ pre {
   }
 
   tbody tr td:first-child {
-    border-left: 2px solid $darkGreyColor;
+    border-left: 1px solid $darkGreyColor;
   }
 
   tbody tr td:last-child {
-    border-right: 2px solid $darkGreyColor;
+    border-right: 1px solid $darkGreyColor;
   }
 
   tbody tr:first-child td {
-    border-top: 2px solid $darkGreyColor;
+    border-top: 1px solid $darkGreyColor;
   }
 
   tbody tr:last-child td {
-    border-bottom: 2px solid $darkGreyColor;
+    border-bottom: 1px solid $darkGreyColor;
   }
 
   tbody tr td {
     border: none;
     overflow: visible;
     padding-top: 8px;
-    padding-bottom: 4px;
-    vertical-align: top;
+    padding-bottom: 8px;
+    vertical-align: middle;
   }
 
   tbody tr td.border {
-    border: none;
     border-top: 1px solid rgba(34, 36, 38, 0.15);
-  }
-
-  tbody tr:first-child td.border {
-    border: none;
   }
 
   tbody tr:not(:hover) {


### PR DESCRIPTION
Several css fixes:

- scroll bar position in settings
- table border glitches in download section
- rework settings tables (groups, members, ...) to add line seperators
- remove 'tall stacked' proprerty of tips cards + convert link to documention into a button
- change table border size from 2px to 1px