### PR TITLE
chore(docker-compose): maxcontainers is too small

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,14 +78,16 @@ services:
     environment:
       CDS_HATCHERY_SWARM_COMMONCONFIGURATION_NAME: hatchery-swarm
       CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_TOKEN: changeitchangeitchangeitchangeitchangeitchangeitchangeitchangeit
+      # if you launch docker-compose on osx with socat, set 2376 insteand of 2375 below
       DOCKER_HOST: tcp://${HOSTNAME}:2375
+      # CDS_LOG_LEVEL: debug
       # DOCKER_HOST: unix://var/run/docker.sock
       # DOCKER_CERT_PATH: /Users/me/.docker/machines/.client
       # DOCKER_TLS_VERIFY: 1
       # CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_HTTP_URL will be use by hatchery to communicate with cds-api
       # and by container spawned by hatchery to download the binary worker from api.
       CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_HTTP_URL: http://${HOSTNAME}:8081
-      CDS_HATCHERY_SWARM_MAXCONTAINERS: 4
+      CDS_HATCHERY_SWARM_MAXCONTAINERS: 12
     links:
        - cds-api
     #volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       # CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_HTTP_URL will be use by hatchery to communicate with cds-api
       # and by container spawned by hatchery to download the binary worker from api.
       CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_HTTP_URL: http://${HOSTNAME}:8081
-      CDS_HATCHERY_SWARM_MAXCONTAINERS: 12
+      CDS_HATCHERY_SWARM_MAXCONTAINERS: 4
     #volumes:
        # Uncomment this to bind the docker socket
        # - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,6 @@ services:
       # and by container spawned by hatchery to download the binary worker from api.
       CDS_HATCHERY_SWARM_COMMONCONFIGURATION_API_HTTP_URL: http://${HOSTNAME}:8081
       CDS_HATCHERY_SWARM_MAXCONTAINERS: 12
-    links:
-       - cds-api
     #volumes:
        # Uncomment this to bind the docker socket
        # - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
CDS_HATCHERY_SWARM_MAXCONTAINERS = 4 -> the hatchery can't spawn workers
 (as max containers is reached with cds-ui, cds-cache, cds-api, cds-hatchery-swarm, cds-db...).

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>