### PR TITLE
fix(api): load old workflow before changing anything in database

### DIFF
--- a/engine/api/workflow.go
+++ b/engine/api/workflow.go
@@ -157,7 +157,7 @@ func (api *API) postWorkflowRollbackHandler() service.Handler {
 		workflowName := vars["permWorkflowName"]
 		auditID, errConv := strconv.ParseInt(vars["auditID"], 10, 64)
 		if errConv != nil {
-			return sdk.WrapError(sdk.ErrWrongRequest, "postWorkflowRollbackHandler> cannot convert auditID to int")
+			return sdk.WrapError(sdk.ErrWrongRequest, "Cannot convert auditID to int")
 		}
 		db := api.mustDB()
 		u := getUser(ctx)
@@ -171,39 +171,39 @@ func (api *API) postWorkflowRollbackHandler() service.Handler {
 			project.LoadOptions.WithApplicationWithDeploymentStrategies,
 		)
 		if errP != nil {
-			return sdk.WrapError(errP, "postWorkflowRollbackHandler> cannot load project %s", key)
+			return sdk.WrapError(errP, "Cannot load project %s", key)
 		}
 
 		wf, errW := workflow.Load(ctx, db, api.Cache, proj, workflowName, u, workflow.LoadOptions{WithoutNode: true})
 		if errW != nil {
-			return sdk.WrapError(errW, "postWorkflowRollbackHandler> cannot load workflow %s/%s", key, workflowName)
+			return sdk.WrapError(errW, "Cannot load workflow %s/%s", key, workflowName)
 		}
 
 		audit, errA := workflow.LoadAudit(db, auditID, wf.ID)
 		if errA != nil {
-			return sdk.WrapError(errA, "postWorkflowRollbackHandler> cannot load workflow audit %s/%s", key, workflowName)
+			return sdk.WrapError(errA, "Cannot load workflow audit %s/%s", key, workflowName)
 		}
 
 		var exportWf exportentities.Workflow
 		if err := yaml.Unmarshal([]byte(audit.DataBefore), &exportWf); err != nil {
-			return sdk.WrapError(err, "Cannot unmarshall data before")
+			return sdk.WrapError(err, "Cannot unmarshal data before")
 		}
 
 		tx, errTx := db.Begin()
 		if errTx != nil {
-			return sdk.WrapError(errTx, "postWorkflowRollbackHandler> Cannot begin transaction")
+			return sdk.WrapError(errTx, "Cannot begin transaction")
 		}
 		defer func() {
 			_ = tx.Rollback()
 		}()
 
-		newWf, _, errP := workflow.ParseAndImport(ctx, tx, api.Cache, proj, &exportWf, u, workflow.ImportOptions{Force: true, WorkflowName: workflowName})
+		newWf, _, errP := workflow.ParseAndImport(ctx, tx, api.Cache, proj, wf, &exportWf, u, workflow.ImportOptions{Force: true, WorkflowName: workflowName})
 		if errP != nil {
-			return sdk.WrapError(errP, "postWorkflowRollbackHandler> cannot parse and import previous workflow")
+			return sdk.WrapError(errP, "Cannot parse and import previous workflow")
 		}
 
 		if err := tx.Commit(); err != nil {
-			return sdk.WrapError(err, "cannot commit transaction")
+			return sdk.WrapError(err, "Cannot commit transaction")
 		}
 
 		event.PublishWorkflowUpdate(key, *wf, *newWf, getUser(ctx))

--- a/engine/api/workflow.go
+++ b/engine/api/workflow.go
@@ -174,7 +174,7 @@ func (api *API) postWorkflowRollbackHandler() service.Handler {
 			return sdk.WrapError(errP, "Cannot load project %s", key)
 		}
 
-		wf, errW := workflow.Load(ctx, db, api.Cache, proj, workflowName, u, workflow.LoadOptions{WithoutNode: true})
+		wf, errW := workflow.Load(ctx, db, api.Cache, proj, workflowName, u, workflow.LoadOptions{WithIcon: true})
 		if errW != nil {
 			return sdk.WrapError(errW, "Cannot load workflow %s/%s", key, workflowName)
 		}
@@ -315,7 +315,13 @@ func (api *API) postWorkflowHandler() service.Handler {
 		vars := mux.Vars(r)
 		key := vars["permProjectKey"]
 
-		p, errP := project.Load(api.mustDB(), api.Cache, key, getUser(ctx), project.LoadOptions.WithApplicationWithDeploymentStrategies, project.LoadOptions.WithPipelines, project.LoadOptions.WithEnvironments, project.LoadOptions.WithGroups, project.LoadOptions.WithPlatforms)
+		p, errP := project.Load(api.mustDB(), api.Cache, key, getUser(ctx),
+			project.LoadOptions.WithApplicationWithDeploymentStrategies,
+			project.LoadOptions.WithPipelines,
+			project.LoadOptions.WithEnvironments,
+			project.LoadOptions.WithGroups,
+			project.LoadOptions.WithPlatforms,
+		)
 		if errP != nil {
 			return sdk.WrapError(errP, "Cannot load Project %s", key)
 		}
@@ -394,7 +400,12 @@ func (api *API) putWorkflowHandler() service.Handler {
 		key := vars["key"]
 		name := vars["permWorkflowName"]
 
-		p, errP := project.Load(api.mustDB(), api.Cache, key, getUser(ctx), project.LoadOptions.WithApplicationWithDeploymentStrategies, project.LoadOptions.WithPipelines, project.LoadOptions.WithEnvironments, project.LoadOptions.WithPlatforms)
+		p, errP := project.Load(api.mustDB(), api.Cache, key, getUser(ctx),
+			project.LoadOptions.WithApplicationWithDeploymentStrategies,
+			project.LoadOptions.WithPipelines,
+			project.LoadOptions.WithEnvironments,
+			project.LoadOptions.WithPlatforms,
+		)
 		if errP != nil {
 			return sdk.WrapError(errP, "putWorkflowHandler> Cannot load Project %s", key)
 		}

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -539,7 +539,7 @@ func loadFavorite(db gorp.SqlExecutor, w *sdk.Workflow, u *sdk.User) (bool, erro
 // Insert inserts a new workflow
 func Insert(db gorp.SqlExecutor, store cache.Store, w *sdk.Workflow, p *sdk.Project, u *sdk.User) error {
 	if err := IsValid(context.TODO(), store, db, w, p, u); err != nil {
-		return sdk.WrapError(err, "Unable to valid workflow")
+		return sdk.WrapError(err, "Unable to validate workflow")
 	}
 
 	if w.HistoryLength == 0 {
@@ -1285,7 +1285,7 @@ func checkPipeline(ctx context.Context, db gorp.SqlExecutor, proj *sdk.Project, 
 				}
 			}
 			if !found {
-				return sdk.WithStack(sdk.ErrPipelineNotFound)
+				return sdk.NewErrorFrom(sdk.ErrPipelineNotFound, "Can not found a pipeline with id %d", n.Context.PipelineID)
 			}
 
 			// Load pipeline from db to get stage/jobs

--- a/engine/api/workflow/workflow_importer_test.go
+++ b/engine/api/workflow/workflow_importer_test.go
@@ -465,7 +465,20 @@ func TestImport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			(tt.args.w).RetroMigrate()
-			if err := workflow.Import(context.TODO(), db, cache, proj, tt.args.w, u, tt.args.force, nil, false); err != nil {
+
+			workflowExists, err := workflow.Exists(db, proj.Key, tt.args.w.Name)
+			if err != nil {
+				t.Errorf("%s", err)
+			}
+			var wf *sdk.Workflow
+			if workflowExists {
+				wf, err = workflow.Load(context.TODO(), db, cache, proj, tt.args.w.Name, u, workflow.LoadOptions{WithIcon: true})
+				if err != nil {
+					t.Errorf("%s", err)
+				}
+			}
+
+			if err := workflow.Import(context.TODO(), db, cache, proj, wf, tt.args.w, u, tt.args.force, nil, false); err != nil {
 				if !tt.wantErr {
 					t.Errorf("Import() error = %v, wantErr %v", err, tt.wantErr)
 				} else {

--- a/engine/api/workflow/workflow_parser.go
+++ b/engine/api/workflow/workflow_parser.go
@@ -51,7 +51,7 @@ func Parse(proj *sdk.Project, ew *exportentities.Workflow, u *sdk.User) (*sdk.Wo
 }
 
 // ParseAndImport parse an exportentities.workflow and insert or update the workflow in database
-func ParseAndImport(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, ew *exportentities.Workflow, u *sdk.User, opts ImportOptions) (*sdk.Workflow, []sdk.Message, error) {
+func ParseAndImport(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, oldW *sdk.Workflow, ew *exportentities.Workflow, u *sdk.User, opts ImportOptions) (*sdk.Workflow, []sdk.Message, error) {
 	ctx, end := observability.Span(ctx, "workflow.ParseAndImport")
 	defer end()
 
@@ -94,7 +94,7 @@ func ParseAndImport(ctx context.Context, db gorp.SqlExecutor, store cache.Store,
 		}
 	}(&msgList)
 
-	globalError := Import(ctx, db, store, proj, w, u, opts.Force, msgChan, opts.DryRun)
+	globalError := Import(ctx, db, store, proj, oldW, w, u, opts.Force, msgChan, opts.DryRun)
 	close(msgChan)
 	done.Wait()
 

--- a/engine/api/workflow/workflow_parser_test.go
+++ b/engine/api/workflow/workflow_parser_test.go
@@ -3,8 +3,9 @@ package workflow_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ovh/cds/engine/api/application"
 	"github.com/ovh/cds/engine/api/environment"
@@ -84,7 +85,7 @@ func TestParseAndImport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := workflow.ParseAndImport(context.TODO(), db, cache, proj, tt.input, u, workflow.ImportOptions{DryRun: false, Force: true})
+			_, _, err := workflow.ParseAndImport(context.TODO(), db, cache, proj, nil, tt.input, u, workflow.ImportOptions{DryRun: false, Force: true})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseAndImport() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/engine/api/workflow_import.go
+++ b/engine/api/workflow_import.go
@@ -138,7 +138,7 @@ func (api *API) postWorkflowImportHandler() service.Handler {
 		}
 		defer tx.Rollback()
 
-		wrkflw, msgList, globalError := workflow.ParseAndImport(ctx, tx, api.Cache, proj, ew, getUser(ctx), workflow.ImportOptions{DryRun: false, Force: force})
+		wrkflw, msgList, globalError := workflow.ParseAndImport(ctx, tx, api.Cache, proj, nil, ew, getUser(ctx), workflow.ImportOptions{DryRun: false, Force: force})
 		msgListString := translate(r, msgList)
 		if globalError != nil {
 
@@ -178,6 +178,13 @@ func (api *API) putWorkflowImportHandler() service.Handler {
 			return sdk.WrapError(errp, "Unable load project")
 		}
 
+		u := getUser(ctx)
+
+		wf, err := workflow.Load(ctx, api.mustDB(), api.Cache, proj, wfName, u, workflow.LoadOptions{WithIcon: true})
+		if err != nil {
+			return sdk.WrapError(err, "Unable to load workflow")
+		}
+
 		body, errr := ioutil.ReadAll(r.Body)
 		if errr != nil {
 			return sdk.NewError(sdk.ErrWrongRequest, errr)
@@ -212,7 +219,7 @@ func (api *API) putWorkflowImportHandler() service.Handler {
 			_ = tx.Rollback()
 		}()
 
-		wrkflw, msgList, globalError := workflow.ParseAndImport(ctx, tx, api.Cache, proj, ew, getUser(ctx), workflow.ImportOptions{DryRun: false, Force: true, WorkflowName: wfName})
+		wrkflw, msgList, globalError := workflow.ParseAndImport(ctx, tx, api.Cache, proj, wf, ew, getUser(ctx), workflow.ImportOptions{DryRun: false, Force: true, WorkflowName: wfName})
 		msgListString := translate(r, msgList)
 		if globalError != nil {
 


### PR DESCRIPTION
1. Description
Extract workflow loading out of import func and load the workflow before using workflow ParseAndImport.
This will avoid problems to load the workflow when its components were already updated (ex: workflow.Push make changes on application before loading the workflow, this will generate an error if you remove a deployment strategy on an application).

1. Related issues
#3763 
1. About tests
Create the workflow before updating it for put workflow endpoint. The put workflow will not create the workflow anymore.
1. Mentions

@ovh/cds
