### PR TITLE
feat(action/gitTag): advanced parameter bool vprefix

### DIFF
--- a/docs/content/workflows/pipelines/actions/builtin/gittag.md
+++ b/docs/content/workflows/pipelines/actions/builtin/gittag.md
@@ -18,6 +18,7 @@ This action creates a tag. You can use a pgp key to sign it.
 * tagMessage - optional - Message for the tag
 * path - optional - path to your git repository
 * signKey - optional - pgp key to sign the tag
+* Advanced parameter: vprefix - if checked, add 'v' prefix in tag created
 
 ## Example of usage
 

--- a/docs/content/workflows/pipelines/actions/builtin/gittag.md
+++ b/docs/content/workflows/pipelines/actions/builtin/gittag.md
@@ -18,7 +18,7 @@ This action creates a tag. You can use a pgp key to sign it.
 * tagMessage - optional - Message for the tag
 * path - optional - path to your git repository
 * signKey - optional - pgp key to sign the tag
-* Advanced parameter: vprefix - if checked, add 'v' prefix in tag created
+* Advanced parameter: prefix - add a prefix in tag name created
 
 ## Example of usage
 

--- a/engine/api/action/builtin.go
+++ b/engine/api/action/builtin.go
@@ -207,6 +207,13 @@ Semver used if fully compatible with https://semver.org/
 		Value:       "{{.cds.workspace}}",
 		Type:        sdk.StringParameter,
 	})
+	gittag.Parameter(sdk.Parameter{
+		Name:        "vprefix",
+		Description: "add ''v'' prefix in tag created",
+		Value:       "false",
+		Type:        sdk.BooleanParameter,
+		Advanced:    true,
+	})
 	gittag.Requirement("git", sdk.BinaryRequirement, "git")
 	gittag.Requirement("gpg", sdk.BinaryRequirement, "gpg")
 

--- a/engine/api/action/builtin.go
+++ b/engine/api/action/builtin.go
@@ -210,7 +210,7 @@ Semver used if fully compatible with https://semver.org/
 	gittag.Parameter(sdk.Parameter{
 		Name:        "prefix",
 		Description: "Prefix for tag name",
-		Value:       "false",
+		Value:       "",
 		Type:        sdk.StringParameter,
 		Advanced:    true,
 	})

--- a/engine/api/action/builtin.go
+++ b/engine/api/action/builtin.go
@@ -211,7 +211,7 @@ Semver used if fully compatible with https://semver.org/
 		Name:        "prefix",
 		Description: "Prefix for tag name",
 		Value:       "false",
-		Type:        sdk.BooleanParameter,
+		Type:        sdk.StringParameter,
 		Advanced:    true,
 	})
 	gittag.Requirement("git", sdk.BinaryRequirement, "git")

--- a/engine/api/action/builtin.go
+++ b/engine/api/action/builtin.go
@@ -208,8 +208,8 @@ Semver used if fully compatible with https://semver.org/
 		Type:        sdk.StringParameter,
 	})
 	gittag.Parameter(sdk.Parameter{
-		Name:        "vprefix",
-		Description: "add ''v'' prefix in tag created",
+		Name:        "prefix",
+		Description: "Prefix for tag name",
 		Value:       "false",
 		Type:        sdk.BooleanParameter,
 		Advanced:    true,

--- a/engine/sql/127_git_tag.sql
+++ b/engine/sql/127_git_tag.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+INSERT into action_parameter (action_id, name, description, type, value, advanced) values((select id from action where name = 'GitTag' and type = 'Builtin'), 'vprefix', 'add ''v'' prefix in tag created', 'boolean', 'false', true);
+
+-- +migrate Down
+
+DELETE from action_parameter where name = 'vprefix' and action_id = (select id from action where name = 'GitTag' and type = 'Builtin');
+

--- a/engine/sql/127_git_tag.sql
+++ b/engine/sql/127_git_tag.sql
@@ -1,8 +1,8 @@
 -- +migrate Up
 
-INSERT into action_parameter (action_id, name, description, type, value, advanced) values((select id from action where name = 'GitTag' and type = 'Builtin'), 'vprefix', 'add ''v'' prefix in tag created', 'boolean', 'false', true);
+INSERT into action_parameter (action_id, name, description, type, value, advanced) values((select id from action where name = 'GitTag' and type = 'Builtin'), 'prefix', 'Prefix for tag name', 'string', '', true);
 
 -- +migrate Down
 
-DELETE from action_parameter where name = 'vprefix' and action_id = (select id from action where name = 'GitTag' and type = 'Builtin');
+DELETE from action_parameter where name = 'prefix' and action_id = (select id from action where name = 'GitTag' and type = 'Builtin');
 

--- a/engine/worker/builtin_gitclone.go
+++ b/engine/worker/builtin_gitclone.go
@@ -287,7 +287,7 @@ func extractInfo(w *currentWorker, dir string, params *[]sdk.Parameter, tag, bra
 		}
 		sendLog(fmt.Sprintf("git.describe: %s", info.GitDescribe))
 
-		smver, errT := semver.Make(info.GitDescribe)
+		smver, errT := semver.ParseTolerant(info.GitDescribe)
 		if errT != nil {
 			sendLog(fmt.Sprintf("!! WARNING !! git describe %s is not semver compatible, we can't create cds.semver variable", info.GitDescribe))
 		} else {
@@ -318,6 +318,12 @@ func extractInfo(w *currentWorker, dir string, params *[]sdk.Parameter, tag, bra
 				cdsVersion.Value,
 			)
 		}
+
+		// if git.describe contains a prefix 'v', we keep it
+		if strings.HasPrefix(info.GitDescribe, "v") {
+			cdsSemver = fmt.Sprintf("v%s", cdsSemver)
+		}
+
 	} else {
 		// default value if there is no tag on repository
 		cdsSemver = fmt.Sprintf("0.0.1+cds.%s", cdsVersion.Value)

--- a/engine/worker/builtin_gittag.go
+++ b/engine/worker/builtin_gittag.go
@@ -22,7 +22,7 @@ func runGitTag(w *currentWorker) BuiltInAction {
 		tagLevel := sdk.ParameterFind(&a.Parameters, "tagLevel")
 		tagMessage := sdk.ParameterFind(&a.Parameters, "tagMessage")
 		path := sdk.ParameterFind(&a.Parameters, "path")
-		vprefix := sdk.ParameterFind(&a.Parameters, "vprefix")
+		prefix := sdk.ParameterFind(&a.Parameters, "prefix")
 
 		tagLevelValid := true
 		if tagLevel == nil || tagLevel.Value == "" {
@@ -143,8 +143,8 @@ func runGitTag(w *currentWorker) BuiltInAction {
 			Username: userTag,
 		}
 
-		if vprefix != nil && vprefix.Value == "true" {
-			tagOpts.Name = fmt.Sprintf("v%s", tagOpts.Name)
+		if prefix != nil && prefix.Value != "" {
+			tagOpts.Name = fmt.Sprintf("%s%s", prefix, tagOpts.Name)
 		}
 
 		if auth.SignKey.ID != "" {

--- a/engine/worker/builtin_gittag.go
+++ b/engine/worker/builtin_gittag.go
@@ -144,7 +144,7 @@ func runGitTag(w *currentWorker) BuiltInAction {
 		}
 
 		if prefix != nil && prefix.Value != "" {
-			tagOpts.Name = fmt.Sprintf("%s%s", prefix, tagOpts.Name)
+			tagOpts.Name = fmt.Sprintf("%s%s", prefix.Value, tagOpts.Name)
 		}
 
 		if auth.SignKey.ID != "" {

--- a/engine/worker/builtin_gittag.go
+++ b/engine/worker/builtin_gittag.go
@@ -22,6 +22,7 @@ func runGitTag(w *currentWorker) BuiltInAction {
 		tagLevel := sdk.ParameterFind(&a.Parameters, "tagLevel")
 		tagMessage := sdk.ParameterFind(&a.Parameters, "tagMessage")
 		path := sdk.ParameterFind(&a.Parameters, "path")
+		vprefix := sdk.ParameterFind(&a.Parameters, "vprefix")
 
 		tagLevelValid := true
 		if tagLevel == nil || tagLevel.Value == "" {
@@ -64,7 +65,7 @@ func runGitTag(w *currentWorker) BuiltInAction {
 			return res
 		}
 
-		smver, errT := semver.Make(cdsSemver.Value)
+		smver, errT := semver.ParseTolerant(cdsSemver.Value)
 		if errT != nil {
 			res := sdk.Result{
 				Status: sdk.StatusFail.String(),
@@ -140,6 +141,10 @@ func runGitTag(w *currentWorker) BuiltInAction {
 			Message:  msg,
 			Name:     smver.String(),
 			Username: userTag,
+		}
+
+		if vprefix != nil && vprefix.Value == "true" {
+			tagOpts.Name = fmt.Sprintf("v%s", tagOpts.Name)
 		}
 
 		if auth.SignKey.ID != "" {

--- a/sdk/exportentities/action.go
+++ b/sdk/exportentities/action.go
@@ -189,9 +189,9 @@ func newSteps(a sdk.Action) []Step {
 				if tagPrerelease != nil && tagPrerelease.Value != "" {
 					gitTagArgs["tagPrerelease"] = tagPrerelease.Value
 				}
-				vprefix := sdk.ParameterFind(&act.Parameters, "vprefix")
-				if vprefix != nil && vprefix.Value == "true" {
-					gitTagArgs["vprefix"] = vprefix.Value
+				prefix := sdk.ParameterFind(&act.Parameters, "prefix")
+				if prefix != nil && prefix.Value != "" {
+					gitTagArgs["prefix"] = prefix.Value
 				}
 				s["gitTag"] = gitTagArgs
 			case sdk.ReleaseAction:

--- a/sdk/exportentities/action.go
+++ b/sdk/exportentities/action.go
@@ -189,6 +189,10 @@ func newSteps(a sdk.Action) []Step {
 				if tagPrerelease != nil && tagPrerelease.Value != "" {
 					gitTagArgs["tagPrerelease"] = tagPrerelease.Value
 				}
+				vprefix := sdk.ParameterFind(&act.Parameters, "vprefix")
+				if vprefix != nil && vprefix.Value == "true" {
+					gitTagArgs["vprefix"] = vprefix.Value
+				}
 				s["gitTag"] = gitTagArgs
 			case sdk.ReleaseAction:
 				releaseArgs := map[string]string{}
@@ -635,9 +639,8 @@ func (s Step) Name() (string, error) {
 	if stepAttr, ok := s["name"]; ok {
 		if stepName, okName := stepAttr.(string); okName {
 			return stepName, nil
-		} else {
-			return "", fmt.Errorf("Malformatted Step : name must be a string")
 		}
+		return "", fmt.Errorf("Malformatted Step : name must be a string")
 	}
 	return "", nil
 }


### PR DESCRIPTION
if git.describe return a tag with a 'v', keep it to compute cds.semver

New advanced parameter on gitTag action, prefix 'v' is disabled by default
If false, this field is not exported

This will be usefull for go 1.11 and allow using the default value
of tag-version-prefix for node users:
https://docs.npmjs.com/misc/config#tag-version-prefix

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>
