### PR TITLE
fix (api): unit test exportentities

### DIFF
--- a/sdk/exportentities/workflow_test.go
+++ b/sdk/exportentities/workflow_test.go
@@ -1,6 +1,7 @@
 package exportentities
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -612,7 +613,15 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 
 			expextedValues, _ := dump.ToStringMap(tt.want)
 			actualValues, _ := dump.ToStringMap(got)
-			for expectedKey, expectedValue := range expextedValues {
+
+			var keysExpextedValues []string
+			for k := range expextedValues {
+				keysExpextedValues = append(keysExpextedValues, k)
+			}
+			sort.Strings(keysExpextedValues)
+
+			for _, expectedKey := range keysExpextedValues {
+				expectedValue := expextedValues[expectedKey]
 				actualValue, ok := actualValues[expectedKey]
 				if strings.Contains(expectedKey, ".Ref") {
 					assert.NotEmpty(t, actualValue, "value %s is empty but shoud not be empty", expectedKey)


### PR DESCRIPTION
with that: https://github.com/ovh/cds/pull/2816/files#diff-e62d6ddf5c536d7b3ed7418615c60916R111
ancestors are sorted.

The expected keys need to be sorted too in unit test

This will avoid this error:

```

	Error Trace:

	Error:		Not equal: "F" (expected)
    			        != "E" (actual)

	Messages:	value Workflow.Joins.Joins0.Triggers.Triggers2.WorkflowDestNode.Name doesn't match. Got E but want F

    	assertions.go:213:

	Error Trace:

	Error:		Not equal: "E" (expected)
    			        != "F" (actual)

	Messages:	value Workflow.Joins.Joins0.Triggers.Triggers1.WorkflowDestNode.Name doesn't match. Got F but want E
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>

