### PR TITLE
Generate call stack for sdk error and preserve stack trace

### DIFF
--- a/cli/cdsctl/admin.go
+++ b/cli/cdsctl/admin.go
@@ -22,6 +22,7 @@ func admin() *cobra.Command {
 				adminPlatformModels,
 				adminPlugins,
 				adminBroadcasts,
+				adminErrors,
 				usr,
 				group,
 				worker,
@@ -36,5 +37,6 @@ func admin() *cobra.Command {
 			adminPlugins,
 			adminPluginsAction,
 			adminBroadcasts,
+			adminErrors,
 		})
 }

--- a/cli/cdsctl/admin_errors.go
+++ b/cli/cdsctl/admin_errors.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ovh/cds/cli"
+	"github.com/spf13/cobra"
+)
+
+var (
+	adminErrorsCmd = cli.Command{
+		Name:  "errors",
+		Short: "Manage CDS errors",
+	}
+
+	adminErrors = cli.NewCommand(adminErrorsCmd, nil,
+		[]*cobra.Command{
+			cli.NewCommand(adminErrorsGetCmd, adminErrorsGetFunc, nil),
+		})
+)
+
+var adminErrorsGetCmd = cli.Command{
+	Name:  "get",
+	Short: "Get CDS error",
+	Args: []cli.Arg{
+		{Name: "uuid"},
+	},
+}
+
+func adminErrorsGetFunc(v cli.Values) error {
+	res, err := client.MonErrorsGet(v.GetString("uuid"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Message: %s\n", res.Message)
+	if res.StackTrace != "" {
+		fmt.Printf("Stack trace:\n%s", res.StackTrace)
+	}
+
+	return nil
+}

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fsamin/go-dump"
 	"github.com/olekukonko/tablewriter"
+	"github.com/ovh/cds/sdk"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -27,18 +28,23 @@ func ExitOnError(err error, helpFunc ...func() error) {
 		return
 	}
 
-	if e, ok := err.(*Error); ok {
+	var code int
+
+	switch e := err.(type) {
+	case sdk.Error:
+		fmt.Printf("Error(%s): %s\n", e.UUID, e.Message)
+	case *Error:
+		code = e.Code
 		fmt.Println("Error:", e.Error())
-		for _, f := range helpFunc {
-			f()
-		}
-		OSExit(e.Code)
+	default:
+		fmt.Println("Error:", err.Error())
 	}
-	fmt.Println("Error:", err.Error())
+
 	for _, f := range helpFunc {
 		f()
 	}
-	OSExit(50)
+
+	OSExit(code)
 }
 
 // OSExit will os.Exit if ShellMode is false, display only exit code if true

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -14,9 +14,10 @@ import (
 
 	"github.com/fsamin/go-dump"
 	"github.com/olekukonko/tablewriter"
-	"github.com/ovh/cds/sdk"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+
+	"github.com/ovh/cds/sdk"
 )
 
 // ShellMode will os.Exit if false, display only exit code if true

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -28,7 +28,7 @@ func ExitOnError(err error, helpFunc ...func() error) {
 		return
 	}
 
-	var code int
+	code := 50 // default error code
 
 	switch e := err.(type) {
 	case sdk.Error:

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -171,7 +171,7 @@ type Configuration struct {
 	DefaultOS   string `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)" json:"defaultOS"`
 	DefaultArch string `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)" json:"defaultArch"`
 	Graylog     struct {
-		AccessToken string `toml:"accessToken" json:"accessToken"`
+		AccessToken string `toml:"accessToken" json:"-"`
 		URL         string `toml:"url" comment:"Example: http://localhost:9000" json:"url"`
 	} `toml:"graylog"  json:"graylog"`
 }

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -170,6 +170,10 @@ type Configuration struct {
 	} `toml:"status" comment:"###########################\n CDS Status Settings \n Documentation: https://ovh.github.io/cds/hosting/monitoring/ \n##########################" json:"status"`
 	DefaultOS   string `toml:"defaultOS" default:"linux" comment:"if no model and os/arch is specified in your job's requirements then spawn worker on this operating system (example: freebsd, linux, windows)" json:"defaultOS"`
 	DefaultArch string `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)" json:"defaultArch"`
+	Graylog     struct {
+		AccessToken string `toml:"accessToken" json:"accessToken"`
+		URL         string `toml:"url" comment:"Example: http://localhost:9000" json:"url"`
+	} `toml:"graylog"  json:"graylog"`
 }
 
 // ProviderConfiguration is the piece of configuration for each provider authentication

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -101,6 +101,7 @@ func (api *API) InitRouter() {
 	r.Handle("/mon/building/{hash}", r.GET(api.getPipelineBuildingCommitHandler))
 	r.Handle("/mon/metrics", r.GET(api.getMetricsHandler, Auth(false)))
 	r.Handle("/mon/stats", r.GET(observability.StatsHandler, Auth(false)))
+	r.Handle("/mon/error", r.GET(api.getErrorHandler, NeedAdmin(true)))
 
 	r.Handle("/ui/navbar", r.GET(api.getNavbarHandler))
 	r.Handle("/ui/project/{key}/application/{permApplicationName}/overview", r.GET(api.getApplicationOverviewHandler))

--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -101,7 +101,7 @@ func (api *API) InitRouter() {
 	r.Handle("/mon/building/{hash}", r.GET(api.getPipelineBuildingCommitHandler))
 	r.Handle("/mon/metrics", r.GET(api.getMetricsHandler, Auth(false)))
 	r.Handle("/mon/stats", r.GET(observability.StatsHandler, Auth(false)))
-	r.Handle("/mon/error", r.GET(api.getErrorHandler, NeedAdmin(true)))
+	r.Handle("/mon/errors/{uuid}", r.GET(api.getErrorHandler, NeedAdmin(true)))
 
 	r.Handle("/ui/navbar", r.GET(api.getNavbarHandler))
 	r.Handle("/ui/project/{key}/application/{permApplicationName}/overview", r.GET(api.getApplicationOverviewHandler))

--- a/engine/api/application_import.go
+++ b/engine/api/application_import.go
@@ -71,9 +71,9 @@ func (api *API) postApplicationImportHandler() service.Handler {
 			myError, ok := globalError.(sdk.Error)
 			if ok {
 				log.Warning("postApplicationImportHandler> Unable to import application %s : %v", eapp.Name, myError)
-				msgTranslated, _ := sdk.ProcessError(myError, r.Header.Get("Accept-Language"))
-				msgListString = append(msgListString, msgTranslated)
-				return service.WriteJSON(w, msgListString, myError.Status)
+				sdkErr := sdk.ExtractHTTPError(myError, r.Header.Get("Accept-Language"))
+				msgListString = append(msgListString, sdkErr.Message)
+				return service.WriteJSON(w, msgListString, sdkErr.Status)
 			}
 			return sdk.WrapError(globalError, "postApplicationImportHandler> Unable import application %s", eapp.Name)
 		}

--- a/engine/api/ascode_test.go
+++ b/engine/api/ascode_test.go
@@ -37,10 +37,9 @@ func writeError(w *http.Response, err error) (*http.Response, error) {
 	body := new(bytes.Buffer)
 	enc := json.NewEncoder(body)
 	w.Body = ioutil.NopCloser(body)
-	msg, errProcessed := sdk.ProcessError(err, "")
-	sdkErr := sdk.Error{Message: msg}
+	sdkErr := sdk.ExtractHTTPError(err, "")
 	enc.Encode(sdkErr)
-	w.StatusCode = errProcessed.Status
+	w.StatusCode = sdkErr.Status
 	return w, sdkErr
 }
 

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -1,1 +1,74 @@
 package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ovh/cds/sdk"
+
+	"github.com/ovh/cds/engine/service"
+)
+
+type graylogResponse struct {
+	TotalResult int `json:"total_results"`
+	Messages    []struct {
+		Message map[string]interface{} `json:"message"`
+	} `json:"messages"`
+}
+
+func (api *API) getErrorHandler() service.Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		errorUUID := FormString(r, "errorUUID")
+
+		if api.Config.Graylog.URL == "" || api.Config.Graylog.AccessToken == "" {
+			return sdk.ErrNotImplemented
+		}
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/search/universal/absolute", api.Config.Graylog.URL), nil)
+		if err != nil {
+			return sdk.WrapError(err, "invalid given Graylog url")
+		}
+
+		q := req.URL.Query()
+		q.Add("query", fmt.Sprintf("error_uuid:%s", errorUUID))
+		q.Add("from", "1970-01-01 00:00:00.000")
+		q.Add("to", time.Now().Format("2006-01-02 15:04:05"))
+		q.Add("limit", "1")
+		req.URL.RawQuery = q.Encode()
+
+		req.SetBasicAuth(api.Config.Graylog.AccessToken, "token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return sdk.WrapError(err, "cannot send query to Graylog")
+		}
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return sdk.WrapError(err, "cannot read response from Graylog")
+		}
+
+		var res graylogResponse
+		if err := json.Unmarshal(body, &res); err != nil {
+			return sdk.WrapError(err, "cannot unmarshal response from Graylog")
+		}
+
+		if res.TotalResult < 1 {
+			return sdk.ErrNotFound
+		}
+
+		e := sdk.Error{
+			UUID:    res.Messages[0].Message["error_uuid"].(string),
+			Message: res.Messages[0].Message["message"].(string),
+		}
+		if st, ok := res.Messages[0].Message["stack_trace"]; ok {
+			e.StackTrace = st.(string)
+		}
+
+		return service.WriteJSON(w, e, http.StatusOK)
+	}
+}

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/ovh/cds/sdk"
 
 	"github.com/ovh/cds/engine/service"
@@ -22,7 +23,8 @@ type graylogResponse struct {
 
 func (api *API) getErrorHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		errorUUID := FormString(r, "errorUUID")
+		vars := mux.Vars(r)
+		uuid := vars["uuid"]
 
 		if api.Config.Graylog.URL == "" || api.Config.Graylog.AccessToken == "" {
 			return sdk.ErrNotImplemented
@@ -34,7 +36,7 @@ func (api *API) getErrorHandler() service.Handler {
 		}
 
 		q := req.URL.Query()
-		q.Add("query", fmt.Sprintf("error_uuid:%s", errorUUID))
+		q.Add("query", fmt.Sprintf("error_uuid:%s", uuid))
 		q.Add("from", "1970-01-01 00:00:00.000")
 		q.Add("to", time.Now().Format("2006-01-02 15:04:05"))
 		q.Add("limit", "1")

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/ovh/cds/sdk"
 
+	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/engine/service"
 )
 

--- a/engine/api/services/dao.go
+++ b/engine/api/services/dao.go
@@ -69,7 +69,7 @@ func All(db gorp.SqlExecutor) ([]sdk.Service, error) {
 		if err == sdk.ErrNotFound {
 			return nil, nil
 		}
-		return nil, sdk.WrapError(err, "All> Unable to find all services")
+		return nil, sdk.WrapError(err, "Unable to find all services")
 	}
 	return services, nil
 }
@@ -95,13 +95,13 @@ func findAll(db gorp.SqlExecutor, query string, args ...interface{}) ([]sdk.Serv
 		if err == sql.ErrNoRows {
 			return nil, sdk.ErrNotFound
 		}
-		return nil, sdk.WrapError(err, "findAll> no service found")
+		return nil, sdk.WithStack(err)
 	}
 	ss := make([]sdk.Service, len(sdbs))
 	for i := 0; i < len(sdbs); i++ {
 		s := &sdbs[i]
 		if err := s.PostGet(db); err != nil {
-			return nil, sdk.WrapError(err, "findAll> postGet on srv id:%d name:%s type:%s lastHeartbeat:%v", s.ID, s.Name, s.Type, s.LastHeartbeat)
+			return nil, sdk.WrapError(err, "postGet on srv id:%d name:%s type:%s lastHeartbeat:%v", s.ID, s.Name, s.Type, s.LastHeartbeat)
 		}
 		ss[i] = sdk.Service(sdbs[i])
 	}

--- a/engine/api/status.go
+++ b/engine/api/status.go
@@ -61,7 +61,7 @@ func (api *API) statusHandler() service.Handler {
 
 		srvs, err := services.All(api.mustDB())
 		if err != nil {
-			return sdk.WrapError(err, "statusHandler> error on q.All()")
+			return err
 		}
 
 		mStatus := api.computeGlobalStatus(srvs)

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -1043,8 +1043,7 @@ func Push(ctx context.Context, db *gorp.DbMap, store cache.Store, proj *sdk.Proj
 	wf, msgList, err := ParseAndImport(ctx, tx, store, proj, &wrkflw, u, ImportOptions{DryRun: dryRun, Force: true})
 	if err != nil {
 		log.Error("Push> Unable to import workflow: %v", err)
-		err = sdk.SetError(err, "unable to import workflow %s", wrkflw.Name)
-		return nil, nil, sdk.WrapError(err, "Push> %v ", err)
+		return nil, nil, sdk.WrapError(err, "Push> unable to import workflow %s", wrkflw.Name)
 	}
 
 	// TODO workflow as code, manage derivation workflow

--- a/engine/service/http.go
+++ b/engine/service/http.go
@@ -92,15 +92,14 @@ func WriteProcessTime(w http.ResponseWriter) {
 func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	al := r.Header.Get("Accept-Language")
 	httpErr := sdk.ExtractHTTPError(err, al)
+	httpErr.UUID = uuid.NewUUID().String()
 	isErrWithStack := sdk.IsErrorWithStack(err)
 
 	entry := logrus.WithField("method", r.Method).
 		WithField("request_uri", r.RequestURI).
 		WithField("status", httpErr.Status).
-		WithField("message", httpErr.Message)
+		WithField("error_uuid", httpErr.UUID)
 	if isErrWithStack {
-		httpErr.UUID = uuid.NewUUID().String()
-		entry = entry.WithField("error_uuid", httpErr.UUID)
 		entry = entry.WithField("stack_trace", fmt.Sprintf("%+v", err))
 	}
 
@@ -114,5 +113,5 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 
 	// safely ignore error returned by WriteJSON
-	WriteJSON(w, httpErr, httpErr.Status)
+	_ = WriteJSON(w, httpErr, httpErr.Status)
 }

--- a/engine/worker/cmd_cache.go
+++ b/engine/worker/cmd_cache.go
@@ -378,22 +378,22 @@ func (wk *currentWorker) cachePullHandler(w http.ResponseWriter, r *http.Request
 		case tar.TypeReg, tar.TypeLink:
 			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
-				err = sdk.Error{
+				sdkErr := sdk.Error{
 					Message: "worker cache pull > Unable to open file : " + err.Error(),
 					Status:  http.StatusInternalServerError,
 				}
-				writeJSON(w, err, err.Status)
+				writeJSON(w, sdkErr, sdkErr.Status)
 				return
 			}
 
 			// copy over contents
 			if _, err := io.Copy(f, tr); err != nil {
 				_ = f.Close()
-				err = sdk.Error{
+				sdkErr := sdk.Error{
 					Message: "worker cache pull > Cannot copy content file : " + err.Error(),
 					Status:  http.StatusInternalServerError,
 				}
-				writeJSON(w, err, err.Status)
+				writeJSON(w, sdkErr, sdkErr.Status)
 				return
 			}
 

--- a/engine/worker/cmd_cache.go
+++ b/engine/worker/cmd_cache.go
@@ -382,7 +382,7 @@ func (wk *currentWorker) cachePullHandler(w http.ResponseWriter, r *http.Request
 					Message: "worker cache pull > Unable to open file : " + err.Error(),
 					Status:  http.StatusInternalServerError,
 				}
-				writeJSON(w, err, http.StatusInternalServerError)
+				writeJSON(w, err, err.Status)
 				return
 			}
 
@@ -393,7 +393,7 @@ func (wk *currentWorker) cachePullHandler(w http.ResponseWriter, r *http.Request
 					Message: "worker cache pull > Cannot copy content file : " + err.Error(),
 					Status:  http.StatusInternalServerError,
 				}
-				writeJSON(w, err, http.StatusInternalServerError)
+				writeJSON(w, err, err.Status)
 				return
 			}
 

--- a/engine/worker/cmd_server.go
+++ b/engine/worker/cmd_server.go
@@ -86,7 +86,6 @@ func writeJSON(w http.ResponseWriter, data interface{}, status int) {
 
 func writeError(w http.ResponseWriter, r *http.Request, err error) {
 	al := r.Header.Get("Accept-Language")
-	msg, sdkError := sdk.ProcessError(err, al)
-	sdkErr := sdk.Error{Message: msg}
+	sdkErr := sdk.ExtractHTTPError(err, al)
 	writeJSON(w, sdkErr, sdkError.Status)
 }

--- a/engine/worker/cmd_server.go
+++ b/engine/worker/cmd_server.go
@@ -87,5 +87,5 @@ func writeJSON(w http.ResponseWriter, data interface{}, status int) {
 func writeError(w http.ResponseWriter, r *http.Request, err error) {
 	al := r.Header.Get("Accept-Language")
 	sdkErr := sdk.ExtractHTTPError(err, al)
-	writeJSON(w, sdkErr, sdkError.Status)
+	writeJSON(w, sdkErr, sdkErr.Status)
 }

--- a/sdk/cdsclient/client_mon.go
+++ b/sdk/cdsclient/client_mon.go
@@ -1,6 +1,9 @@
 package cdsclient
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/ovh/cds/sdk"
 )
 
@@ -26,4 +29,18 @@ func (c *client) MonDBMigrate() ([]sdk.MonDBMigrate, error) {
 		return nil, err
 	}
 	return monDBMigrate, nil
+}
+
+func (c *client) MonErrorsGet(uuid string) (*sdk.Error, error) {
+	res, _, _, err := c.Request("GET", fmt.Sprintf("/mon/errors/%s", uuid), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdkError sdk.Error
+	if err := json.Unmarshal(res, &sdkError); err != nil {
+		return nil, err
+	}
+
+	return &sdkError, nil
 }

--- a/sdk/cdsclient/http.go
+++ b/sdk/cdsclient/http.go
@@ -111,15 +111,19 @@ func (c *client) RequestJSON(method, path string, in interface{}, out interface{
 		return nil, nil, code, err
 	}
 
+	if code >= 400 {
+		if err := sdk.DecodeError(res); err != nil {
+			return res, nil, code, err
+		}
+		return res, nil, code, fmt.Errorf("HTTP %d", code)
+	}
+
 	if out != nil {
 		if err := json.Unmarshal(res, out); err != nil {
 			return res, nil, code, err
 		}
 	}
 
-	if code >= 400 {
-		return res, nil, code, fmt.Errorf("HTTP %d", code)
-	}
 	return res, header, code, nil
 }
 
@@ -149,8 +153,9 @@ func (c *client) Request(method string, path string, body io.Reader, mods ...Req
 
 	if code >= 400 {
 		if err := sdk.DecodeError(bodyBtes); err != nil {
-			return nil, nil, code, err
+			return bodyBtes, nil, code, err
 		}
+		return bodyBtes, nil, code, fmt.Errorf("HTTP %d", code)
 	}
 
 	return bodyBtes, respHeader, code, nil

--- a/sdk/cdsclient/http.go
+++ b/sdk/cdsclient/http.go
@@ -147,8 +147,10 @@ func (c *client) Request(method string, path string, body io.Reader, mods ...Req
 		}
 	}
 
-	if err := sdk.DecodeError(bodyBtes); err != nil {
-		return nil, nil, code, err
+	if code >= 400 {
+		if err := sdk.DecodeError(bodyBtes); err != nil {
+			return nil, nil, code, err
+		}
 	}
 
 	return bodyBtes, respHeader, code, nil

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -278,6 +278,7 @@ type MonitoringClient interface {
 	MonStatus() (*sdk.MonitoringStatus, error)
 	MonVersion() (*sdk.Version, error)
 	MonDBMigrate() ([]sdk.MonDBMigrate, error)
+	MonErrorsGet(uuid string) (*sdk.Error, error)
 }
 
 // PlatformClient exposes platform functions

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -566,6 +566,15 @@ func WrapError(err error, format string, args ...interface{}) error {
 		return e
 	}
 
+	// if it's a Error wrap it in error with stack
+	if e, ok := err.(Error); ok {
+		return errorWithStack{
+			root:      errors.Wrap(err, m),
+			stack:     callers(),
+			httpError: e,
+		}
+	}
+
 	return errorWithStack{
 		root:      errors.Wrap(err, m),
 		stack:     callers(),
@@ -583,6 +592,15 @@ func WithStack(err error) error {
 	// if it's already a CDS error do not override the stack
 	if e, ok := err.(errorWithStack); ok {
 		return e
+	}
+
+	// if it's a Error wrap it in error with stack
+	if e, ok := err.(Error); ok {
+		return errorWithStack{
+			root:      errors.WithStack(err),
+			stack:     callers(),
+			httpError: e,
+		}
 	}
 
 	return errorWithStack{

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -458,10 +458,11 @@ var errorsLanguages = []map[int]string{
 
 // Error type.
 type Error struct {
-	ID      int    `json:"-"`
-	Status  int    `json:"-"`
-	Message string `json:"message"`
-	UUID    string `json:"uuid,omitempty"`
+	ID         int    `json:"-"`
+	Status     int    `json:"-"`
+	Message    string `json:"message"`
+	UUID       string `json:"uuid,omitempty"`
+	StackTrace string `json:"stack_trace,omitempty"`
 }
 
 type errorWithStack struct {
@@ -482,7 +483,7 @@ func (w errorWithStack) Format(s fmt.State, verb rune) {
 		}
 		fallthrough
 	case 's':
-		io.WriteString(s, fmt.Sprintf("%s: %s", w.stack.String(), w.Cause().Error()))
+		_, _ = io.WriteString(s, fmt.Sprintf("%s: %s", w.stack.String(), w.Cause().Error()))
 	}
 }
 

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -471,8 +471,10 @@ type errorWithStack struct {
 	httpError Error
 }
 
-func (w errorWithStack) Error() string { return w.stack.String() + ": " + w.root.Error() }
-func (w errorWithStack) Cause() error  { return w.root }
+func (w errorWithStack) Error() string {
+	return fmt.Sprintf("%s: %s (caused by: %s)", w.stack.String(), w.httpError, w.root)
+}
+func (w errorWithStack) Cause() error { return w.root }
 
 func (w errorWithStack) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -483,7 +485,7 @@ func (w errorWithStack) Format(s fmt.State, verb rune) {
 		}
 		fallthrough
 	case 's':
-		_, _ = io.WriteString(s, fmt.Sprintf("%s: %s", w.stack.String(), w.Cause().Error()))
+		_, _ = io.WriteString(s, w.Error())
 	}
 }
 

--- a/sdk/error.go
+++ b/sdk/error.go
@@ -458,7 +458,7 @@ var errorsLanguages = []map[int]string{
 
 // Error type.
 type Error struct {
-	ID         int    `json:"-"`
+	ID         int    `json:"id"`
 	Status     int    `json:"-"`
 	Message    string `json:"message"`
 	UUID       string `json:"uuid,omitempty"`

--- a/sdk/error_test.go
+++ b/sdk/error_test.go
@@ -40,3 +40,29 @@ func TestErrorIs(t *testing.T) {
 		})
 	}
 }
+
+func TestNewError(t *testing.T) {
+	err := fmt.Errorf("this is an error generated from vendor")
+	cdsErr := NewError(ErrWrongRequest, err)
+	// print the CDS error line
+	fmt.Printf("%s\n", cdsErr)
+	// print the root error message and stack trace
+	fmt.Printf("%+v\n", cdsErr.(Error).Root)
+}
+
+func TestWrapError(t *testing.T) {
+	err := oneForStackTest()
+	// print the CDS error line
+	fmt.Printf("%s\n", err)
+	// print the root error message and stack trace
+	fmt.Printf("%+v\n", err.(Error).Root)
+}
+
+func oneForStackTest() error   { return twoForStackTest() }
+func twoForStackTest() error   { return threeForStackTest() }
+func threeForStackTest() error { return fourForStackTest() }
+func fourForStackTest() error  { return fiveForStackTest() }
+func fiveForStackTest() error {
+	err := fmt.Errorf("this is an error generated from vendor")
+	return WrapError(err, "cds custom message %d", 50)
+}

--- a/sdk/error_test.go
+++ b/sdk/error_test.go
@@ -42,27 +42,29 @@ func TestErrorIs(t *testing.T) {
 }
 
 func TestNewError(t *testing.T) {
-	err := fmt.Errorf("this is an error generated from vendor")
-	cdsErr := NewError(ErrWrongRequest, err)
-	// print the CDS error line
-	fmt.Printf("%s\n", cdsErr)
-	// print the root error message and stack trace
-	fmt.Printf("%+v\n", cdsErr.(Error).Root)
+	err := NewError(ErrWrongRequest, fmt.Errorf("this is an error generated from vendor"))
+	// print the error call stack
+	fmt.Println(err)
+	// print the error stack trace
+	fmt.Printf("%+v\n", err)
+
+	httpErr := ExtractHTTPError(err, "fr")
+	// print the http error
+	fmt.Println(httpErr)
 }
 
 func TestWrapError(t *testing.T) {
 	err := oneForStackTest()
-	// print the CDS error line
-	fmt.Printf("%s\n", err)
-	// print the root error message and stack trace
-	fmt.Printf("%+v\n", err.(Error).Root)
+	// print the error call stack
+	fmt.Println(err)
+	// print the error stack trace
+	fmt.Printf("%+v\n", err)
 }
 
-func oneForStackTest() error   { return twoForStackTest() }
-func twoForStackTest() error   { return threeForStackTest() }
-func threeForStackTest() error { return fourForStackTest() }
-func fourForStackTest() error  { return fiveForStackTest() }
+func oneForStackTest() error   { return WrapError(twoForStackTest(), "one") }
+func twoForStackTest() error   { return WrapError(threeForStackTest(), "two") }
+func threeForStackTest() error { return WrapError(fourForStackTest(), "three") }
+func fourForStackTest() error  { return WrapError(fiveForStackTest(), "four") }
 func fiveForStackTest() error {
-	err := fmt.Errorf("this is an error generated from vendor")
-	return WrapError(err, "cds custom message %d", 50)
+	return WrapError(fmt.Errorf("this is an error generated from vendor"), "five")
 }

--- a/sdk/error_test.go
+++ b/sdk/error_test.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestErrorIs(t *testing.T) {
@@ -16,17 +18,25 @@ func TestErrorIs(t *testing.T) {
 		want bool
 	}{
 		{
-			"Check Error is true",
+			"Check for wrapped Error is true",
 			args{
-				err: fmt.Errorf(ErrNoProject.String()),
+				err: WithStack(ErrNoProject),
 				t:   ErrNoProject,
 			},
 			true,
 		},
 		{
-			"Check Error is false",
+			"Check for Error is true",
 			args{
-				err: fmt.Errorf("FOO"),
+				err: ErrNoProject,
+				t:   ErrNoProject,
+			},
+			true,
+		},
+		{
+			"Check for other error is false",
+			args{
+				err: fmt.Errorf("project does not exist"),
 				t:   ErrNoProject,
 			},
 			false,
@@ -43,18 +53,25 @@ func TestErrorIs(t *testing.T) {
 
 func TestNewError(t *testing.T) {
 	err := NewError(ErrWrongRequest, fmt.Errorf("this is an error generated from vendor"))
+	assert.Equal(t, "TestNewError: wrong request (caused by: this is an error generated from vendor)", err.Error())
+
 	// print the error call stack
 	fmt.Println(err)
 	// print the error stack trace
 	fmt.Printf("%+v\n", err)
 
 	httpErr := ExtractHTTPError(err, "fr")
+
 	// print the http error
 	fmt.Println(httpErr)
+
+	assert.Equal(t, "la requête est incorrecte", httpErr.Error())
 }
 
 func TestWrapError(t *testing.T) {
 	err := oneForStackTest()
+	assert.Equal(t, "TestWrapError>oneForStackTest>twoForStackTest>threeForStackTest>fourForStackTest>fiveForStackTest: internal server error (caused by: one: two: three: four: five: this is an error generated from vendor)", err.Error())
+
 	// print the error call stack
 	fmt.Println(err)
 	// print the error stack trace

--- a/sdk/log/log.go
+++ b/sdk/log/log.go
@@ -122,50 +122,45 @@ func Initialize(conf *Conf) {
 
 // Debug prints debug log
 func Debug(format string, values ...interface{}) {
-	input := strings.Replace(fmt.Sprintf(format, values...), "\\n", " ", -1)
 	if logger != nil {
-		logger.Logf("[DEBUG]    " + input)
+		logger.Logf("[DEBUG]    "+format, values...)
 	} else {
-		log.Debugf(input)
+		log.Debugf(format, values...)
 	}
 }
 
 // Info prints information log
 func Info(format string, values ...interface{}) {
-	input := strings.Replace(fmt.Sprintf(format, values...), "\\n", " ", -1)
 	if logger != nil {
-		logger.Logf("[INFO]    " + input)
+		logger.Logf("[INFO]    "+format, values...)
 	} else {
-		log.Infof(input)
+		log.Infof(format, values...)
 	}
 }
 
 // Warning prints warnings for user
 func Warning(format string, values ...interface{}) {
-	input := strings.Replace(fmt.Sprintf(format, values...), "\\n", " ", -1)
 	if logger != nil {
-		logger.Logf("[WARN]    " + input)
+		logger.Logf("[WARN]    "+format, values...)
 	} else {
-		log.Warnf(input)
+		log.Warnf(format, values...)
 	}
 }
 
 // Error prints error informations
 func Error(format string, values ...interface{}) {
-	input := strings.Replace(fmt.Sprintf(format, values...), "\\n", " ", -1)
 	if logger != nil {
-		logger.Logf("[ERROR]    " + input)
+		logger.Logf("[ERROR]    "+format, values...)
 	} else {
-		log.Errorf(input)
+		log.Errorf(format, values...)
 	}
 }
 
 // Fatalf prints fatal informations, then os.Exit(1)
 func Fatalf(format string, values ...interface{}) {
-	input := strings.Replace(fmt.Sprintf(format, values...), "\\n", " ", -1)
 	if logger != nil {
-		logger.Logf("[FATAL]    " + input)
+		logger.Logf("[FATAL]    "+format, values...)
 	} else {
-		log.Fatalf(input)
+		log.Fatalf(format, values...)
 	}
 }

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -199,11 +199,10 @@ func Request(method string, path string, args []byte, mods ...RequestModifier) (
 		return nil, code, err
 	}
 
-	if err := DecodeError(body); err != nil {
-		return nil, code, err
-	}
-
 	if code >= 400 {
+		if err := DecodeError(body); err != nil {
+			return nil, code, err
+		}
 		return body, code, fmt.Errorf("HTTP %d", code)
 	}
 


### PR DESCRIPTION
1. Description
- Printing call stack and stack trace automatically in wrapped errors.
- Add UUID on error returned from API.
- Show error uuid in ctl when an error occured.
- Create admin endpoint to get error from Graylog by uuid.
- Create ctl command to get error by uuid.

2. Log strategy
- For a simple error: catched by the router and associated with a unknown sdk.Error, then logged with a UUID.
- For a sdk.Error: catched by the router the logged with a UUID.
- For a wrapped simple error: same as simple error but logged with stack trace and call stack.
- For a wrapped sdk.Error: same as sdk.Error but logged with stack trace and call stack.

3. Err return strategy
- All error from lib should be wrapped like sdk.WithStack(err) or sdk.WrapError(err, format, values...), WithStack and WrapError do not override existing callers on already wrapped errors. This will generate unknown http error (500).
- Create new error from existing sdk.Error like sdk.NewError(ErrForbidden, err). This will generated a predefined http error with stack trace. New errors can also be wrapped to add more details.
- Return sdk.Error{} or predefined sdk.Error like ErrForbidden. This will generated a http error that will be logged with a uuid but without stack trace or call stack.
- If a simple error is return it will be catched be the router and returns as an unknown error (500).
@ovh/cds
