### PR TITLE
fix(api): workflow as code improvements

### DIFF
--- a/engine/api/workflow/audit.go
+++ b/engine/api/workflow/audit.go
@@ -63,7 +63,7 @@ func (a addWorkflowAudit) Compute(db gorp.SqlExecutor, e sdk.Event) error {
 	}
 
 	buffer := bytes.NewBufferString("")
-	_, errE := exportWorkflow(wEvent.Workflow, exportentities.FormatYAML, false, buffer)
+	_, errE := exportWorkflow(wEvent.Workflow, exportentities.FormatYAML, buffer)
 	if errE != nil {
 		return sdk.WrapError(errE, "addWorkflowAudit.Compute> Unable to export workflow")
 	}
@@ -88,12 +88,12 @@ func (u updateWorkflowAudit) Compute(db gorp.SqlExecutor, e sdk.Event) error {
 	}
 
 	oldWorkflowBuffer := bytes.NewBufferString("")
-	_, errE := exportWorkflow(wEvent.OldWorkflow, exportentities.FormatYAML, false, oldWorkflowBuffer)
+	_, errE := exportWorkflow(wEvent.OldWorkflow, exportentities.FormatYAML, oldWorkflowBuffer)
 	if errE != nil {
 		return sdk.WrapError(errE, "updateWorkflowAudit.Compute> Unable to export workflow")
 	}
 	newWorkflowBuffer := bytes.NewBufferString("")
-	_, errN := exportWorkflow(wEvent.NewWorkflow, exportentities.FormatYAML, false, newWorkflowBuffer)
+	_, errN := exportWorkflow(wEvent.NewWorkflow, exportentities.FormatYAML, newWorkflowBuffer)
 	if errN != nil {
 		return sdk.WrapError(errN, "updateWorkflowAudit.Compute> Unable to export workflow")
 	}
@@ -119,7 +119,7 @@ func (d deleteWorkflowAudit) Compute(db gorp.SqlExecutor, e sdk.Event) error {
 	}
 
 	oldWorkflowBuffer := bytes.NewBufferString("")
-	_, errE := exportWorkflow(wEvent.Workflow, exportentities.FormatYAML, false, oldWorkflowBuffer)
+	_, errE := exportWorkflow(wEvent.Workflow, exportentities.FormatYAML, oldWorkflowBuffer)
 	if errE != nil {
 		return sdk.WrapError(errE, "deleteWorkflowAudit.Compute> Unable to export workflow")
 	}

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -1040,6 +1040,22 @@ func Push(ctx context.Context, db *gorp.DbMap, store cache.Store, proj *sdk.Proj
 		dryRun = opts.DryRun
 	}
 
+	// In workflow as code context, if we only have the repowebhook, we skip it
+	//  because it will be automatically recreated later with the proper configuration
+	if opts != nil && opts.FromRepository != "" {
+		if len(wrkflw.Workflow) == 0 {
+			if len(wrkflw.PipelineHooks) == 1 && wrkflw.PipelineHooks[0].Model == sdk.RepositoryWebHookModelName {
+				wrkflw.PipelineHooks = nil
+			}
+		} else {
+			for node, hooks := range wrkflw.Hooks {
+				if len(hooks) == 1 && hooks[0].Model == sdk.RepositoryWebHookModelName {
+					wrkflw.Hooks[node] = nil
+				}
+			}
+		}
+	}
+
 	wf, msgList, err := ParseAndImport(ctx, tx, store, proj, &wrkflw, u, ImportOptions{DryRun: dryRun, Force: true})
 	if err != nil {
 		log.Error("Push> Unable to import workflow: %v", err)

--- a/engine/api/workflow/dao_node_run_vulnerability.go
+++ b/engine/api/workflow/dao_node_run_vulnerability.go
@@ -205,6 +205,7 @@ func loadLatestRunVulnerabilityReport(db gorp.SqlExecutor, nr *sdk.WorkflowNodeR
 	return dbReport.Report.Summary, nil
 }
 
+// InsertVulnerabilityReport inserts vulnerability report
 func InsertVulnerabilityReport(db gorp.SqlExecutor, report sdk.WorkflowNodeRunVulnerabilityReport) error {
 	dbReport := dbNodeRunVulenrabilitiesReport(report)
 	if err := db.Insert(&dbReport); err != nil {

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -80,7 +80,7 @@ func TestInsertSimpleWorkflowAndExport(t *testing.T) {
 	test.NoError(t, err)
 	assert.Equal(t, 1, len(ws))
 
-	exp, err := exportentities.NewWorkflow(*w1, false)
+	exp, err := exportentities.NewWorkflow(*w1)
 	test.NoError(t, err)
 	btes, err := exportentities.Marshal(exp, exportentities.FormatYAML)
 	test.NoError(t, err)
@@ -311,7 +311,7 @@ func TestInsertComplexeWorkflowAndExport(t *testing.T) {
 
 	assertEqualNode(t, w.Root, w1.Root)
 
-	exp, err := exportentities.NewWorkflow(w, false)
+	exp, err := exportentities.NewWorkflow(w)
 	test.NoError(t, err)
 	btes, err := exportentities.Marshal(exp, exportentities.FormatYAML)
 	test.NoError(t, err)
@@ -789,7 +789,7 @@ func TestInsertComplexeWorkflowWithJoinsAndExport(t *testing.T) {
 	}, w1.Joins[0].SourceNodeIDs)
 	assert.Equal(t, pip5.Name, w.Joins[0].Triggers[0].WorkflowDestNode.PipelineName)
 
-	exp, err := exportentities.NewWorkflow(*w1, false)
+	exp, err := exportentities.NewWorkflow(*w1)
 	test.NoError(t, err)
 	btes, err := exportentities.Marshal(exp, exportentities.FormatYAML)
 	test.NoError(t, err)
@@ -1250,7 +1250,7 @@ func TestInsertSimpleWorkflowWithHookAndExport(t *testing.T) {
 	assert.Len(t, w.Root.Hooks, 1)
 	t.Log(w.Root.Hooks)
 
-	exp, err := exportentities.NewWorkflow(*w1, false)
+	exp, err := exportentities.NewWorkflow(*w1)
 	test.NoError(t, err)
 	btes, err := exportentities.Marshal(exp, exportentities.FormatYAML)
 	test.NoError(t, err)

--- a/engine/api/workflow/hook.go
+++ b/engine/api/workflow/hook.go
@@ -328,9 +328,13 @@ func DefaultPayload(ctx context.Context, db gorp.SqlExecutor, store cache.Store,
 
 		defaultPayload = wf.Root.Context.DefaultPayload
 		if !wf.Root.Context.HasDefaultPayload() {
-			defaultPayload = sdk.WorkflowNodeContextDefaultPayloadVCS{
+			structuredDefaultPayload := sdk.WorkflowNodeContextDefaultPayloadVCS{
 				GitBranch:     defaultBranch,
 				GitRepository: wf.Root.Context.Application.RepositoryFullname,
+			}
+			defaultPayloadBtes, _ := json.Marshal(structuredDefaultPayload)
+			if err := json.Unmarshal(defaultPayloadBtes, &defaultPayload); err != nil {
+				return nil, err
 			}
 		} else if defaultPayloadMap, err := wf.Root.Context.DefaultPayloadToMap(); err == nil && defaultPayloadMap["git.branch"] == "" {
 			defaultPayloadMap["git.branch"] = defaultBranch

--- a/engine/api/workflow/hook.go
+++ b/engine/api/workflow/hook.go
@@ -295,8 +295,12 @@ func mergeAndDiffHook(oldHooks map[string]sdk.WorkflowNodeHook, newHooks map[str
 
 // DefaultPayload returns the default payload for the workflow root
 func DefaultPayload(ctx context.Context, db gorp.SqlExecutor, store cache.Store, p *sdk.Project, u *sdk.User, wf *sdk.Workflow) (interface{}, error) {
+	if wf.Root.Context == nil {
+		return nil, nil
+	}
 	var defaultPayload interface{}
-	if wf.Root.Context == nil || wf.Root.Context.Application == nil || wf.Root.Context.Application.ID == 0 {
+	// Load application if not available
+	if wf.Root.Context != nil && wf.Root.Context.Application == nil && wf.Root.Context.ApplicationID != 0 {
 		app, errLa := application.LoadByID(db, store, wf.Root.Context.ApplicationID, u)
 		if errLa != nil {
 			return wf.Root.Context.DefaultPayload, sdk.WrapError(errLa, "DefaultPayload> unable to load application by id %d", wf.Root.Context.ApplicationID)

--- a/engine/api/workflow/hook.go
+++ b/engine/api/workflow/hook.go
@@ -298,6 +298,11 @@ func DefaultPayload(ctx context.Context, db gorp.SqlExecutor, store cache.Store,
 	if wf.Root.Context == nil {
 		return nil, nil
 	}
+
+	if wf.Root.Context.Application == nil {
+		return wf.Root.Context.DefaultPayload, nil
+	}
+
 	var defaultPayload interface{}
 	// Load application if not available
 	if wf.Root.Context != nil && wf.Root.Context.Application == nil && wf.Root.Context.ApplicationID != 0 {

--- a/engine/api/workflow/workflow_exporter.go
+++ b/engine/api/workflow/workflow_exporter.go
@@ -29,6 +29,11 @@ func Export(ctx context.Context, db gorp.SqlExecutor, cache cache.Store, proj *s
 		return 0, sdk.WrapError(errload, "workflow.Export> Cannot load workflow %s", name)
 	}
 
+	// If repo is from as-code do not export WorkflowSkipIfOnlyOneRepoWebhook
+	if wf.FromRepository != "" {
+		opts = append(opts, exportentities.WorkflowSkipIfOnlyOneRepoWebhook)
+	}
+
 	return exportWorkflow(*wf, f, w, opts...)
 }
 

--- a/engine/api/workflow/workflow_exporter_test.go
+++ b/engine/api/workflow/workflow_exporter_test.go
@@ -123,7 +123,7 @@ func TestPull(t *testing.T) {
 	test.Equal(t, w.PurgeTags, w1.PurgeTags)
 
 	buff := new(bytes.Buffer)
-	test.NoError(t, workflow.Pull(context.TODO(), db, cache, proj, w1.Name, exportentities.FormatYAML, false, project.EncryptWithBuiltinKey, u, buff))
+	test.NoError(t, workflow.Pull(context.TODO(), db, cache, proj, w1.Name, exportentities.FormatYAML, project.EncryptWithBuiltinKey, u, buff))
 
 	// Open the tar archive for reading.
 	r := bytes.NewReader(buff.Bytes())

--- a/engine/api/workflow/workflow_importer.go
+++ b/engine/api/workflow/workflow_importer.go
@@ -117,6 +117,12 @@ func Import(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *s
 		return sdk.WrapError(errE, "Import> Cannot check if workflow exists")
 	}
 
+	//Manage default payload
+	var err error
+	if w.Root.Context.DefaultPayload, err = DefaultPayload(ctx, db, store, proj, u, w); err != nil {
+		log.Warning("workflow.Import> Cannot set default payload : %v", err)
+	}
+
 	if !doUpdate {
 		if err := Insert(db, store, w, proj, u); err != nil {
 			return sdk.WrapError(err, "Import> Unable to insert workflow")

--- a/engine/api/workflow/workflow_importer.go
+++ b/engine/api/workflow/workflow_importer.go
@@ -119,6 +119,9 @@ func Import(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *s
 
 	//Manage default payload
 	var err error
+	if w.Root.Context == nil {
+		w.Root.Context = &sdk.WorkflowNodeContext{}
+	}
 	if w.Root.Context.DefaultPayload, err = DefaultPayload(ctx, db, store, proj, u, w); err != nil {
 		log.Warning("workflow.Import> Cannot set default payload : %v", err)
 	}

--- a/engine/api/workflow_export.go
+++ b/engine/api/workflow_export.go
@@ -27,6 +27,11 @@ func (api *API) getWorkflowExportHandler() service.Handler {
 		}
 		withPermissions := FormBool(r, "withPermissions")
 
+		opts := []exportentities.WorkflowOptions{}
+		if withPermissions {
+			opts = append(opts, exportentities.WorkflowWithPermissions)
+		}
+
 		f, err := exportentities.GetFormat(format)
 		if err != nil {
 			return sdk.WrapError(err, "getWorkflowExportHandler> Format invalid")
@@ -36,7 +41,7 @@ func (api *API) getWorkflowExportHandler() service.Handler {
 		if err != nil {
 			return sdk.WrapError(err, "getWorkflowExportHandler> unable to load projet")
 		}
-		if _, err := workflow.Export(ctx, api.mustDB(), api.Cache, proj, name, f, withPermissions, getUser(ctx), w); err != nil {
+		if _, err := workflow.Export(ctx, api.mustDB(), api.Cache, proj, name, f, getUser(ctx), w, opts...); err != nil {
 			return sdk.WrapError(err, "getWorkflowExportHandler>")
 		}
 
@@ -53,13 +58,18 @@ func (api *API) getWorkflowPullHandler() service.Handler {
 		name := vars["permWorkflowName"]
 		withPermissions := FormBool(r, "withPermissions")
 
+		opts := []exportentities.WorkflowOptions{}
+		if withPermissions {
+			opts = append(opts, exportentities.WorkflowWithPermissions)
+		}
+
 		proj, err := project.Load(api.mustDB(), api.Cache, key, getUser(ctx), project.LoadOptions.WithPlatforms)
 		if err != nil {
 			return sdk.WrapError(err, "getWorkflowPullHandler> unable to load projet")
 		}
 
 		buf := new(bytes.Buffer)
-		if err := workflow.Pull(ctx, api.mustDB(), api.Cache, proj, name, exportentities.FormatYAML, withPermissions, project.EncryptWithBuiltinKey, getUser(ctx), buf); err != nil {
+		if err := workflow.Pull(ctx, api.mustDB(), api.Cache, proj, name, exportentities.FormatYAML, project.EncryptWithBuiltinKey, getUser(ctx), buf, opts...); err != nil {
 			return sdk.WrapError(err, "getWorkflowPullHandler")
 		}
 

--- a/engine/api/workflow_test.go
+++ b/engine/api/workflow_test.go
@@ -441,11 +441,11 @@ func Test_postWorkflowRollbackHandler(t *testing.T) {
 
 	assert.NotEmpty(t, payload["git.branch"], "git.branch should not be empty")
 
-	eWf, err := exportentities.NewWorkflow(*wf, false)
+	eWf, err := exportentities.NewWorkflow(*wf)
 	test.NoError(t, err)
 	wfBts, err := yaml.Marshal(eWf)
 	test.NoError(t, err)
-	eWfUpdate, err := exportentities.NewWorkflow(*workflow1, false)
+	eWfUpdate, err := exportentities.NewWorkflow(*workflow1)
 	test.NoError(t, err)
 	wfUpdatedBts, err := yaml.Marshal(eWfUpdate)
 	test.NoError(t, err)

--- a/sdk/cdsclient/client_export.go
+++ b/sdk/cdsclient/client_export.go
@@ -58,12 +58,15 @@ func (c *client) EnvironmentExport(projectKey, name string, exportWithPermission
 	return body, nil
 }
 
-func (c *client) WorkflowExport(projectKey, name string, exportWithPermissions bool, exportFormat string) ([]byte, error) {
-	path := fmt.Sprintf("/project/%s/export/workflows/%s?format=%s", projectKey, name, exportFormat)
-	if exportWithPermissions {
-		path += "&withPermissions=true"
-	}
-	bodyReader, _, _, err := c.Stream(context.Background(), "GET", path, nil, true)
+func (c *client) WorkflowExport(projectKey, name string, mods ...RequestModifier) ([]byte, error) {
+	/*
+		path := fmt.Sprintf("/project/%s/export/workflows/%s?format=%s", projectKey, name, exportFormat)
+		if exportWithPermissions {
+			path += "&withPermissions=true"
+		}
+	*/
+	path := fmt.Sprintf("/project/%s/export/workflows/%s", projectKey, name)
+	bodyReader, _, _, err := c.Stream(context.Background(), "GET", path, nil, true, mods...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,12 +79,13 @@ func (c *client) WorkflowExport(projectKey, name string, exportWithPermissions b
 	return body, nil
 }
 
-func (c *client) WorkflowPull(projectKey, name string, exportWithPermissions bool) (*tar.Reader, error) {
+func (c *client) WorkflowPull(projectKey, name string, mods ...RequestModifier) (*tar.Reader, error) {
 	path := fmt.Sprintf("/project/%s/pull/workflows/%s", projectKey, name)
-	if exportWithPermissions {
+	/*if exportWithPermissions {
 		path += "?withPermissions=true"
 	}
-	body, _, _, err := c.Request(context.Background(), "GET", path, nil)
+	*/
+	body, _, _, err := c.Request(context.Background(), "GET", path, nil, mods...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cdsclient/client_export.go
+++ b/sdk/cdsclient/client_export.go
@@ -59,12 +59,6 @@ func (c *client) EnvironmentExport(projectKey, name string, exportWithPermission
 }
 
 func (c *client) WorkflowExport(projectKey, name string, mods ...RequestModifier) ([]byte, error) {
-	/*
-		path := fmt.Sprintf("/project/%s/export/workflows/%s?format=%s", projectKey, name, exportFormat)
-		if exportWithPermissions {
-			path += "&withPermissions=true"
-		}
-	*/
 	path := fmt.Sprintf("/project/%s/export/workflows/%s", projectKey, name)
 	bodyReader, _, _, err := c.Stream(context.Background(), "GET", path, nil, true, mods...)
 	if err != nil {
@@ -81,10 +75,6 @@ func (c *client) WorkflowExport(projectKey, name string, mods ...RequestModifier
 
 func (c *client) WorkflowPull(projectKey, name string, mods ...RequestModifier) (*tar.Reader, error) {
 	path := fmt.Sprintf("/project/%s/pull/workflows/%s", projectKey, name)
-	/*if exportWithPermissions {
-		path += "?withPermissions=true"
-	}
-	*/
 	body, _, _, err := c.Request(context.Background(), "GET", path, nil, mods...)
 	if err != nil {
 		return nil, err

--- a/sdk/cdsclient/client_import.go
+++ b/sdk/cdsclient/client_import.go
@@ -197,7 +197,7 @@ func (c *client) WorkflowPush(projectKey string, tarContent io.Reader, mods ...R
 	if wName == "" {
 		return messages, nil, nil
 	}
-	tarReader, err := c.WorkflowPull(projectKey, wName, false)
+	tarReader, err := c.WorkflowPull(projectKey, wName, mods...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -31,8 +31,8 @@ type ExportImportInterface interface {
 	PipelineImport(projectKey string, content io.Reader, format string, force bool) ([]string, error)
 	ApplicationExport(projectKey, name string, exportWithPermissions bool, format string) ([]byte, error)
 	ApplicationImport(projectKey string, content io.Reader, format string, force bool) ([]string, error)
-	WorkflowExport(projectKey, name string, exportWithPermissions bool, exportFormat string) ([]byte, error)
-	WorkflowPull(projectKey, name string, exportWithPermissions bool) (*tar.Reader, error)
+	WorkflowExport(projectKey, name string, mods ...RequestModifier) ([]byte, error)
+	WorkflowPull(projectKey, name string, mods ...RequestModifier) (*tar.Reader, error)
 	WorkflowImport(projectKey string, content io.Reader, format string, force bool) ([]string, error)
 	WorkflowPush(projectKey string, tarContent io.Reader, mods ...RequestModifier) ([]string, *tar.Reader, error)
 	WorkflowAsCodeInterface

--- a/sdk/exportentities/workflow.go
+++ b/sdk/exportentities/workflow.go
@@ -77,6 +77,22 @@ func WorkflowWithPermissions(w sdk.Workflow, exportedWorkflow *Workflow) error {
 }
 
 func WorkflowSkipIfOnlyOneRepoWebhook(w sdk.Workflow, exportedWorkflow *Workflow) error {
+	if len(exportedWorkflow.Workflow) == 0 {
+		if len(exportedWorkflow.PipelineHooks) == 1 && exportedWorkflow.PipelineHooks[0].Model == sdk.RepositoryWebHookModelName {
+			exportedWorkflow.PipelineHooks = nil
+		}
+		return nil
+	}
+
+	for nodeName, hs := range exportedWorkflow.Hooks {
+		if nodeName == w.Root.Name && len(hs) == 1 {
+			if hs[0].Model == sdk.RepositoryWebHookModelName {
+				delete(exportedWorkflow.Hooks, nodeName)
+				break
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"time"
@@ -945,6 +946,49 @@ type WorkflowNodeContextDefaultPayloadVCS struct {
 	GitHashBefore string `json:"git.hash.before" db:"-"`
 	GitRepository string `json:"git.repository" db:"-"`
 	GitMessage    string `json:"git.message" db:"-"`
+}
+
+// IsWorkflowNodeContextDefaultPayloadVCS checks with several way if the workflow node context has a default vcs payloas
+func IsWorkflowNodeContextDefaultPayloadVCS(i interface{}) bool {
+	_, ok := i.(WorkflowNodeContextDefaultPayloadVCS)
+	if ok {
+		return true
+	}
+
+	dumper := dump.NewDefaultEncoder(nil)
+	dumper.ExtraFields.DetailedMap = false
+	dumper.ExtraFields.DetailedStruct = false
+	dumper.ExtraFields.Len = false
+	dumper.ExtraFields.Type = false
+
+	mI, _ := dumper.ToMap(i)
+	mD, _ := dumper.ToMap(WorkflowNodeContextDefaultPayloadVCS{})
+	var kI, kD []string
+	for k := range mI {
+		kI = append(kI, k)
+	}
+	for k := range mD {
+		kD = append(kD, k)
+	}
+
+	if reflect.DeepEqual(kI, kD) {
+		return true
+	}
+
+	hasKey := func(s string) bool {
+		_, has := mI[s]
+		return has
+	}
+
+	if hasKey("git.branch") &&
+		hasKey("git.hash") &&
+		hasKey("git.author") &&
+		hasKey("git.hash.before") &&
+		hasKey("git.repository") &&
+		hasKey("git.message") {
+		return true
+	}
+	return false
 }
 
 //WorkflowList return the list of the workflows for a project

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"time"
@@ -963,32 +962,29 @@ func IsWorkflowNodeContextDefaultPayloadVCS(i interface{}) bool {
 
 	mI, _ := dumper.ToMap(i)
 	mD, _ := dumper.ToMap(WorkflowNodeContextDefaultPayloadVCS{})
-	var kI, kD []string
-	for k := range mI {
-		kI = append(kI, k)
-	}
-	for k := range mD {
-		kD = append(kD, k)
-	}
 
-	if reflect.DeepEqual(kI, kD) {
-		return true
-	}
-
+	// compare interface keys with default payload keys
 	hasKey := func(s string) bool {
 		_, has := mI[s]
 		return has
 	}
 
-	if hasKey("git.branch") &&
+	if len(mI) == len(mD) {
+		for k := range mD {
+			if !hasKey(k) {
+				goto checkGitKey
+			}
+		}
+		return true
+	}
+
+checkGitKey:
+	return hasKey("git.branch") &&
 		hasKey("git.hash") &&
 		hasKey("git.author") &&
 		hasKey("git.hash.before") &&
 		hasKey("git.repository") &&
-		hasKey("git.message") {
-		return true
-	}
-	return false
+		hasKey("git.message")
 }
 
 //WorkflowList return the list of the workflows for a project


### PR DESCRIPTION
1. Description
* Since a hook is mandatory for workflow as code, do not export it
* Do not export default VCS payload
1. Related issues
* closes #3239
1. About tests
1. Mentions

@ovh/cds
