### PR TITLE
fix (api): do not use curl "-C -"

### DIFF
--- a/engine/api/migrate/hatchery_cmd.go
+++ b/engine/api/migrate/hatchery_cmd.go
@@ -61,7 +61,7 @@ func HatcheryCmdMigration(store cache.Store, DBFunc func() *gorp.DbMap) {
 			wm.ModelDocker = sdk.ModelDocker{
 				Image: wm.Image,
 				Shell: "sh -c",
-				Cmd:   "curl {{.API}}/download/worker/linux/$(uname -m) -o worker --retry 10 --retry-max-time 120 -C - && chmod +x worker && exec ./worker",
+				Cmd:   "curl {{.API}}/download/worker/linux/$(uname -m) -o worker --retry 10 --retry-max-time 120 && chmod +x worker && exec ./worker",
 			}
 		case sdk.Openstack:
 			var osdata deprecatedOpenstackModelData
@@ -112,7 +112,7 @@ export CDS_INSECURE={{.HTTPInsecure}}
 			preCmd += string(userdata)
 
 			preCmd += `
-			curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120 -C -
+			curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120
 			chmod +x worker
 			`
 			wm.ModelVirtualMachine = sdk.ModelVirtualMachine{
@@ -163,7 +163,7 @@ export CDS_GRAYLOG_EXTRA_VALUE={{.GraylogExtraValue}}
 #export CDS_GRPC_API={{.GrpcAPI}}
 #export CDS_GRPC_INSECURE={{.GrpcInsecure}}
 
-curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120 -C -
+curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120
 chmod +x worker
 `
 			wm.ModelVirtualMachine = sdk.ModelVirtualMachine{

--- a/engine/api/worker/pattern.go
+++ b/engine/api/worker/pattern.go
@@ -130,7 +130,7 @@ else
 	service docker restart >> /tmp/user_data 2>&1
 fi;
 
-curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120 -C - >> /tmp/user_data 2>&1
+curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o worker --retry 10 --retry-max-time 120 >> /tmp/user_data 2>&1
 chmod +x worker
 `
 	patternCases := [...]patternCase{
@@ -141,7 +141,7 @@ chmod +x worker
 				Name: "basic_unix",
 				Model: sdk.ModelCmds{
 					Shell: "sh -c",
-					Cmd:   "curl {{.API}}/download/worker/linux/$(uname -m) -o worker --retry 10 --retry-max-time 120 -C - && chmod +x worker && exec ./worker",
+					Cmd:   "curl {{.API}}/download/worker/linux/$(uname -m) -o worker --retry 10 --retry-max-time 120 && chmod +x worker && exec ./worker",
 				},
 			},
 		},


### PR DESCRIPTION


    as we want to always download the latest worker model.
    use case: a snapshot openstack will contains a worker,
    with -C -, the worker is not updated by the curl command

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>