### PR TITLE
fix(api): Take care of workflow name value after template generation

### DIFF
--- a/cli/cdsctl/template.go
+++ b/cli/cdsctl/template.go
@@ -203,7 +203,7 @@ func templateInstancesRun(v cli.Values) (cli.ListResult, error) {
 		if wtis[i].Workflow != nil {
 			tids[i].Workflow = wtis[i].Workflow.Name
 		} else {
-			tids[i].Workflow = fmt.Sprintf("%s (not imported)", wtis[i].Request.WorkflowName)
+			tids[i].Workflow = fmt.Sprintf("%s (not imported)", wtis[i].WorkflowName)
 		}
 		for k, v := range wtis[i].Request.Parameters {
 			tids[i].Params = fmt.Sprintf("%s%s:%s\n", tids[i].Params, k, v)

--- a/engine/api/workflow/workflow_importer.go
+++ b/engine/api/workflow/workflow_importer.go
@@ -127,38 +127,31 @@ func setTemplateData(db gorp.SqlExecutor, p *sdk.Project, w *sdk.Workflow, u *sd
 		return err
 	}
 	if wt == nil {
-		return sdk.WrapError(sdk.ErrWrongRequest, "Could not find given workflow template")
+		return sdk.NewErrorFrom(sdk.ErrWrongRequest, "Could not find given workflow template")
 	}
 
-	wtis, err := workflowtemplate.GetInstancesByTemplateIDAndProjectIDs(db, wt.ID, []int64{p.ID})
+	wti, err := workflowtemplate.GetInstanceByWorkflowNameAndTemplateIDAndProjectID(db, w.Name, wt.ID, p.ID)
 	if err != nil {
 		return err
 	}
-	var wTemplateInstance *sdk.WorkflowTemplateInstance
-	for _, wti := range wtis {
-		if wti.Request.WorkflowName == w.Name {
-			wTemplateInstance = &wti
-			break
-		}
-	}
-	if wTemplateInstance == nil {
-		return sdk.WrapError(sdk.ErrWrongRequest, "Could not find a template instance for workflow %s", w.Name)
+	if wti == nil {
+		return sdk.NewErrorFrom(sdk.ErrWrongRequest, "Could not find a template instance for workflow %s", w.Name)
 	}
 
 	// remove existing relations between workflow and template
-	if err := workflowtemplate.DeleteInstanceNotIDAndWorkflowID(db, wTemplateInstance.ID, w.ID); err != nil {
+	if err := workflowtemplate.DeleteInstanceNotIDAndWorkflowID(db, wti.ID, w.ID); err != nil {
 		return err
 	}
 
-	old := sdk.WorkflowTemplateInstance(*wTemplateInstance)
+	old := sdk.WorkflowTemplateInstance(*wti)
 
 	// set the workflow id on target instance
-	wTemplateInstance.WorkflowID = &w.ID
-	if err := workflowtemplate.UpdateInstance(db, wTemplateInstance); err != nil {
+	wti.WorkflowID = &w.ID
+	if err := workflowtemplate.UpdateInstance(db, wti); err != nil {
 		return err
 	}
 
-	event.PublishWorkflowTemplateInstanceUpdate(old, *wTemplateInstance, u)
+	event.PublishWorkflowTemplateInstanceUpdate(old, *wti, u)
 
 	return nil
 }

--- a/engine/sql/143_template_instance_workflow_name.sql
+++ b/engine/sql/143_template_instance_workflow_name.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+
+ALTER TABLE workflow_template_instance ADD COLUMN workflow_name VARCHAR(100) NOT NULL DEFAULT '';
+UPDATE workflow_template_instance SET workflow_name = request->>'workflow_name';
+
+-- +migrate Down
+
+ALTER TABLE workflow_template_instance DROP COLUMN workflow_name;

--- a/sdk/workflow_template.go
+++ b/sdk/workflow_template.go
@@ -314,6 +314,7 @@ type WorkflowTemplateInstance struct {
 	WorkflowID              *int64                  `json:"workflow_id" db:"workflow_id"`
 	WorkflowTemplateVersion int64                   `json:"workflow_template_version" db:"workflow_template_version"`
 	Request                 WorkflowTemplateRequest `json:"request" db:"request"`
+	WorkflowName            string                  `json:"workflow_name" db:"workflow_name"`
 	// aggregates
 	FirstAudit *AuditWorkflowTemplateInstance `json:"first_audit,omitempty" db:"-"`
 	LastAudit  *AuditWorkflowTemplateInstance `json:"last_audit,omitempty" db:"-"`

--- a/ui/src/app/views/settings/workflow-template/add/workflow-template.add.component.ts
+++ b/ui/src/app/views/settings/workflow-template/add/workflow-template.add.component.ts
@@ -25,7 +25,9 @@ export class WorkflowTemplateAddComponent {
         private _toast: ToastService,
         private _translate: TranslateService
     ) {
-        this.workflowTemplate = new WorkflowTemplate();
+        let wt = new WorkflowTemplate();
+        wt.editable = true;
+        this.workflowTemplate = wt;
         this.getGroups();
     }
 

--- a/ui/src/app/views/settings/workflow-template/form/workflow-template.form.component.ts
+++ b/ui/src/app/views/settings/workflow-template/form/workflow-template.form.component.ts
@@ -19,6 +19,7 @@ export class WorkflowTemplateFormComponent {
     @Input() set workflowTemplate(wt: WorkflowTemplate) {
         if (!wt) {
             wt = new WorkflowTemplate();
+            wt.editable = true;
         }
 
         this._workflowTemplate = wt;

--- a/ui/src/app/views/settings/workflow-template/form/workflow-template.form.html
+++ b/ui/src/app/views/settings/workflow-template/form/workflow-template.form.html
@@ -14,7 +14,7 @@
                             <div class="field">
                                 <label>{{'common_slug' | translate}} *</label>
                                 <input class="ui input" type="text" name="slug" [ngModel]="_workflowTemplate.slug"
-                                    [readonly]="true">
+                                    [disabled]="true">
                             </div>
                             <div class="field">
                                 <label>{{'common_group' | translate}} *</label>


### PR DESCRIPTION
1. Description
Take care of the workflow name value from generated workflow after template execution.
Allow admin to apply a template on all projects.
Remove template instance duplicates (not already linked to a workflow with same workflow name).

1. Related issues
1. About tests
1. Mentions

@ovh/cds
