### PR TITLE
fix(api): report could be nil

### DIFF
--- a/engine/api/router_middleware.go
+++ b/engine/api/router_middleware.go
@@ -142,9 +142,8 @@ func (api *API) authMiddleware(ctx context.Context, w http.ResponseWriter, req *
 	if rc.Options["needService"] == "true" {
 		if getService(ctx) != nil {
 			return ctx, nil
-		} else {
-			return ctx, sdk.WrapError(sdk.ErrForbidden, "Router> Need worker")
 		}
+		return ctx, sdk.WrapError(sdk.ErrForbidden, "Router> Need worker")
 	}
 
 	if rc.Options["needWorker"] == "true" {

--- a/engine/api/workflow/execute_node_job_run.go
+++ b/engine/api/workflow/execute_node_job_run.go
@@ -34,6 +34,9 @@ type ProcessorReport struct {
 
 // WorkflowRuns returns the list of concerned workflow runs
 func (r *ProcessorReport) WorkflowRuns() []sdk.WorkflowRun {
+	if r == nil {
+		return nil
+	}
 	return r.workflows
 }
 

--- a/engine/api/workflow/resync_workflow.go
+++ b/engine/api/workflow/resync_workflow.go
@@ -107,6 +107,9 @@ func ResyncWorkflowRunStatus(db gorp.SqlExecutor, wr *sdk.WorkflowRun) (*Process
 
 // ResyncNodeRunsWithCommits load commits build in this node run and save it into node run
 func ResyncNodeRunsWithCommits(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, report *ProcessorReport) {
+	if report == nil {
+		return
+	}
 	nodeRuns := report.nodes
 	for _, nodeRun := range nodeRuns {
 		if len(nodeRun.Commits) > 0 {

--- a/engine/api/workflow/workflow_run_event.go
+++ b/engine/api/workflow/workflow_run_event.go
@@ -19,6 +19,9 @@ import (
 
 // SendEvent Send event on workflow run
 func SendEvent(db gorp.SqlExecutor, key string, report *ProcessorReport) {
+	if report == nil {
+		return
+	}
 	for _, wr := range report.workflows {
 		event.PublishWorkflowRun(wr, key)
 	}

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -428,6 +428,7 @@ func (api *API) postWorkflowJobResultHandler() service.Handler {
 				observability.Record(ctx, api.Stats.WorkflowRunFailed, 1)
 			}
 		}
+
 		_, next = observability.Span(ctx, "workflow.ResyncNodeRunsWithCommits")
 		workflow.ResyncNodeRunsWithCommits(ctx, api.mustDB(), api.Cache, proj, report)
 		next()

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -419,23 +419,20 @@ func (api *API) postWorkflowJobResultHandler() service.Handler {
 			return sdk.WrapError(err, "unable to post job result")
 		}
 
-		// report could be nil, even if there is no error on workflow.UpdateNodeJobRunStatus
-		if report != nil {
-			workflowRuns := report.WorkflowRuns()
-			if len(workflowRuns) > 0 {
-				observability.Current(ctx,
-					observability.Tag(observability.TagWorkflow, workflowRuns[0].Workflow.Name))
+		workflowRuns := report.WorkflowRuns()
+		if len(workflowRuns) > 0 {
+			observability.Current(ctx,
+				observability.Tag(observability.TagWorkflow, workflowRuns[0].Workflow.Name))
 
-				if workflowRuns[0].Status == sdk.StatusFail.String() {
-					observability.Record(ctx, api.Stats.WorkflowRunFailed, 1)
-				}
+			if workflowRuns[0].Status == sdk.StatusFail.String() {
+				observability.Record(ctx, api.Stats.WorkflowRunFailed, 1)
 			}
-			_, next = observability.Span(ctx, "workflow.ResyncNodeRunsWithCommits")
-			workflow.ResyncNodeRunsWithCommits(ctx, api.mustDB(), api.Cache, proj, report)
-			next()
-
-			go workflow.SendEvent(api.mustDB(), proj.Key, report)
 		}
+		_, next = observability.Span(ctx, "workflow.ResyncNodeRunsWithCommits")
+		workflow.ResyncNodeRunsWithCommits(ctx, api.mustDB(), api.Cache, proj, report)
+		next()
+
+		go workflow.SendEvent(api.mustDB(), proj.Key, report)
 
 		return nil
 	}
@@ -498,13 +495,10 @@ func postJobResult(ctx context.Context, dbFunc func(context.Context) *gorp.DbMap
 		return nil, sdk.WrapError(err, "Cannot commit tx")
 	}
 
-	// report could be nil, even if there is no error on workflow.UpdateNodeJobRunStatus
-	if report != nil {
-		for i := range report.WorkflowRuns() {
-			run := &report.WorkflowRuns()[i]
-			if err := updateParentWorkflowRun(ctx, newDBFunc, store, run); err != nil {
-				return nil, sdk.WrapError(err, "postJobResult")
-			}
+	for i := range report.WorkflowRuns() {
+		run := &report.WorkflowRuns()[i]
+		if err := updateParentWorkflowRun(ctx, newDBFunc, store, run); err != nil {
+			return nil, sdk.WrapError(err, "postJobResult")
 		}
 	}
 


### PR DESCRIPTION
this will avoid this stack:

```
[PANIC_RECOVERY] Stacktrace of 4096 bytes
goroutine 331321 [running]:
github.com/ovh/cds/engine/api.(*Router).recoverWrap.func1.1(0xc42b27da28, 0xc42018bf00, 0xc4200d1a00, 0x28ca880, 0xc43203a370)
	/go/src/github.com/ovh/cds/engine/api/router.go:130 +0x502
panic(0x2150f80, 0x3a0b7a0)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/ovh/cds/engine/api/workflow.(*ProcessorReport).WorkflowRuns(...)
	/go/src/github.com/ovh/cds/engine/api/workflow/execute_node_job_run.go:37
github.com/ovh/cds/engine/api.postJobResult(0x28d7ec0, 0xc432581500, 0xc423d70c10, 0x28fba60, 0xc420385c90, 0xc4211650e0, 0xc4277322d0, 0xc43203a410, 0x0, 0x0, ...)
	/go/src/github.com/ovh/cds/engine/api/workflow_queue.go:499 +0x82e
github.com/ovh/cds/engine/api.(*API).postWorkflowJobResultHandler.func1(0x28d7ec0, 0xc4304de270, 0x28ca880, 0xc43203a370, 0xc42018bf00, 0x0, 0x0)
	/go/src/github.com/ovh/cds/engine/api/workflow_queue.go:417 +0xcf4

...

```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
