### PR TITLE
fix(sdk): no more ctx.Err() in queue polling

### DIFF
--- a/sdk/cdsclient/http_sse.go
+++ b/sdk/cdsclient/http_sse.go
@@ -76,13 +76,13 @@ func (c *client) RequestSSEGet(ctx context.Context, path string, evCh chan<- SSE
 	var currEvent *SSEvent
 	var EOF bool
 
+	go func(stop *bool) {
+		<-ctx.Done()
+		*stop = true
+	}(&EOF)
+
 	for !EOF {
-		if ctx.Err() != nil {
-			break
-		}
-
 		bs, err := br.ReadBytes('\n')
-
 		if err != nil && err != io.EOF {
 			return err
 		}


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
