### PR TITLE
feat(ui): harmonize helpers + use menu instead of buttons for info

### DIFF
--- a/ui/src/app/views/admin/broadcast/add/broadcast.add.html
+++ b/ui/src/app/views/admin/broadcast/add/broadcast.add.html
@@ -74,7 +74,7 @@
         </div>
         <div class="six wide column">
           <div class="ui segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'broadcast_help_line_1' | translate}}</p>
             <p>{{'broadcast_help_line_2' | translate}}</p>
           </div>

--- a/ui/src/app/views/admin/broadcast/edit/broadcast.edit.html
+++ b/ui/src/app/views/admin/broadcast/edit/broadcast.edit.html
@@ -75,7 +75,7 @@
         </div>
         <div class="six wide column">
           <div class="ui segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'broadcast_help_line_1' | translate}}</p>
             <p>{{'broadcast_help_line_2' | translate}}</p>
           </div>

--- a/ui/src/app/views/admin/worker-model-pattern/add/worker-model-pattern.add.html
+++ b/ui/src/app/views/admin/worker-model-pattern/add/worker-model-pattern.add.html
@@ -92,8 +92,8 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+          <div class="ui segment">
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>
 

--- a/ui/src/app/views/admin/worker-model-pattern/edit/worker-model-pattern.edit.html
+++ b/ui/src/app/views/admin/worker-model-pattern/edit/worker-model-pattern.edit.html
@@ -86,8 +86,8 @@
             </div>
         </div>
         <div class="six wide column">
-          <div class="ui tall stacked segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+          <div class="ui segment">
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>
 

--- a/ui/src/app/views/broadcast/list/broadcast.list.component.html
+++ b/ui/src/app/views/broadcast/list/broadcast.list.component.html
@@ -20,9 +20,9 @@
                         </div>
                         <div class="ui row">
                             <div class="sixteen wide column">
-                                <div class="ui fluid buttons">
-                                  <button class="ui button" [class.active]="recentView" [class.blue]="recentView" (click)="switchToRecentView(true)">{{'broadcast_recent' | translate}}</button>
-                                  <button class="ui button" [class.active]="!recentView" [class.blue]="!recentView" (click)="switchToRecentView(false)">{{'broadcast_seen' | translate}}</button>
+                                <div class="ui grey two item pointing menu">
+                                  <div class="item" [class.active]="recentView" (click)="switchToRecentView(true)">{{'broadcast_recent' | translate}}</div>
+                                  <div class="item" [class.active]="!recentView" (click)="switchToRecentView(false)">{{'broadcast_seen' | translate}}</div>
                                 </div>
                             </div>
                         </div>
@@ -59,7 +59,7 @@
                     </ng-container>
                     <ng-container *ngIf="!filteredBroadcasts || filteredBroadcasts.length === 0">
                         <div class="ui row mt5">
-                            <div class="centered sixteen wide column">
+                            <div class="ui segment centered sixteen wide column">
                                 {{'broadcast_none' | translate}}
                             </div>
                         </div>

--- a/ui/src/app/views/settings/action/add/action.add.html
+++ b/ui/src/app/views/settings/action/add/action.add.html
@@ -9,7 +9,7 @@
 
       <div class="three wide column">
         <div class="ui segment">
-          <h4 class="ui header"><i class="fa fa-book fa-x4"></i> Documentation</h4>
+          <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
 
           <div class="ui list">
             <a class="item" href="https://ovh.github.io/cds/workflows/pipelines/actions/" target="_blank">What's an action?</a>
@@ -18,7 +18,7 @@
             <a class="item" href="https://ovh.github.io/cds/workflows/pipelines/actions/plugins/" target="_blank">Plugins Actions</a>
           </div>
 
-          <a href="https://ovh.github.io/cds" target="_blank">https://ovh.github.io/cds</a>
+          <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
         </div>
       </div>
 

--- a/ui/src/app/views/settings/action/edit/action.edit.html
+++ b/ui/src/app/views/settings/action/edit/action.edit.html
@@ -28,7 +28,7 @@
 
       <div class="three wide column">
         <div class="ui segment">
-          <h4 class="ui header"><i class="fa fa-book fa-x4"></i> Documentation</h4>
+          <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
 
           <div class="ui list">
             <a class="item" href="https://ovh.github.io/cds/workflows/pipelines/actions/">What's an action?</a>
@@ -37,7 +37,7 @@
             <a class="item" href="https://ovh.github.io/cds/workflows/pipelines/actions/plugins/">Plugins Actions</a>
           </div>
 
-          <a href="https://ovh.github.io/cds">https://ovh.github.io/cds</a>
+          <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
         </div>
       </div>
 

--- a/ui/src/app/views/settings/group/edit/group.edit.html
+++ b/ui/src/app/views/settings/group/edit/group.edit.html
@@ -92,7 +92,7 @@
 
         <div class="six wide column">
           <div class="ui center aligned segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
           </div>
         </div>

--- a/ui/src/app/views/settings/user/edit/user.edit.html
+++ b/ui/src/app/views/settings/user/edit/user.edit.html
@@ -65,8 +65,7 @@
 
             <div class="six wide column">
                 <div class="ui center aligned segment">
-                    <h4 class="ui header">
-                        <i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
+                    <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
                     <a class="circular ui blue button" href="https://ovh.github.io/cds" target="_blank">{{ 'common_see_documentation' | translate }}</a>
                 </div>
             </div>

--- a/ui/src/app/views/settings/worker-model/add/worker-model.add.html
+++ b/ui/src/app/views/settings/worker-model/add/worker-model.add.html
@@ -207,7 +207,7 @@
         </div>
         <div class="six wide column">
           <div class="ui segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i></h4>
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>
 

--- a/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
+++ b/ui/src/app/views/settings/worker-model/edit/worker-model.edit.html
@@ -250,7 +250,7 @@
         </div>
         <div class="six wide column">
           <div class="ui segment">
-            <h4 class="ui header"><i class="fa fa-book fa-3x"></i>{{ 'settings_tips' | translate }}</h4>
+            <h2 class="ui header"><i class="fa fa-book"></i> {{ 'settings_tips' | translate }}</h2>
             <p>{{'worker_model_help_line_1' | translate}}</p>
             <p>{{'worker_model_help_line_2' | translate}}</p>
 

--- a/ui/src/app/views/settings/worker-model/list/worker-model.list.html
+++ b/ui/src/app/views/settings/worker-model/list/worker-model.list.html
@@ -31,32 +31,32 @@
 
       <table class="ui fixed celled table" *ngIf="getDataForCurrentPage().length > 0">
           <thead>
-          <tr>
-              <th class="four wide">{{ 'worker_model_name' | translate }}</th>
-              <th class="four wide">{{ 'worker_model_description' | translate }}</th>
-              <th class="two wide">{{ 'worker_model_type' | translate }}</th>
-              <th class="three wide">{{ 'worker_model_image' | translate }}</th>
-              <th class="three wide">{{ 'worker_model_group' | translate }}</th>
-          </tr>
+            <tr>
+                <th class="four wide">{{ 'worker_model_name' | translate }}</th>
+                <th class="four wide">{{ 'worker_model_description' | translate }}</th>
+                <th class="two wide">{{ 'worker_model_type' | translate }}</th>
+                <th class="three wide">{{ 'worker_model_image' | translate }}</th>
+                <th class="three wide">{{ 'worker_model_group' | translate }}</th>
+            </tr>
           </thead>
           <tbody>
-          <tr *ngFor="let v of getDataForCurrentPage()">
-              <td>
-                  <a class="ui" [routerLink]="[v.name]">
-                    <div class="ui">
-                        {{v.name}}
-                        <span *ngIf="v.disabled" [smDirTooltip]="'worker_model_disabled' | translate" smDirPosition="top center"> {{ 'worker_model_disabled' | translate }}</span>
-                        <span *ngIf="v.nb_spawn_err > 0" [smDirTooltip]="'worker_model_spawn_error_tooltip' | translate" smDirPosition="top center">  <i class="exclamation triangle icon large red" title="{{ 'worker_model_warning' | translate }}"></i> </span>
-                        <span *ngIf="v.is_official" [smDirTooltip]="'worker_model_official_tooltip' | translate" smDirPosition="top center"> <i class="check circle outline icon large green"></i> </span>
-                        <span *ngIf="v.is_deprecated" [smDirTooltip]="'worker_model_deprecated_tooltip' | translate" smDirPosition="top center"> <i class="exclamation circle icon large orange"></i> </span>
-                    </div>
-                  </a>
-              </td>
-              <td>{{v.description}}</td>
-              <td>{{v.type}}</td>
-              <td>{{getImageName(v)}}</td>
-              <td>{{v.group.name}}</td>
-          </tr>
+            <tr *ngFor="let v of getDataForCurrentPage()">
+                <td class="border">
+                    <a class="ui" [routerLink]="[v.name]">
+                        <div class="ui">
+                            {{v.name}}
+                            <span *ngIf="v.disabled" [smDirTooltip]="'worker_model_disabled' | translate" smDirPosition="top center"> {{ 'worker_model_disabled' | translate }}</span>
+                            <span *ngIf="v.nb_spawn_err > 0" [smDirTooltip]="'worker_model_spawn_error_tooltip' | translate" smDirPosition="top center">  <i class="exclamation triangle icon large red" title="{{ 'worker_model_warning' | translate }}"></i> </span>
+                            <span *ngIf="v.is_official" [smDirTooltip]="'worker_model_official_tooltip' | translate" smDirPosition="top center"> <i class="check circle outline icon large green"></i> </span>
+                            <span *ngIf="v.is_deprecated" [smDirTooltip]="'worker_model_deprecated_tooltip' | translate" smDirPosition="top center"> <i class="exclamation circle icon large orange"></i> </span>
+                        </div>
+                    </a>
+                </td>
+                <td class="border">{{v.description}}</td>
+                <td class="border">{{v.type}}</td>
+                <td class="border">{{getImageName(v)}}</td>
+                <td class="border">{{v.group.name}}</td>
+            </tr>
           </tbody>
           <tfoot *ngIf="getNbOfPages() > 1">
             <tr>


### PR DESCRIPTION
- harmonize all helper to use <h2> and remove fa-3x on icons
- use borders on worker models table
- use a pointing menu instead of button group for information page

@ovh/cds
