### PR TITLE
fix(api): reset git.hash for child pipeline if diff repo

### DIFF
--- a/engine/api/suggest.go
+++ b/engine/api/suggest.go
@@ -110,15 +110,11 @@ func (api *API) getVariablesHandler() service.Handler {
 		cdsVar := []string{
 			"{{.cds.version}}",
 			"{{.cds.application}}",
-			"{{.cds.buildNumber}}",
 			"{{.cds.environment}}",
 			"{{.cds.job}}",
 			"{{.cds.manual}}",
 			"{{.cds.node}}",
 			"{{.cds.node.id}}",
-			"{{.cds.parent.application}}",
-			"{{.cds.parent.buildNumber}}",
-			"{{.cds.parent.pipeline}}",
 			"{{.cds.pipeline}}",
 			"{{.cds.project}}",
 			"{{.cds.run}}",
@@ -143,6 +139,7 @@ func (api *API) getVariablesHandler() service.Handler {
 			"{{.git.repository}}",
 			"{{.git.url}}",
 			"{{.git.http_url}}",
+			"{{.git.server}}",
 		}
 		allVariables = append(allVariables, gitVar...)
 

--- a/engine/api/workflow/execute_node_run.go
+++ b/engine/api/workflow/execute_node_run.go
@@ -847,6 +847,7 @@ func getVCSInfos(ctx context.Context, db gorp.SqlExecutor, store cache.Store, vc
 			if !isChildNode {
 				return vcsInfos, sdk.NewError(sdk.ErrNotFound, fmt.Errorf("repository %s not found", vcsInfos.Repository))
 			}
+			vcsInfos.Hash = ""
 			vcsInfos.Repository = applicationRepositoryFullname
 		}
 	}


### PR DESCRIPTION
usecase:

a workflow, 1 pipeline, 2 nodes. pipeline doing checkoutApplication only. Node A: app A, Node B: appB. If we launch the workflow with git.hash = aa, git.hash is no more propagated on Node B with this fix. This will avoid a checkoutApplication on a non-existent hash. Bug introduced from https://github.com/ovh/cds/commit/906aac70466855788c0ee01aae5934f35061fd31 on action checkoutApplication