### PR TITLE
fix(api): default value for logs truncate to 15728640 bytes

### DIFF
--- a/engine/api/workflow/logs.go
+++ b/engine/api/workflow/logs.go
@@ -6,7 +6,7 @@ import (
 
 // max size of a log in database in bytes
 const (
-	DefaultMaxLogSize = 15*1024 ^ 2 // 15MB
+	DefaultMaxLogSize = 15728640 // 15MB
 	maxLogMarker      = "... truncated\n"
 )
 


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
