### PR TITLE
fix (api): do not regenerate uuid on import hook

### DIFF
--- a/cli/cdsctl/admin_grpc_plugin.go
+++ b/cli/cdsctl/admin_grpc_plugin.go
@@ -149,12 +149,12 @@ func adminPluginsAddBinaryFunc(v cli.Values) error {
 
 	f, err := os.Open(v.GetString("filename"))
 	if err != nil {
-		return fmt.Errorf("unable to open file %s", v.GetString("filename"), err)
+		return fmt.Errorf("unable to open file %s: %v", v.GetString("filename"), err)
 	}
 
 	fi, err := os.Stat(f.Name())
 	if err != nil {
-		return fmt.Errorf("unable to open file %s", v.GetString("filename"), err)
+		return fmt.Errorf("unable to open file %s: %v", v.GetString("filename"), err)
 	}
 
 	b, err := ioutil.ReadFile(v.GetString("descriptor"))
@@ -171,13 +171,13 @@ func adminPluginsAddBinaryFunc(v cli.Values) error {
 	desc.Perm = uint32(fi.Mode().Perm())
 	desc.FileContent, err = ioutil.ReadFile(f.Name())
 	if err != nil {
-		return fmt.Errorf("unable to open file %s", v.GetString("filename"), err)
+		return fmt.Errorf("unable to open file %s: %v", v.GetString("filename"), err)
 	}
 
 	desc.Size = int64(len(desc.FileContent))
 	desc.MD5sum, err = sdk.FileMd5sum(f.Name())
 	if err != nil {
-		return fmt.Errorf("unable to compute md5sum for file %s", v.GetString("filename"), err)
+		return fmt.Errorf("unable to compute md5sum for file %s: %v", v.GetString("filename"), err)
 	}
 
 	if err := client.PluginAddBinary(p, &desc); err != nil {

--- a/engine/api/workflow/hook_test.go
+++ b/engine/api/workflow/hook_test.go
@@ -1,0 +1,62 @@
+package workflow
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func Test_mergeAndDiffHook(t *testing.T) {
+	type args struct {
+		oldHooks map[string]sdk.WorkflowNodeHook
+		newHooks map[string]sdk.WorkflowNodeHook
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantHookToUpdate map[string]sdk.WorkflowNodeHook
+		wantHookToDelete map[string]sdk.WorkflowNodeHook
+	}{
+		{
+			name: "one to update",
+			args: args{
+				oldHooks: map[string]sdk.WorkflowNodeHook{
+					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+				},
+				newHooks: map[string]sdk.WorkflowNodeHook{
+					"my-uuid-b": sdk.WorkflowNodeHook{Ref: "BBB"},
+					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+				},
+			},
+			wantHookToUpdate: map[string]sdk.WorkflowNodeHook{
+				"my-uuid-b": sdk.WorkflowNodeHook{Ref: "BBB"},
+			},
+			wantHookToDelete: map[string]sdk.WorkflowNodeHook{},
+		},
+		{
+			name: "one delete",
+			args: args{
+				oldHooks: map[string]sdk.WorkflowNodeHook{
+					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+				},
+				newHooks: map[string]sdk.WorkflowNodeHook{},
+			},
+			wantHookToUpdate: map[string]sdk.WorkflowNodeHook{},
+			wantHookToDelete: map[string]sdk.WorkflowNodeHook{
+				"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHookToUpdate, gotHookToDelete := mergeAndDiffHook(tt.args.oldHooks, tt.args.newHooks)
+			if !reflect.DeepEqual(gotHookToUpdate, tt.wantHookToUpdate) {
+				t.Errorf("mergeAndDiffHook() gotHookToUpdate = %v, want %v", gotHookToUpdate, tt.wantHookToUpdate)
+			}
+			if !reflect.DeepEqual(gotHookToDelete, tt.wantHookToDelete) {
+				t.Errorf("mergeAndDiffHook() gotHookToDelete = %v, want %v", gotHookToDelete, tt.wantHookToDelete)
+			}
+		})
+	}
+}

--- a/engine/sql/099_hook_ref.sql
+++ b/engine/sql/099_hook_ref.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+ALTER TABLE workflow_node_hook ADD COLUMN ref VARCHAR(50);
+update workflow_node_hook set ref = id;
+
+-- +migrate Down
+ALTER TABLE workflow_node_hook DROP COLUMN ref;

--- a/sdk/exportentities/workflow.go
+++ b/sdk/exportentities/workflow.go
@@ -176,6 +176,9 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 			if exportedWorkflow.Hooks == nil {
 				exportedWorkflow.Hooks = make(map[string][]HookEntry)
 			}
+			if h.Ref == "" {
+				h.Ref = fmt.Sprintf("%d", time.Now().Unix())
+			}
 			exportedWorkflow.PipelineHooks = append(exportedWorkflow.PipelineHooks, HookEntry{
 				Model:  h.WorkflowHookModel.Name,
 				Ref:    h.Ref,
@@ -201,6 +204,9 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 		for _, h := range hooks {
 			if exportedWorkflow.Hooks == nil {
 				exportedWorkflow.Hooks = make(map[string][]HookEntry)
+			}
+			if h.Ref == "" {
+				h.Ref = fmt.Sprintf("%d", time.Now().Unix())
 			}
 			exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name] = append(exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name], HookEntry{
 				Model:  h.WorkflowHookModel.Name,

--- a/sdk/exportentities/workflow.go
+++ b/sdk/exportentities/workflow.go
@@ -48,6 +48,7 @@ type NodeEntry struct {
 
 type HookEntry struct {
 	Model  string            `json:"type,omitempty" yaml:"type,omitempty"`
+	Ref    string            `json:"ref,omitempty" yaml:"ref,omitempty"`
 	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
@@ -177,6 +178,7 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 			}
 			exportedWorkflow.PipelineHooks = append(exportedWorkflow.PipelineHooks, HookEntry{
 				Model:  h.WorkflowHookModel.Name,
+				Ref:    h.Ref,
 				Config: h.Config.Values(),
 			})
 		}
@@ -202,6 +204,7 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 			}
 			exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name] = append(exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name], HookEntry{
 				Model:  h.WorkflowHookModel.Name,
+				Ref:    h.Ref,
 				Config: h.Config.Values(),
 			})
 		}
@@ -481,6 +484,7 @@ func (w *Workflow) processHooks(n *sdk.WorkflowNode) {
 			}
 			n.Hooks = append(n.Hooks, sdk.WorkflowNodeHook{
 				WorkflowHookModel: sdk.GetDefaultHookModel(h.Model),
+				Ref:               h.Ref,
 				Config:            cfg,
 			})
 		}

--- a/sdk/exportentities/workflow.go
+++ b/sdk/exportentities/workflow.go
@@ -176,9 +176,6 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 			if exportedWorkflow.Hooks == nil {
 				exportedWorkflow.Hooks = make(map[string][]HookEntry)
 			}
-			if h.Ref == "" {
-				h.Ref = fmt.Sprintf("%d", time.Now().Unix())
-			}
 			exportedWorkflow.PipelineHooks = append(exportedWorkflow.PipelineHooks, HookEntry{
 				Model:  h.WorkflowHookModel.Name,
 				Ref:    h.Ref,
@@ -204,9 +201,6 @@ func NewWorkflow(w sdk.Workflow, withPermission bool) (Workflow, error) {
 		for _, h := range hooks {
 			if exportedWorkflow.Hooks == nil {
 				exportedWorkflow.Hooks = make(map[string][]HookEntry)
-			}
-			if h.Ref == "" {
-				h.Ref = fmt.Sprintf("%d", time.Now().Unix())
 			}
 			exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name] = append(exportedWorkflow.Hooks[w.GetNode(h.WorkflowNodeID).Name], HookEntry{
 				Model:  h.WorkflowHookModel.Name,
@@ -487,6 +481,9 @@ func (w *Workflow) processHooks(n *sdk.WorkflowNode) {
 					Configurable: true,
 					Type:         hType,
 				}
+			}
+			if h.Ref == "" {
+				h.Ref = fmt.Sprintf("%d", time.Now().Unix())
 			}
 			n.Hooks = append(n.Hooks, sdk.WorkflowNodeHook{
 				WorkflowHookModel: sdk.GetDefaultHookModel(h.Model),

--- a/sdk/workflow_hook.go
+++ b/sdk/workflow_hook.go
@@ -54,6 +54,7 @@ func (w *Workflow) GetHooks() map[string]WorkflowNodeHook {
 type WorkflowNodeHook struct {
 	ID                  int64                  `json:"id" db:"id"`
 	UUID                string                 `json:"uuid" db:"uuid"`
+	Ref                 string                 `json:"ref" db:"ref"`
 	WorkflowNodeID      int64                  `json:"workflow_node_id" db:"workflow_node_id"`
 	WorkflowHookModelID int64                  `json:"workflow_hook_model_id" db:"workflow_hook_model_id"`
 	WorkflowHookModel   WorkflowHookModel      `json:"model" db:"-"`
@@ -116,7 +117,7 @@ type WorkflowNodeHookConfigValue struct {
 const (
 	// HookConfigTypeString type string
 	HookConfigTypeString = "string"
-	// HookConfigTypeString type platform
+	// HookConfigTypePlatform type platform
 	HookConfigTypePlatform = "platform"
 )
 


### PR DESCRIPTION
1. Description
A new field named 'ref' is exported with workflow
This will let CDS to know if the hook have to be delete, update or create on import

1. Related issues
close #2690

1. About tests
Unit test on impacted func

1. Mentions

@ovh/cds


Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>