### PR TITLE
fix(ui): calculating the right size of the svg for the workflow

### DIFF
--- a/ui/src/app/views/workflow/graph/workflow.graph.component.ts
+++ b/ui/src/app/views/workflow/graph/workflow.graph.component.ts
@@ -142,22 +142,12 @@ export class WorkflowGraphComponent implements AfterViewInit {
         // Resize svg
         let svg = d3.select('svg');
         let inner = d3.select('svg g');
-        if (this.direction === 'LR') {
-            let w = 0;
-            inner.each(function () {
-                w = this.getBBox().width;
-            });
-            this.svgWidth = w + 30;
-            inner.attr('transform', 'translate(20, 0)');
-        } else {
-            inner.attr('transform', 'translate(20, 0)');
-            // Horizontal center
-            if (event) {
-                this.svgWidth = event.target.innerWidth;
-            } else {
-                this.svgWidth = window.innerWidth;
-            }
-        }
+
+        let w = 0;
+        inner.each(function () {
+            w = this.getBBox().width;
+        });
+        this.svgWidth = w + 30;
 
         this.svgHeight = this.g.graph().height + 40;
         svg.attr('height', this.svgHeight);


### PR DESCRIPTION
# Description

In the case of a workflow displayed in horizontal, the user can't scroll all his workflow if this one is bigger than the width of his screen.

For example, if a workflow is drawn and the with is 3000px or more, the width of the screen is 1920px, you will never see the remaining 1080px on the right side.

It's hard to manage the overflow of a SVG, because if you draw outside the viewBox, it's just not displayed. So all the drawn should be in the viewBox :)

Solution: Calculating the right size of the svg for the workflow and let the HTML manage the overflow :)

# Related issues

@bnjjj I don't know if you have an issue about it :)

# About tests

All right, no change ;D

# Mentions

cc @bnjjj 

Have a good day :)
