### PR TITLE
feat(api): avoid AL if it's not an AL on /mon/status

### DIFF
--- a/docs/content/hosting/monitoring.md
+++ b/docs/content/hosting/monitoring.md
@@ -25,6 +25,15 @@ Example:
 }
 ```
 
+If you don't need a CDS µService repositories, you can disable monitoring on it by setting `0` on configuration.
+
+```toml
+    [api.status.repositories]
+
+      # if less than minInstance of hooks repositories is running, an alert on Global/hooks will be created on /mon/status
+      minInstance = 0
+```
+
 ### Monitoring with Command Line
 
 ```bash

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -144,10 +144,33 @@ type Configuration struct {
 	Vault struct {
 		ConfigurationKey string `toml:"configurationKey"`
 	} `toml:"vault"`
-	Providers   []ProviderConfiguration `toml:"providers" comment:"###########################\n CDS Providers Settings \n##########################"`
-	Services    []ServiceConfiguration  `toml:"services" comment:"###########################\n CDS Providers Settings \n##########################"`
-	DefaultOS   string                  `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)"`
-	DefaultArch string                  `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)"`
+	Providers []ProviderConfiguration `toml:"providers" comment:"###########################\n CDS Providers Settings \n##########################"`
+	Services  []ServiceConfiguration  `toml:"services" comment:"###########################\n CDS Services Settings \n##########################"`
+	Status    struct {
+		API struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of API is running, an alert will on Global/API be created on /mon/status"`
+		} `toml:"api"`
+		DBMigrate struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of dbmigrate service is running, an alert on Global/dbmigrate will be created on /mon/status"`
+		} `toml:"dbmigrate"`
+		ElasticSearch struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of elasticsearch service is running, an alert on Global/elasticsearch will be created on /mon/status"`
+		} `toml:"elasticsearch"`
+		Hatchery struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of hatchery service is running, an alert on Global/hatchery will be created on /mon/status"`
+		} `toml:"hatchery"`
+		Hooks struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of hooks service is running, an alert on Global/hooks will be created on /mon/status"`
+		} `toml:"hooks"`
+		Repositories struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of hooks repositories is running, an alert on Global/hooks will be created on /mon/status"`
+		} `toml:"repositories"`
+		VCS struct {
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of vcs is running, an alert will on Global/vcs be created on /mon/status"`
+		} `toml:"vcs"`
+	} `toml:"status" comment:"###########################\n CDS Status Settings \n##########################"`
+	DefaultOS   string `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)"`
+	DefaultArch string `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)"`
 }
 
 // ProviderConfiguration is the piece of configuration for each provider authentication

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -168,7 +168,7 @@ type Configuration struct {
 		VCS struct {
 			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of vcs is running, an alert will on Global/vcs be created on /mon/status"`
 		} `toml:"vcs"`
-	} `toml:"status" comment:"###########################\n CDS Status Settings \n##########################"`
+	} `toml:"status" comment:"###########################\n CDS Status Settings \n Documentation: https://ovh.github.io/cds/hosting/monitoring/ \n##########################"`
 	DefaultOS   string `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)"`
 	DefaultArch string `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)"`
 }

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -163,10 +163,10 @@ type Configuration struct {
 			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of hooks service is running, an alert on Global/hooks will be created on /mon/status"`
 		} `toml:"hooks"`
 		Repositories struct {
-			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of hooks repositories is running, an alert on Global/hooks will be created on /mon/status"`
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of repositories service is running, an alert on Global/hooks will be created on /mon/status"`
 		} `toml:"repositories"`
 		VCS struct {
-			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of vcs is running, an alert will on Global/vcs be created on /mon/status"`
+			MinInstance int `toml:"minInstance" default:"1" comment:"if less than minInstance of vcs service is running, an alert will on Global/vcs be created on /mon/status"`
 		} `toml:"vcs"`
 	} `toml:"status" comment:"###########################\n CDS Status Settings \n Documentation: https://ovh.github.io/cds/hosting/monitoring/ \n##########################"`
 	DefaultOS   string `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)"`

--- a/engine/api/status.go
+++ b/engine/api/status.go
@@ -76,10 +76,11 @@ func (api *API) statusHandler() service.Handler {
 }
 
 type computeGlobalNumbers struct {
-	nbSrv    int
-	nbOK     int
-	nbAlerts int
-	nbWarn   int
+	nbSrv       int
+	nbOK        int
+	nbAlerts    int
+	nbWarn      int
+	minInstance int
 }
 
 func (api *API) computeGlobalStatus(srvs []sdk.Service) sdk.MonitoringStatus {
@@ -90,13 +91,13 @@ func (api *API) computeGlobalStatus(srvs []sdk.Service) sdk.MonitoringStatus {
 	linesGlobal := []sdk.MonitoringStatusLine{}
 
 	resume := map[string]computeGlobalNumbers{
-		services.TypeAPI:           {},
-		services.TypeRepositories:  {},
-		services.TypeVCS:           {},
-		services.TypeHooks:         {},
-		services.TypeHatchery:      {},
-		services.TypeDBMigrate:     {},
-		services.TypeElasticsearch: {},
+		services.TypeAPI:           {minInstance: api.Config.Status.API.MinInstance},
+		services.TypeRepositories:  {minInstance: api.Config.Status.Repositories.MinInstance},
+		services.TypeVCS:           {minInstance: api.Config.Status.VCS.MinInstance},
+		services.TypeHooks:         {minInstance: api.Config.Status.Hooks.MinInstance},
+		services.TypeHatchery:      {minInstance: api.Config.Status.Hatchery.MinInstance},
+		services.TypeDBMigrate:     {minInstance: api.Config.Status.DBMigrate.MinInstance},
+		services.TypeElasticsearch: {minInstance: api.Config.Status.ElasticSearch.MinInstance},
 	}
 	var nbg computeGlobalNumbers
 	for _, s := range srvs {
@@ -178,7 +179,7 @@ func (api *API) computeGlobalStatusByNumbers(s computeGlobalNumbers) string {
 		r = sdk.MonitoringStatusAlert
 	} else if s.nbWarn > 0 {
 		r = sdk.MonitoringStatusWarn
-	} else if s.nbSrv == 0 {
+	} else if s.nbSrv < s.minInstance {
 		r = sdk.MonitoringStatusAlert
 	}
 	return r


### PR DESCRIPTION
example (default min is 1 for everything):

```toml
  [api.status]

    [api.status.api]

      # if less than minInstance of API is running, an alert will on Global/API be created on /mon/status
      minInstance = 1

    [api.status.dbmigrate]

      # if less than minInstance of dbmigrate service is running, an alert on Global/dbmigrate will be created on /mon/status
      minInstance = 0

    [api.status.elasticsearch]

      # if less than minInstance of elasticsearch service is running, an alert on Global/elasticsearch will be created on /mon/status
      minInstance = 0

    [api.status.hatchery]

      # if less than minInstance of hatchery service is running, an alert on Global/hatchery will be created on /mon/status
      minInstance = 1

    [api.status.hooks]

      # if less than minInstance of hooks service is running, an alert on Global/hooks will be created on /mon/status
      minInstance = 1

    [api.status.repositories]

      # if less than minInstance of repositories service is running, an alert on Global/hooks will be created on /mon/status
      minInstance = 0

    [api.status.vcs]

      # if less than minInstance of vcs service is running, an alert will on Global/vcs be created on /mon/status
      minInstance = 1
```