### PR TITLE
fix(api): add deployment strategy with same model

### DIFF
--- a/engine/api/application/application_importer.go
+++ b/engine/api/application/application_importer.go
@@ -135,7 +135,7 @@ func Import(db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, app *sdk.
 		if pf == nil {
 			return sdk.WrapError(sdk.NewError(sdk.ErrNotFound, fmt.Errorf("platform %s not found", pfName)), "application.Import")
 		}
-		if err := SetDeploymentStrategy(db, proj.ID, app.ID, pf.PlatformModelID, pfConfig); err != nil {
+		if err := SetDeploymentStrategy(db, proj.ID, app.ID, pf.PlatformModelID, pfName, pfConfig); err != nil {
 			return sdk.WrapError(err, "application.Import> unable to set deployment strategy %s", pfName)
 		}
 	}

--- a/engine/api/application/application_platform.go
+++ b/engine/api/application/application_platform.go
@@ -91,7 +91,7 @@ func DeleteDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64) er
 }
 
 // SetDeploymentStrategy update the application_deployment_strategy table
-func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, cfg sdk.PlatformConfig) error {
+func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, ppfName string, cfg sdk.PlatformConfig) error {
 	//Parse the config and encrypt password values
 	newcfg := sdk.PlatformConfig{}
 	for k, v := range cfg {
@@ -117,7 +117,8 @@ func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, cfg s
 	JOIN project_platform ON project_platform.id = application_deployment_strategy.project_platform_id
 	WHERE project_platform.project_id = $1
 	AND project_platform.platform_model_id = $2
-	AND application_deployment_strategy.application_id = $3`, projID, pfID, appID)
+	AND application_deployment_strategy.application_id = $3
+	AND project_platform.name = $4`, projID, pfID, appID, ppfName)
 
 	if err != nil {
 		return sdk.WrapError(err, "SetDeploymentStrategy> unable to check if deployment strategy exist")
@@ -135,8 +136,9 @@ func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, cfg s
 		WHERE project_platform.id = application_deployment_strategy.project_platform_id
 		AND application_deployment_strategy.application_id = $2
 		AND project_platform.project_id = $3
-		AND project_platform.platform_model_id = $4`
-		if _, err := db.Exec(query, scfg, appID, projID, pfID); err != nil {
+		AND project_platform.platform_model_id = $4
+		AND project_platform.name = $5`
+		if _, err := db.Exec(query, scfg, appID, projID, pfID, ppfName); err != nil {
 			return sdk.WrapError(err, "SetDeploymentStrategy> unable to update deployment strategy")
 		}
 		return nil
@@ -149,6 +151,7 @@ func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, cfg s
 			FROM project_platform
 			WHERE project_platform.project_id = $3
 			AND project_platform.platform_model_id = $4
+			AND project_platform.name = $5
 		)
 	)`
 	if _, err := db.Exec(query, scfg, appID, projID, pfID); err != nil {

--- a/engine/api/application/application_platform.go
+++ b/engine/api/application/application_platform.go
@@ -154,7 +154,7 @@ func SetDeploymentStrategy(db gorp.SqlExecutor, projID, appID, pfID int64, ppfNa
 			AND project_platform.name = $5
 		)
 	)`
-	if _, err := db.Exec(query, scfg, appID, projID, pfID); err != nil {
+	if _, err := db.Exec(query, scfg, appID, projID, pfID, ppfName); err != nil {
 		return sdk.WrapError(err, "SetDeploymentStrategy> unable to update deployment strategy")
 	}
 	return nil

--- a/engine/api/application_deployment.go
+++ b/engine/api/application_deployment.go
@@ -79,7 +79,7 @@ func (api *API) postApplicationDeploymentStrategyConfigHandler() Handler {
 			}
 		}
 
-		if err := application.SetDeploymentStrategy(tx, proj.ID, app.ID, pf.Model.ID, pfConfig); err != nil {
+		if err := application.SetDeploymentStrategy(tx, proj.ID, app.ID, pf.Model.ID, pfName, pfConfig); err != nil {
 			return sdk.WrapError(err, "postApplicationDeploymentStrategyConfigHandler")
 		}
 

--- a/engine/api/application_deployment_test.go
+++ b/engine/api/application_deployment_test.go
@@ -162,6 +162,153 @@ func Test_postApplicationDeploymentStrategyConfigHandler(t *testing.T) {
 	assert.Equal(t, 404, w.Code)
 }
 
+func Test_postApplicationDeploymentStrategyConfigHandler_InsertTwoDifferentPlatforms(t *testing.T) {
+	api, db, router := newTestAPI(t)
+	u, pass := assets.InsertAdminUser(api.mustDB())
+	pkey := sdk.RandomString(10)
+	proj := assets.InsertTestProject(t, db, api.Cache, pkey, pkey, u)
+	app := &sdk.Application{
+		Name: sdk.RandomString(10),
+	}
+	test.NoError(t, application.Insert(api.mustDB(), api.Cache, proj, app, u))
+
+	pf := sdk.PlatformModel{
+		Name:       "test-deploy-2",
+		Deployment: true,
+	}
+	test.NoError(t, platform.InsertModel(db, &pf))
+	defer platform.DeleteModel(db, pf.ID)
+
+	pp := sdk.ProjectPlatform{
+		Model:           pf,
+		Name:            pf.Name,
+		PlatformModelID: pf.ID,
+		ProjectID:       proj.ID,
+		Config: sdk.PlatformConfig{
+			"token": sdk.PlatformConfigValue{
+				Type:  sdk.PlatformConfigTypePassword,
+				Value: "my-secret-token",
+			},
+			"url": sdk.PlatformConfigValue{
+				Type:  sdk.PlatformConfigTypeString,
+				Value: "my-url",
+			},
+		},
+	}
+	test.NoError(t, platform.InsertPlatform(db, &pp))
+
+	pp2 := sdk.ProjectPlatform{
+		Model:           pf,
+		Name:            pf.Name + "-2",
+		PlatformModelID: pf.ID,
+		ProjectID:       proj.ID,
+		Config: sdk.PlatformConfig{
+			"token": sdk.PlatformConfigValue{
+				Type:  sdk.PlatformConfigTypePassword,
+				Value: "my-secret-token",
+			},
+			"url": sdk.PlatformConfigValue{
+				Type:  sdk.PlatformConfigTypeString,
+				Value: "my-url",
+			},
+		},
+	}
+	test.NoError(t, platform.InsertPlatform(db, &pp2))
+
+	vars := map[string]string{
+		"key": proj.Key,
+		"permApplicationName": app.Name,
+		"platform":            pf.Name,
+	}
+
+	uri := router.GetRoute("POST", api.postApplicationDeploymentStrategyConfigHandler, vars)
+	req := assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, sdk.PlatformConfig{
+		"token": sdk.PlatformConfigValue{
+			Type:  sdk.PlatformConfigTypePassword,
+			Value: "my-secret-token",
+		},
+		"url": sdk.PlatformConfigValue{
+			Type:  sdk.PlatformConfigTypeString,
+			Value: "my-url",
+		},
+	})
+
+	// Do the request
+	w := httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	//Now add a new
+	vars = map[string]string{
+		"key": proj.Key,
+		"permApplicationName": app.Name,
+		"platform":            pp2.Name,
+	}
+
+	uri = router.GetRoute("POST", api.postApplicationDeploymentStrategyConfigHandler, vars)
+	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, sdk.PlatformConfig{
+		"token": sdk.PlatformConfigValue{
+			Type:  sdk.PlatformConfigTypePassword,
+			Value: "my-secret-token",
+		},
+		"url": sdk.PlatformConfigValue{
+			Type:  sdk.PlatformConfigTypeString,
+			Value: "my-url",
+		},
+	})
+
+	// Do the request
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
+	//Then we try to update
+	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
+	// Do the request
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	cfg := sdk.PlatformConfig{}
+	test.NoError(t, json.Unmarshal(w.Body.Bytes(), &cfg))
+	assert.Equal(t, sdk.PasswordPlaceholder, cfg["token"].Value)
+
+	// with clear paswword
+	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
+	// Then we try to update
+	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
+	q := req.URL.Query()
+	q.Set("withClearPassword", "true")
+	req.URL.RawQuery = q.Encode()
+
+	// Do the request
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	cfg2 := sdk.PlatformConfig{}
+	test.NoError(t, json.Unmarshal(w.Body.Bytes(), &cfg2))
+	assert.Equal(t, "my-secret-token-2", cfg2["token"].Value)
+
+	// with clear paswword
+	uri = router.GetRoute("DELETE", api.deleteApplicationDeploymentStrategyConfigHandler, vars)
+	// Then we try to update
+	req = assets.NewAuthentifiedRequest(t, u, pass, "DELETE", uri, nil)
+	// Do the request
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
+	//Then we try to update
+	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
+	// Do the request
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 404, w.Code)
+}
+
 func Test_deleteApplicationDeploymentStrategyConfigHandler(t *testing.T) {
 	//see Test_postApplicationDeploymentStrategyConfigHandler
 }

--- a/engine/api/application_deployment_test.go
+++ b/engine/api/application_deployment_test.go
@@ -262,7 +262,11 @@ func Test_postApplicationDeploymentStrategyConfigHandler_InsertTwoDifferentPlatf
 	router.Mux.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 
-	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
+	vars = map[string]string{
+		"key": proj.Key,
+		"permApplicationName": app.Name,
+	}
+	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategiesConfigHandler, vars)
 	//Then we try to update
 	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
 	// Do the request
@@ -270,43 +274,10 @@ func Test_postApplicationDeploymentStrategyConfigHandler_InsertTwoDifferentPlatf
 	router.Mux.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 
-	cfg := sdk.PlatformConfig{}
+	cfg := map[string]sdk.PlatformConfig{}
 	test.NoError(t, json.Unmarshal(w.Body.Bytes(), &cfg))
-	assert.Equal(t, sdk.PasswordPlaceholder, cfg["token"].Value)
+	assert.Len(t, cfg, 2)
 
-	// with clear paswword
-	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
-	// Then we try to update
-	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
-	q := req.URL.Query()
-	q.Set("withClearPassword", "true")
-	req.URL.RawQuery = q.Encode()
-
-	// Do the request
-	w = httptest.NewRecorder()
-	router.Mux.ServeHTTP(w, req)
-	assert.Equal(t, 200, w.Code)
-
-	cfg2 := sdk.PlatformConfig{}
-	test.NoError(t, json.Unmarshal(w.Body.Bytes(), &cfg2))
-	assert.Equal(t, "my-secret-token-2", cfg2["token"].Value)
-
-	// with clear paswword
-	uri = router.GetRoute("DELETE", api.deleteApplicationDeploymentStrategyConfigHandler, vars)
-	// Then we try to update
-	req = assets.NewAuthentifiedRequest(t, u, pass, "DELETE", uri, nil)
-	// Do the request
-	w = httptest.NewRecorder()
-	router.Mux.ServeHTTP(w, req)
-	assert.Equal(t, 200, w.Code)
-
-	uri = router.GetRoute("GET", api.getApplicationDeploymentStrategyConfigHandler, vars)
-	//Then we try to update
-	req = assets.NewAuthentifiedRequest(t, u, pass, "GET", uri, nil)
-	// Do the request
-	w = httptest.NewRecorder()
-	router.Mux.ServeHTTP(w, req)
-	assert.Equal(t, 404, w.Code)
 }
 
 func Test_deleteApplicationDeploymentStrategyConfigHandler(t *testing.T) {

--- a/engine/api/application_import_test.go
+++ b/engine/api/application_import_test.go
@@ -629,7 +629,7 @@ func Test_postApplicationImportHandler_ExistingAppWithDeploymentStrategy(t *test
 	}
 	test.NoError(t, application.Insert(db, api.Cache, proj, &app, u))
 
-	test.NoError(t, application.SetDeploymentStrategy(db, proj.ID, app.ID, pf.ID, sdk.PlatformConfig{
+	test.NoError(t, application.SetDeploymentStrategy(db, proj.ID, app.ID, pf.ID, pp.Name, sdk.PlatformConfig{
 		"token": sdk.PlatformConfigValue{
 			Type:  sdk.PlatformConfigTypePassword,
 			Value: "my-secret-token-2",


### PR DESCRIPTION
1. Description
The problem was in a sql subquery while adding two platform deployment strategies on coming from the same platform model (which is totally legit)

1. Related issues
#2703 

1. About tests
New unit test

1. Mentions
@ovh/cds
