### PR TITLE
docs(readme): specify the right anchor on the comparison matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,32 +66,32 @@ Core Team is available on [Gitter](https://gitter.im/ovh-cds/Lobby)
 
 All the features of the table are detailed below.
 
-| Feature | CDS | Bamboo | Buildbot | Gitlab CI | Jenkins | 
+| Feature | CDS | Bamboo | Buildbot | Gitlab CI | Jenkins |
 | --- | --- | --- | --- | --- | --- |
-| [Pipeline](#pipeline) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 
+| [Pipeline](#pipeline) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Workflow](#workflow) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: |
-| [Visual configuration with Web UI](#visual-configuration-with-web-ui) | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: <sub><sup>[*1](#some-explanations-on-the-comparaison-matrix)</sub></sup> | 
+| [Visual configuration with Web UI](#visual-configuration-with-web-ui) | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: <sub><sup>[*1](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 | [Configuration on Git Repository](#configuration-on-git-repository) | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [Configuration as code on UI](#configuration-as-code-on-ui) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*2](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
-| [Native Git branching](#native-git-branching) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: <sub><sup>[*3](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
+| [Configuration as code on UI](#configuration-as-code-on-ui) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*2](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Native Git branching](#native-git-branching) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: <sub><sup>[*3](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 | [Job's Services](#jobs-services) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: |
-| [Secure Remote Caching](#secure-remote-caching) | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*4](#some-explanations-on-the-comparaison-matrix)</sub></sup> | 
+| [Secure Remote Caching](#secure-remote-caching) | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*4](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 | [Enterprise Notification Bus](#enterprise-notification-bus) & [Built-in Hooks](#built-in-hooks) | :white_check_mark: | :x: | :x: | :x: | :x: |
-| [Continuous Deployment & Environment Support](#continuous-deployment--environment-support) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*5](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
-| [Enterprise-grade permissions, Support of ACLs delegation](#enterprise-grade-permissions--support-of-acls-delegation) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*6](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
-| [Build Artifacts Cloud](#build-artifacts-cloud) | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*7](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
-| [Tests & Vulnerabilities Reports](#tests--vulnerabilities-reports) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*8](#some-explanations-on-the-comparaison-matrix)</sub></sup> | :white_check_mark: |
-| [Self-Service Project Creation - ability to create a tenant](#self-service-project-creation) | :white_check_mark: | :x: | :x: <sub><sup>[*9](#some-explanations-on-the-comparaison-matrix)</sub></sup> | :white_check_mark: | :x: |
-| [Execution Environment Customization](#execution-environment-customization) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*10](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
-| [Multi-Tenancy](#multi-tenancy) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*11](#some-explanations-on-the-comparaison-matrix)</sub></sup> | 
-| [Command Line Interface (cdsctl): 100% features supported & User Friendly](#command-line-interface-cdsctl-100-features-supported) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: <sub><sup>[*12](#some-explanations-on-the-comparaison-matrix)</sub></sup> | 
+| [Continuous Deployment & Environment Support](#continuous-deployment--environment-support) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*5](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Enterprise-grade permissions, Support of ACLs delegation](#enterprise-grade-permissions--support-of-acls-delegation) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*6](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Build Artifacts Cloud](#build-artifacts-cloud) | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*7](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Tests & Vulnerabilities Reports](#tests--vulnerabilities-reports) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: <sub><sup>[*8](#some-explanations-on-the-comparison-matrix)</sub></sup> | :white_check_mark: |
+| [Self-Service Project Creation - ability to create a tenant](#self-service-project-creation) | :white_check_mark: | :x: | :x: <sub><sup>[*9](#some-explanations-on-the-comparison-matrix)</sub></sup> | :white_check_mark: | :x: |
+| [Execution Environment Customization](#execution-environment-customization) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*10](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Multi-Tenancy](#multi-tenancy) | :white_check_mark: | :x: | :x: | :white_check_mark: | :x: <sub><sup>[*11](#some-explanations-on-the-comparison-matrix)</sub></sup> |
+| [Command Line Interface (cdsctl): 100% features supported & User Friendly](#command-line-interface-cdsctl-100-features-supported) | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: <sub><sup>[*12](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 | [REST API & SDK](#rest-api--sdk) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Self-Hosting](#self-hosting) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [High Availability & Scalability & Upgrade without User Downtime](#high-availability--scalability--upgrade-without-user-downtime) | :white_check_mark: | :x: | :x: | :white_check_mark: <sub><sup>[*13](#some-explanations-on-the-comparaison-matrix)</sub></sup> | :x: | 
-| [Built-in Metrics](#built-in-metrics) | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: <sub><sup>[*14](#some-explanations-on-the-comparaison-matrix)</sub></sup> |
+| [High Availability & Scalability & Upgrade without User Downtime](#high-availability--scalability--upgrade-without-user-downtime) | :white_check_mark: | :x: | :x: | :white_check_mark: <sub><sup>[*13](#some-explanations-on-the-comparison-matrix)</sub></sup> | :x: |
+| [Built-in Metrics](#built-in-metrics) | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :x: <sub><sup>[*14](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 | [Extensibility Plugins](#extensibility-plugins) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [OS/Arch Compatibility](#osarch-compatibility) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [Auto-Scale OnDemand multi-cloud](#auto-scale-ondemand-multi-cloud) | :white_check_mark: | :x: | :x: | :x: <sub><sup>[*15](#some-explanations-on-the-comparaison-matrix)</sub></sup> | :x: <sub><sup>[*16](#some-explanations-on-the-comparaison-matrix)</sub></sup> | 
+| [Auto-Scale OnDemand multi-cloud](#auto-scale-ondemand-multi-cloud) | :white_check_mark: | :x: | :x: | :x: <sub><sup>[*15](#some-explanations-on-the-comparison-matrix)</sub></sup> | :x: <sub><sup>[*16](#some-explanations-on-the-comparison-matrix)</sub></sup> |
 
 
 ### CDS User features
@@ -168,12 +168,12 @@ Doc: https://ovh.github.io/cds/cli/worker/cache/
 
 #### Enterprise Notification Bus
 
-As an Enterprise-Grade platform, CDS can send a wide range of its internal events (e.g. build finished) in an event bus. 
+As an Enterprise-Grade platform, CDS can send a wide range of its internal events (e.g. build finished) in an event bus.
 This event flow can then feed other services (reporting, notifications, etc., ).
 
 #### Built-in Hooks
 
-Ability to launch a workflow manually or with git pushes or via a scheduler or via a webhook. 
+Ability to launch a workflow manually or with git pushes or via a scheduler or via a webhook.
 In addition to the above, CDS can also be triggered using an event bus to (kafka or RabbitMQ).
 
 #### Continuous Deployment & Environment Support
@@ -263,7 +263,7 @@ Thus, you can have hundreds of workers model and when necessary, CDS will start 
 
 A [hatchery](https://ovh.github.io/cds/hatchery/) is like an incubator, it gives birth to the CDS Workers and the right of life and death over them.
 
-Several types of hatchery are available: 
+Several types of hatchery are available:
 
  - **[hatchery kubernetes](https://ovh.github.io/cds/hatchery/kubernetes/)** starts workers in pods
  - **[hatchery openstack](https://ovh.github.io/cds/hatchery/openstack/)** starts virtual machines
@@ -271,7 +271,7 @@ Several types of hatchery are available:
  - **[hatchery marathon](https://ovh.github.io/cds/hatchery/marathon/)** starts docker containers
  - **[hatchery VSphere](https://ovh.github.io/cds/hatchery/vsphere/)** starts virtual machines
  - **[hatchery local](https://ovh.github.io/cds/hatchery/local/)** starts processes on a host
- 
+
  So yes, buzzwords or not, a multi-cloud Auto-scale OnDemand is a reality with CDS :-)
 
 #### Some explanations on the comparison matrix
@@ -288,13 +288,12 @@ Several types of hatchery are available:
 - *10 docker only
 - *11 explained on https://www.cloudbees.com/blog/multi-tenancy-jenkins
 - *12 https://jenkins.io/doc/book/managing/cli/
-- *13 Upgrade Gitlab can be on several days https://docs.gitlab.com/ee/update/ 
+- *13 Upgrade Gitlab can be on several days https://docs.gitlab.com/ee/update/
 - *14 it's a plugin
-- *15 K8s, Docker machine & GKE only 
+- *15 K8s, Docker machine & GKE only
 - *16 limited to about 150 executors https://www.cloudbees.com/blog/multi-tenancy-jenkins(§Scale)
 
 
 ## License
 
 [3-clause BSD](./LICENCE)
-


### PR DESCRIPTION
1. Description
Comparison matrix uses wrong anchors.
**Note**: other parts of the readme file has been updated as well due to the `.editorconfig` rules.

1. Related issues
none.

1. About tests
none.

1. Mentions
none.

@ovh/cds
