### PR TITLE
fix(api): purge workflow with node_root_id=null

### DIFF
--- a/engine/api/purge/purge.go
+++ b/engine/api/purge/purge.go
@@ -16,7 +16,7 @@ import (
 
 //Initialize starts goroutines for workflows
 func Initialize(c context.Context, store cache.Store, DBFunc func() *gorp.DbMap) {
-	tickPurge := time.NewTicker(1 * time.Minute)
+	tickPurge := time.NewTicker(30 * time.Minute)
 	defer tickPurge.Stop()
 
 	for {

--- a/engine/api/purge/purge.go
+++ b/engine/api/purge/purge.go
@@ -16,7 +16,7 @@ import (
 
 //Initialize starts goroutines for workflows
 func Initialize(c context.Context, store cache.Store, DBFunc func() *gorp.DbMap) {
-	tickPurge := time.NewTicker(30 * time.Minute)
+	tickPurge := time.NewTicker(1 * time.Minute)
 	defer tickPurge.Stop()
 
 	for {
@@ -33,15 +33,15 @@ func Initialize(c context.Context, store cache.Store, DBFunc func() *gorp.DbMap)
 			}
 
 			log.Debug("purge> Deleting all workflow marked to delete....")
-			if err := Workflows(c, DBFunc(), store); err != nil {
+			if err := workflows(c, DBFunc(), store); err != nil {
 				log.Warning("purge> Error on workflows : %v", err)
 			}
 		}
 	}
 }
 
-// Workflows purges all marked workflows
-func Workflows(ctx context.Context, db *gorp.DbMap, store cache.Store) error {
+// workflows purges all marked workflows
+func workflows(ctx context.Context, db *gorp.DbMap, store cache.Store) error {
 	query := "SELECT id, project_id FROM workflow WHERE to_delete = true ORDER BY id ASC"
 	res := []struct {
 		ID        int64 `db:"id"`
@@ -72,7 +72,18 @@ func Workflows(ctx context.Context, db *gorp.DbMap, store cache.Store) error {
 
 		w, err := workflow.LoadByID(db, store, &proj, r.ID, nil, workflow.LoadOptions{})
 		if err != nil {
-			return sdk.WrapError(err, "unable to load workflow %d", r.ID)
+			log.Warning("unable to load workflow %d due to error %v, we try to delete it", r.ID, err)
+			if _, err := db.Exec("delete from workflow_node where workflow_id = $1", r.ID); err != nil {
+				log.Error("Unable to delete from workflow_node with workflow_id %d: %v", r.ID, err)
+			} else {
+				log.Warning("workflow_node with workflow_id %d are deleted", r.ID)
+			}
+			if _, err := db.Exec("delete from workflow where id = $1", r.ID); err != nil {
+				log.Error("Unable to delete from workflow with id %d: %v", r.ID, err)
+			} else {
+				log.Warning("workflow with id %d is deleted", r.ID)
+			}
+			continue
 		}
 		wrkflws[i] = *w
 	}

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/docker/distribution v2.7.0-rc.0+incompatible h1:Nw9tozLpkMnG3IA1zLzsC
 github.com/docker/distribution v2.7.0-rc.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/engine v0.0.0-20180816081446-320063a2ad06 h1:7dNp3Uy9WPejW7wy26j3UCz9VP0Hk46uH97DTU0+iX0=
 github.com/docker/engine v0.0.0-20180816081446-320063a2ad06/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
 github.com/docker/go-connections v0.3.0 h1:3lOnM9cSzgGwx8VfK/NGOW5fLQ0GjIlCkaktF+n1M6o=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -507,6 +508,7 @@ github.com/yesnault/go-imap v0.0.0-20160710142244-eb9bbb66bd7b h1:mvFk4C4VehqptP
 github.com/yesnault/go-imap v0.0.0-20160710142244-eb9bbb66bd7b/go.mod h1:LH8s5iF2nb4JFQ1A9fAcvsdqzUGZttifagNxO5TOiPQ=
 github.com/yesnault/go-toml v0.0.0-20170920144045-9a5282f85277 h1:5wm+TddKWEVUnNGFEYYThIVBAdJkZjNCnco5SJYo99Q=
 github.com/yesnault/go-toml v0.0.0-20170920144045-9a5282f85277/go.mod h1:SsMrIuedaKvK8GekjwjVv8gMnHNAuvoINpKCARzdsEQ=
+github.com/yesnault/gorp v0.0.0-20180831150006-1ce9606c8d2f h1:ndiJ8+QzOQ/QPOPBVt3D7JgkXeYtd7VZFHcR0uziFE8=
 github.com/yesnault/gorp v0.0.0-20180831150006-1ce9606c8d2f/go.mod h1:7nhqtxBPZoPXx86SqUzP/OFLd8prnhkydPk51uJthQc=
 github.com/yuin/gluare v0.0.0-20170607022532-d7c94f1a80ed h1:I1vcLHWU9m30rA90rMrKPu0eD3NDA4FBlkB8WMaDyUw=
 github.com/yuin/gluare v0.0.0-20170607022532-d7c94f1a80ed/go.mod h1:9w6KSdZh23UWqOywWsRLUcJUrUNjRh4Ql3z9uVgnSP4=


### PR DESCRIPTION
example:

```
2018-10-24 21:24:41 [WARN] unable to load workflow 486 due to error GoRoutine>Serve>Initialize>workflows>LoadByID>load: internal server error (caused by: Unable to load workflow 486: Unable to load workflow: sql: Scan error on column index 5, name "root_node_id": converting driver.Value type <nil> ("<nil>") to a int64: invalid syntax), we try to delete it
2018-10-24 21:24:41 [WARN] workflow_node with workflow_id 486 are deleted
2018-10-24 21:24:41 [WARN] workflow with id 486 is deleted
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
