### PR TITLE
Add default .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,ts,css,scss,less}]
+indent_size = 4

--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Signed-off-by: Joel Seguillon <joel.seguillon@gmail.com>

1. Add default .editorconfig file that helps to comply with coding style
1. https://github.com/ovh/cds/issues/2893
1. N/A
1. Should be reviewed by devs with IDE handling .editor 

@ovh/cds
