### PR TITLE
fix (sdk): take care of --insecure and http proxy from env

### DIFF
--- a/cli/cdsctl/config.go
+++ b/cli/cdsctl/config.go
@@ -45,6 +45,9 @@ func loadConfig(configFile string) (*cdsclient.Config, error) {
 	c.User = os.Getenv("CDS_USER")
 	c.Token = os.Getenv("CDS_TOKEN")
 	c.InsecureSkipVerifyTLS, _ = strconv.ParseBool(os.Getenv("CDS_INSECURE"))
+	if insecureSkipVerifyTLS { // if set from command line
+		c.InsecureSkipVerifyTLS = true
+	}
 
 	if c.Host != "" && c.User != "" {
 		if verbose {
@@ -100,10 +103,11 @@ func loadConfig(configFile string) (*cdsclient.Config, error) {
 	}
 
 	conf := &cdsclient.Config{
-		Host:    c.Host,
-		User:    c.User,
-		Token:   c.Token,
-		Verbose: verbose,
+		Host:                  c.Host,
+		User:                  c.User,
+		Token:                 c.Token,
+		Verbose:               verbose,
+		InsecureSkipVerifyTLS: c.InsecureSkipVerifyTLS,
 	}
 
 	return conf, nil

--- a/sdk/cdsclient/client.go
+++ b/sdk/cdsclient/client.go
@@ -27,6 +27,10 @@ func New(c Config) Interface {
 	cli.config = c
 	cli.HTTPClient = &http.Client{
 		Timeout: time.Second * 60,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerifyTLS},
+		},
 	}
 	cli.init()
 	return cli
@@ -75,6 +79,7 @@ func NewHatchery(endpoint string, token string, requestSecondsTimeout int, insec
 		Host:  endpoint,
 		Retry: 2,
 		Token: token,
+		InsecureSkipVerifyTLS: insecureSkipVerifyTLS,
 	}
 	cli := new(client)
 	cli.config = conf
@@ -82,7 +87,7 @@ func NewHatchery(endpoint string, token string, requestSecondsTimeout int, insec
 		Transport: &httpcontrol.Transport{
 			RequestTimeout:  time.Duration(requestSecondsTimeout) * time.Second,
 			MaxTries:        5,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerifyTLS},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.InsecureSkipVerifyTLS},
 		},
 	}
 

--- a/sdk/cdsclient/config.go
+++ b/sdk/cdsclient/config.go
@@ -2,13 +2,14 @@ package cdsclient
 
 //Config is the configuration data used by the cdsclient interface implementation
 type Config struct {
-	Host      string
-	User      string
-	Token     string
-	Hash      string
-	userAgent string
-	Verbose   bool
-	Retry     int
+	Host                  string
+	User                  string
+	Token                 string
+	Hash                  string
+	userAgent             string
+	Verbose               bool
+	Retry                 int
+	InsecureSkipVerifyTLS bool
 }
 
 //ProviderConfig is the configuration data used by the cdsclient ProviderClient interface implementation


### PR DESCRIPTION
this is useful for cdsctl, for a cds api behind a proxy

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>