### PR TITLE
(fix)Helm chart : bad indenting in persistent volumes of elasticsearch-deployment.yaml

### DIFF
--- a/contrib/helm/cds/templates/elasticsearch-deployment.yaml
+++ b/contrib/helm/cds/templates/elasticsearch-deployment.yaml
@@ -64,8 +64,8 @@ spec:
           containerPort: 8084
           volumeMounts:
           - name: cds-repos-data
-      mountPath: {{ .Values.repositories.persistence.mountPath }}
-  volumes:
-  - name: cds-repos-data
-    persistentVolumeClaim:
-      claimName: {{ (printf "%s-elasticsearch" (include "cds.fullname" .)) }}
+            mountPath: {{ .Values.repositories.persistence.mountPath }}
+    volumes:
+    - name: cds-repos-data
+      persistentVolumeClaim:
+        claimName: {{ (printf "%s-elasticsearch" (include "cds.fullname" .)) }}


### PR DESCRIPTION
The bad indentation breakes the elasticsearch-deployment.yaml deployment in the Helm chart

@ovh/cds
