### PR TITLE
fix(api): send pull request reports with tests

### DIFF
--- a/engine/api/workflow/workflow_run_event.go
+++ b/engine/api/workflow/workflow_run_event.go
@@ -164,6 +164,16 @@ func ResyncCommitStatus(ctx context.Context, db gorp.SqlExecutor, store cache.St
 func sendVCSEventStatus(db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, wr *sdk.WorkflowRun, nodeRun *sdk.WorkflowNodeRun) error {
 	log.Debug("Send status for node run %d", nodeRun.ID)
 
+	//Reload the workflow node run to get the tests
+	var err error
+	nodeRunID := nodeRun.ID
+	nodeRun, err = LoadNodeRunByID(db, nodeRunID, LoadRunOptions{
+		WithTests: true,
+	})
+	if err != nil {
+		return sdk.WrapError(err, "sendVCSEventStatus> Unable to reload noderun %d", nodeRunID)
+	}
+
 	node := wr.Workflow.GetNode(nodeRun.WorkflowNodeID)
 	if !node.IsLinkedToRepo() {
 		return nil

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -299,6 +299,7 @@ const workflowNodeRunReport = `CDS Report {{.WorkflowNodeName}}#{{.Number}}.{{.S
 {{- end}}
 {{end}}
 
+{{- if .Tests }} 
 {{- if gt .Tests.TotalKO 0}}
 Unit Tests Report
 
@@ -307,6 +308,7 @@ Unit Tests Report
 {{range $tc := $ts.TestCases}}
   {{- if or ($tc.Errors) ($tc.Failures) }}  * {{ $tc.Name }} ✘ {{- end}}
 {{end}}
+{{- end}}
 {{- end}}
 {{- end}}
 `

--- a/sdk/workflow_run_test.go
+++ b/sdk/workflow_run_test.go
@@ -69,6 +69,38 @@ func TestWorkflowRunReport(t *testing.T) {
 			},
 		},
 	}
+
+	wfr = WorkflowNodeRun{
+		Stages: []Stage{
+			{
+				Name: "stage 1",
+				RunJobs: []WorkflowNodeJobRun{
+					{
+						Job: ExecutedJob{
+							Job: Job{
+								Action: Action{
+									Name: "job 1",
+								},
+							},
+						},
+						Status: StatusSuccess.String(),
+					},
+					{
+						Job: ExecutedJob{
+							Job: Job{
+								Action: Action{
+									Name: "job 2",
+								},
+							},
+						},
+						Status: StatusFail.String(),
+					},
+				},
+			},
+		},
+		Tests: nil,
+	}
+
 	s, err := wfr.Report()
 	assert.NoError(t, err)
 	t.Log(s)


### PR DESCRIPTION
1. Description
fixing this error: 
````
| err  | sendVCSEventStatus> unable to compute node run reporttemplate: :9:16: executing "" at <.Tests.TotalKO>: can't evaluate field TotalKO in type *venom.Tests
````
1. Related issues
1. About tests
1. Mentions

@ovh/cds
