### PR TITLE
fix(worker): remove trailing '=' from working dir

### DIFF
--- a/engine/worker/run.go
+++ b/engine/worker/run.go
@@ -341,7 +341,7 @@ func teardownBuildDirectory(wd string) error {
 }
 
 func workingDirectory(basedir string, jobInfo *sdk.WorkflowNodeJobRunData, suffixes ...string) string {
-	var encodedName = base64.StdEncoding.EncodeToString([]byte(jobInfo.NodeJobRun.Job.Job.Action.Name))
+	var encodedName = base64.RawStdEncoding.EncodeToString([]byte(jobInfo.NodeJobRun.Job.Job.Action.Name))
 	paths := append([]string{basedir, encodedName}, suffixes...)
 	dir := path.Join(paths...)
 


### PR DESCRIPTION
Why : some makefile can try to interprete '=' in path.
ex : OBJS = $(SRCS:$(SRCS_DIR)/%.c=$(OBJDIR)/%.o)
if SRCS_DIR contains '=' this fail to create the list of objs
Even if it should be up to the build script to manage this.
This commit will prevent this kind of tricky issue.

How : use RawStdEncoding instead of StdEncoding
RawStdEncoding is the standard raw, unpadded base64 encod

