### PR TITLE
feat(ui): modify css to delimit broadcast content  + fix glitch on CDSMenu on scroll

### DIFF
--- a/ui/src/app/views/broadcast/list/broadcast.list.component.scss
+++ b/ui/src/app/views/broadcast/list/broadcast.list.component.scss
@@ -6,6 +6,20 @@
 
   .mt5 {
     margin-top: 5px;
+    ::ng-deep {
+      .title {
+        line-height: 1.75em;
+      }
+      .content {
+        padding: .5em 1em 1em 1em;
+        & > div {
+          padding: 1em;
+          background-color: rgba(0, 0, 0, 0.05);
+          border: 1px solid rgba(0, 0, 0, 0.10);
+          border-radius: 4px;
+        }
+      }
+    }
   }
 
   .transparent {

--- a/ui/src/common.scss
+++ b/ui/src/common.scss
@@ -56,6 +56,7 @@ pre {
 .CDSmenu {
   padding: 0.25em 30px 0 30px;
   height: 40px;
+  margin-bottom: .3em;
 }
 
 .scrollingContent {


### PR DESCRIPTION
- delimit accordion content in broadcast list to wrap the markdown in order to make it look less messy
- fix glitch on CDSMenu when scrolling (the content partially pass through the menu)

@ovh/cds
