### PR TITLE
feat(hatchery/swarm): enable ipv6

### DIFF
--- a/engine/hatchery/swarm/swarm_util_create.go
+++ b/engine/hatchery/swarm/swarm_util_create.go
@@ -28,7 +28,7 @@ func (h *HatcherySwarm) createNetwork(ctx context.Context, dockerClient *dockerC
 		Driver:         "bridge",
 		Internal:       false,
 		CheckDuplicate: true,
-		EnableIPv6:     false,
+		EnableIPv6:     h.Config.NetworkEnableIPv6,
 		IPAM: &network.IPAM{
 			Driver: "default",
 		},

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -27,6 +27,9 @@ type HatcheryConfiguration struct {
 	// DockerOpts Docker options
 	DockerOpts string `mapstructure:"dockerOpts" toml:"dockerOpts" default:"" commented:"true" comment:"Docker Options. --add-host and --privileged supported. Example: dockerOpts=\"--add-host=myhost:x.x.x.x,myhost2:y.y.y.y --privileged\"" json:"dockerOpts,omitempty"`
 
+	// NetworkEnableIPv6 if true: set ipv6 to true
+	NetworkEnableIPv6 bool `mapstructure:"networkEnableIPv6" toml:"networkEnableIPv6" default:"false" commented:"false" comment:"if true: hatchery creates private network between services with ipv6 enabled" json:"networkEnableIPv6"`
+
 	DockerEngines map[string]DockerEngineConfiguration `mapstructure:"dockerEngines" toml:"dockerEngines" comment:"List of Docker Engines" json:"dockerEngines,omitempty"`
 }
 


### PR DESCRIPTION
It's an option, as it's not enable per default on docker engine.

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>
