### PR TITLE
fix(hatchery): do not put worker model in error when spawn a worker for job doesn't work

### DIFF
--- a/sdk/hatchery/starter.go
+++ b/sdk/hatchery/starter.go
@@ -131,13 +131,7 @@ func spawnWorkerForJob(h Interface, j workerStarterRequest) (bool, error) {
 		if err := h.CDSClient().QueueJobSendSpawnInfo(j.isWorkflowJob, j.id, infos); err != nil {
 			log.Warning("spawnWorkerForJob> %d - cannot client.QueueJobSendSpawnInfo for job (err spawn)%d: %s", j.timestamp, j.id, err)
 		}
-
 		log.Error("hatchery %s cannot spawn worker %s for job %d: %v", h.Hatchery().Name, j.model.Name, j.id, errSpawn)
-		if j.model.NeedRegistration {
-			if err := h.CDSClient().WorkerModelSpawnError(j.model.ID, fmt.Sprintf("hatchery %s cannot spawn worker %s for job %d: %v", h.Hatchery().Name, j.model.Name, j.id, errSpawn)); err != nil {
-				log.Error("spawnWorkerForJob> error on call client.WorkerModelSpawnError on worker model %s for register: %s", j.model.Name, errSpawn)
-			}
-		}
 
 		return false, nil
 	}

--- a/sdk/hatchery/starter.go
+++ b/sdk/hatchery/starter.go
@@ -131,9 +131,14 @@ func spawnWorkerForJob(h Interface, j workerStarterRequest) (bool, error) {
 		if err := h.CDSClient().QueueJobSendSpawnInfo(j.isWorkflowJob, j.id, infos); err != nil {
 			log.Warning("spawnWorkerForJob> %d - cannot client.QueueJobSendSpawnInfo for job (err spawn)%d: %s", j.timestamp, j.id, err)
 		}
-		if err := h.CDSClient().WorkerModelSpawnError(j.model.ID, fmt.Sprintf("hatchery %s cannot spawn worker %s for job %d: %v", h.Hatchery().Name, j.model.Name, j.id, errSpawn)); err != nil {
-			log.Error("spawnWorkerForJob> error on call client.WorkerModelSpawnError on worker model %s for register: %s", j.model.Name, errSpawn)
+
+		log.Error("hatchery %s cannot spawn worker %s for job %d: %v", h.Hatchery().Name, j.model.Name, j.id, errSpawn)
+		if j.model.NeedRegistration {
+			if err := h.CDSClient().WorkerModelSpawnError(j.model.ID, fmt.Sprintf("hatchery %s cannot spawn worker %s for job %d: %v", h.Hatchery().Name, j.model.Name, j.id, errSpawn)); err != nil {
+				log.Error("spawnWorkerForJob> error on call client.WorkerModelSpawnError on worker model %s for register: %s", j.model.Name, errSpawn)
+			}
 		}
+
 		return false, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>

1. Description
For example, on a swarm hatchery when an user want to spawn a model with a lot of service and lack of resources on swarm. It should not return an error on worker model. Only return error on worker model when you try to register
1. Related issues
1. About tests
1. Mentions

@ovh/cds
