### PR TITLE
fix (engine): heatbeat failed -> stopping serve

### DIFF
--- a/engine/main.go
+++ b/engine/main.go
@@ -435,9 +435,19 @@ func serve(c context.Context, s service.Service, serviceName string) error {
 		}
 	}()
 
-	if err := s.Serve(c); err != nil {
-		return err
-	}
+	go func() {
+		if err := s.Serve(c); err != nil {
+			log.Error("%s> Serve: %v", serviceName, err)
+			cancel()
+		}
+	}()
 
+	<-ctx.Done()
+
+	if ctx.Err() != nil {
+		log.Error("%s> Service exiting with err: %v", serviceName, ctx.Err())
+	} else {
+		log.Info("%s> Service exiting", serviceName)
+	}
 	return ctx.Err()
 }


### PR DESCRIPTION
This will avoid to have a running service without a proper heartbeat on API

On a CDS base on docker deployment, this let user to put a healthcheck on a route (as /mon/status or /mon/version), if no heartbeat, the endpoint will not answer anymore, the container could restart.
