### PR TITLE
fix(plugin): add CDS_SEMVER metadata

### DIFF
--- a/contrib/grpcplugins/deployment/arsenal/main.go
+++ b/contrib/grpcplugins/deployment/arsenal/main.go
@@ -78,6 +78,7 @@ const deployData = `{
 		"CDS_WORKFLOW": "{{.cds.workflow}}",
 		"CDS_PROJECT": "{{.cds.project}}",
 		"CDS_VERSION": "{{.cds.version}}",
+		"CDS_SEMVER": "{{.cds.semver}}",
 		"CDS_GIT_REPOSITORY": "{{.git.repository}}",
 		"CDS_GIT_HASH": "{{.git.hash}}"
 	}


### PR DESCRIPTION
As a CDS user in order to access to my semver attribute i want to add CDS_SEMVER in my deployment metadata

1. Description

Just add a new metadata called CDS_SEMVER in deployment metadata

2. Related issues

None

3. About tests

No test

4. Mentions

What is a mention ?

@ovh/cds
