### PR TITLE
fix(api): search err in graylog with cdsctl

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -172,8 +172,9 @@ type Configuration struct {
 	DefaultArch string `toml:"defaultArch" default:"amd64" comment:"if no model and no os/arch is specified in your job's requirements then spawn worker on this architecture (example: amd64, arm, 386)" json:"defaultArch"`
 	Graylog     struct {
 		AccessToken string `toml:"accessToken" json:"-"`
+		Stream      string `toml:"stream" json:"-"`
 		URL         string `toml:"url" comment:"Example: http://localhost:9000" json:"url"`
-	} `toml:"graylog"  json:"graylog"`
+	} `toml:"graylog"  json:"graylog" comment:"###########################\n Graylog Search. \n When CDS API generates errors, you can fetch them with cdsctl. \n Examples: \n $ cdsctl admin errors get <error-id> \n $ cdsctl admin errors get 55f6e977-d39b-11e8-8513-0242ac110007 \n##########################"`
 }
 
 // ProviderConfiguration is the piece of configuration for each provider authentication

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/engine/service"
+	"github.com/ovh/cds/sdk"
 )
 
 type graylogResponse struct {
@@ -40,6 +40,7 @@ func (api *API) getErrorHandler() service.Handler {
 		q.Add("from", "1970-01-01 00:00:00.000")
 		q.Add("to", time.Now().Format("2006-01-02 15:04:05"))
 		q.Add("limit", "1")
+		q.Add("filter", fmt.Sprintf("streams:%s", api.Config.Graylog.Stream))
 		req.URL.RawQuery = q.Encode()
 
 		req.SetBasicAuth(api.Config.Graylog.AccessToken, "token")


### PR DESCRIPTION
conf toml:

```toml

  ###########################
  # Graylog Search.
  # When CDS API generates errors, you can fetch them with cdsctl.
  # Examples:
  #$ cdsctl admin errors get <error-id>
  # $ cdsctl admin errors get 55f6e977-d39b-11e8-8513-0242ac110007
  ###########################
  [api.graylog]
    accessToken = ""
    stream = ""

    # Example: http://localhost:9000
    url = ""

```