### PR TITLE
feat (hatchery/swarm): dockerOpts 

### DIFF
--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -155,7 +155,7 @@ func (h *HatcherySwarm) SpawnWorker(spawnArgs hatchery.SpawnArguments) (string, 
 		"hatchery":            h.Config.Name,
 	}
 
-	dockerOpts, errDockerOpts := computeDockerOpts(h.hatch.IsSharedInfra, spawnArgs.Requirements)
+	dockerOpts, errDockerOpts := h.computeDockerOpts(spawnArgs.Requirements)
 	if errDockerOpts != nil {
 		return name, errDockerOpts
 	}

--- a/engine/hatchery/swarm/swarm_util_create.go
+++ b/engine/hatchery/swarm/swarm_util_create.go
@@ -136,17 +136,24 @@ type dockerOpts struct {
 	extraHosts []string
 }
 
-func computeDockerOpts(isSharedInfra bool, requirements []sdk.Requirement) (*dockerOpts, error) {
+func (h *HatcherySwarm) computeDockerOpts(requirements []sdk.Requirement) (*dockerOpts, error) {
 	dockerOpts := &dockerOpts{}
+
+	// support for add-host on hatchery configuration
+	if strings.HasPrefix(h.Config.DockerOpts, "--add-host=") {
+		if err := dockerOpts.computeDockerOptsExtraHosts(h.Config.DockerOpts); err != nil {
+			return nil, err
+		}
+	}
 
 	for _, r := range requirements {
 		switch r.Type {
 		case sdk.ModelRequirement:
-			if err := dockerOpts.computeDockerOptsOnModelRequirement(isSharedInfra, r); err != nil {
+			if err := dockerOpts.computeDockerOptsOnModelRequirement(h.hatch.IsSharedInfra, r); err != nil {
 				return nil, err
 			}
 		case sdk.VolumeRequirement:
-			if err := dockerOpts.computeDockerOptsOnVolumeRequirement(isSharedInfra, r); err != nil {
+			if err := dockerOpts.computeDockerOptsOnVolumeRequirement(h.hatch.IsSharedInfra, r); err != nil {
 				return nil, err
 			}
 		}

--- a/engine/hatchery/swarm/swarm_util_create.go
+++ b/engine/hatchery/swarm/swarm_util_create.go
@@ -140,9 +140,13 @@ func (h *HatcherySwarm) computeDockerOpts(requirements []sdk.Requirement) (*dock
 	dockerOpts := &dockerOpts{}
 
 	// support for add-host on hatchery configuration
-	if strings.HasPrefix(h.Config.DockerOpts, "--add-host=") {
-		if err := dockerOpts.computeDockerOptsExtraHosts(h.Config.DockerOpts); err != nil {
-			return nil, err
+	for _, opt := range strings.Split(h.Config.DockerOpts, " ") {
+		if strings.HasPrefix(opt, "--add-host=") {
+			if err := dockerOpts.computeDockerOptsExtraHosts(opt); err != nil {
+				return nil, err
+			}
+		} else if opt == "--privileged" {
+			dockerOpts.privileged = true
 		}
 	}
 

--- a/engine/hatchery/swarm/swarm_util_create_test.go
+++ b/engine/hatchery/swarm/swarm_util_create_test.go
@@ -120,7 +120,8 @@ func Test_computeDockerOpts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := computeDockerOpts(tt.args.isSharedInfra, tt.args.requirements)
+			h := &HatcherySwarm{hatch: &sdk.Hatchery{IsSharedInfra: tt.args.isSharedInfra}}
+			got, err := h.computeDockerOpts(tt.args.requirements)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("computeDockerOpts() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -23,6 +23,9 @@ type HatcheryConfiguration struct {
 
 	// WorkerTTL Worker TTL (minutes)
 	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"false" comment:"Worker TTL (minutes)"`
+
+	// DockerOpts Docker options
+	DockerOpts string `mapstructure:"dockerOpts" toml:"dockerOpts" default:"" commented:"true" comment:"Docker Options. --add-host supported. Example: --add-host=myhost:x.x.x.x,myhost2:y.y.y.y"`
 }
 
 // HatcherySwarm is a hatchery which can be connected to a remote to a docker remote api

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -25,7 +25,7 @@ type HatcheryConfiguration struct {
 	WorkerTTL int `mapstructure:"workerTTL" toml:"workerTTL" default:"10" commented:"false" comment:"Worker TTL (minutes)"`
 
 	// DockerOpts Docker options
-	DockerOpts string `mapstructure:"dockerOpts" toml:"dockerOpts" default:"" commented:"true" comment:"Docker Options. --add-host supported. Example: --add-host=myhost:x.x.x.x,myhost2:y.y.y.y"`
+	DockerOpts string `mapstructure:"dockerOpts" toml:"dockerOpts" default:"" commented:"true" comment:"Docker Options. --add-host and --privileged supported. Example: dockerOpts=\"--add-host=myhost:x.x.x.x,myhost2:y.y.y.y --privileged\""`
 }
 
 // HatcherySwarm is a hatchery which can be connected to a remote to a docker remote api


### PR DESCRIPTION
1. Description
This option let user to add --add-host and --privileged on all containers started by the hatchery

For the add-host: unbound should be considered if the hatchery does not manage CDS Service, but using unbound for containers using a private network is much more tricky to configure than using this option.

1. About tests
UT and manual Tests done

1. Mentions

@ovh/cds
