### PR TITLE
Add auth parsing to hatchery-k8s

### DIFF
--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+  _ "k8s.io/client-go/plugin/pkg/client/auth"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/ovh/cds/engine/api"


### PR DESCRIPTION
Adds the auth parsing to the k8s go-client so user's who are using hosted solutions can use the `kubeconfig.yaml` files!

NOTE: I haven't actually tested this, just added this in from lots and lots of reading! :)

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
