### PR TITLE
chore: add cdsctl* in docker images

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -3,12 +3,11 @@ RUN apt-get update && \
     apt-get install -y curl wget git ca-certificates && \
     mkdir /app && cd /app && \
     LAST_RELEASE=$(curl -s https://api.github.com/repos/ovh/cds/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
-    curl -s https://api.github.com/repos/ovh/cds/releases | grep ${LAST_RELEASE} | grep browser_download_url | grep -E 'linux-amd64|worker|sql.tar.gz' | cut -d '"' -f 4 > files && \
+    curl -s https://api.github.com/repos/ovh/cds/releases | grep ${LAST_RELEASE} | grep browser_download_url | grep -E 'cdsctl|engine|worker|sql.tar.gz' | cut -d '"' -f 4 > files && \
     cat files | sort | uniq > filesToDownload && \
     while read f; do wget $f; done < filesToDownload && \
-    chmod +x cds-engine-linux-amd64 && \
+    chmod +x cds* && \
     cp cds-worker-linux-amd64 worker && \
-    chmod +x worker && \
     tar xzf sql.tar.gz && \
     mkdir /app/panic_dumps && \
     chown -R nobody:nogroup /app && \


### PR DESCRIPTION
and: 
 - add engine
 - remove plugins

This will be useful in Ready To Run Tutorial, allowing user to download current cdsctl from image, even if it's a osx user.
Engine cross-os are added too. This image can be launch in a "prod" env, so that users can download engine from UI, then execute hatchery on their side.

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>