### PR TITLE
fix(cdsctl): rename duplicated file arg for template bulk cmd

### DIFF
--- a/cli/cdsctl/template_bulk.go
+++ b/cli/cdsctl/template_bulk.go
@@ -46,9 +46,8 @@ var templateBulkCmd = cli.Command{
 			Default: "",
 		},
 		{
-			Name:      "file",
-			ShortHand: "f",
-			Usage:     "Specify path|url of a json|yaml file that contains instances with params",
+			Name:  "instances-file",
+			Usage: "Specify path|url of a json|yaml file that contains instances with params",
 		},
 		{
 			Type:      cli.FlagBool,
@@ -331,7 +330,7 @@ func templateBulkRun(v cli.Values) error {
 	}
 
 	// validate data from file
-	filePath := v.GetString("file")
+	filePath := v.GetString("instances-file")
 	wtFromFile, fileOperations, err := templateExtractAndValidateFileParams(filePath)
 	if err != nil {
 		return err

--- a/docs/static/images/workflow_template_bulk.cast
+++ b/docs/static/images/workflow_template_bulk.cast
@@ -244,7 +244,7 @@
 [58.884835, "o", "e"]
 [59.749469, "o", "\u001b[?1l\u001b>"]
 [59.749647, "o", "\u001b[?2004l\r\r\n"]
-[59.75067, "o", "\u001b]2;cdsctl template bulk -f instances.yml --track --no-interactive\u0007\u001b]1;cdsctl\u0007"]
+[59.75067, "o", "\u001b]2;cdsctl template bulk --instances-file instances.yml --track --no-interactive\u0007\u001b]1;cdsctl\u0007"]
 [60.038244, "o", "Bulk request with id 98 successfully created for template shared.infra/example-simple with 2 operations\r\n"]
 [60.138665, "o", "\r                                                                                                                            \rDEMO/demo1 -> \u001b[33mprocessing\u001b[0m \r\nDEMO/demo2 -> \u001b[34mpending\u001b[0m \r\n"]
 [60.655449, "o", "\r                                                                                                                            \u001b[1F\r                                                                                                                            \u001b[1F\r                                                                                                                            \rDEMO/demo1 -> \u001b[32mdone\u001b[0m \r\nDEMO/demo2 -> \u001b[32mdone\u001b[0m \r\n"]

--- a/tests/clictl_template_bulk.yml
+++ b/tests/clictl_template_bulk.yml
@@ -14,7 +14,7 @@ testcases:
 
 - name: sendTemplateBulkRequest
   steps:
-  - script: {{.cds.build.cdsctl}} template bulk --file ./tests/fixtures/template/bulk_request.yml --no-interactive
+  - script: {{.cds.build.cdsctl}} template bulk --instances-file ./tests/fixtures/template/bulk_request.yml --no-interactive
     assertions:
       - result.code ShouldEqual 0
     extracts:


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
