### PR TITLE
fix(contrib): fix indentation errors in repositories deployment template file

### DIFF
--- a/contrib/helm/cds/templates/repositories-deployment.yaml
+++ b/contrib/helm/cds/templates/repositories-deployment.yaml
@@ -67,10 +67,10 @@ spec:
         ports:
         - name: http
           containerPort: 8084
-          volumeMounts:
-          - name: cds-repos-data
-      mountPath: {{ .Values.repositories.persistence.mountPath }}
-  volumes:
-  - name: cds-repos-data
-    persistentVolumeClaim:
-      claimName: {{ (printf "%s-repositories" (include "cds.fullname" .)) }}
+        volumeMounts:
+        - name: cds-repos-data
+          mountPath: {{ .Values.repositories.persistence.mountPath }}
+      volumes:
+      - name: cds-repos-data
+        persistentVolumeClaim:
+          claimName: {{ (printf "%s-repositories" (include "cds.fullname" .)) }}


### PR DESCRIPTION
1. Description
Just found an issue when doing kubectl apply -f repositories-deployment.yaml
It's just indentation issues, so here is my fix proposal

2. Related issues

error: error validating "repositories-deployment.yaml": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].ports[0]): unknown field "volumeMounts" in io.k8s.api.core.v1.ContainerPort, ValidationError(Deployment.spec.template.spec): unknown field "mountPath" in io.k8s.api.core.v1.PodSpec, ValidationError(Deployment.spec): unknown field "volumes" in io.k8s.api.extensions.v1beta1.DeploymentSpec]; if you choose to ignore these errors, turn validation off with --validate=false

3. About tests
Tested on my kubernetes cluster

4. Mentions
@ovh/cds
