### PR TITLE
fix(engine): stop warning about missing panic_dumps directories

### DIFF
--- a/engine/hatchery/serve.go
+++ b/engine/hatchery/serve.go
@@ -63,7 +63,7 @@ func init() {
 			files, err := ioutil.ReadDir(path)
 			if err != nil {
 				log.Warning("unable to list files in %s: %v", path, err)
-				continue
+				break
 			}
 
 			for _, f := range files {


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
