### PR TITLE
add .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# https://github.com/golangci/golangci/wiki/Configuration
+
+service:
+  prepare:
+    - apt-get update && apt-get install -y libsecret-1-dev


### PR DESCRIPTION
It's needed to properly run analysis on https://golangci.com

Now analysis fails because of not installed `libsecret-1`. With this fix, it's analyzed [successfully](https://golangci.com/r/github.com/jirfag/cds).

@ovh/cds
