### PR TITLE
fix: go mod tidy and gofmt -s

### DIFF
--- a/contrib/grpcplugins/action/group-tmpl/plugin_test.go
+++ b/contrib/grpcplugins/action/group-tmpl/plugin_test.go
@@ -136,7 +136,7 @@ func TestGetConfigByApplication(t *testing.T) {
 		{
 			apps: &Applications{
 				Apps: map[string]map[string]interface{}{
-					"test": map[string]interface{}{
+					"test": {
 						"a": 1,
 						"b": 2,
 						"c": 3,
@@ -157,7 +157,7 @@ func TestGetConfigByApplication(t *testing.T) {
 					"c": 43,
 				},
 				Apps: map[string]map[string]interface{}{
-					"test": map[string]interface{}{
+					"test": {
 						"a": 1,
 						"c": 3,
 					},

--- a/contrib/grpcplugins/action/kafka-publish/cli.go
+++ b/contrib/grpcplugins/action/kafka-publish/cli.go
@@ -22,14 +22,14 @@ func initCli(mainFunc func()) *cli.App {
 		BashComplete: cli.DefaultAppComplete,
 		Writer:       os.Stdout,
 		Commands: []cli.Command{
-			cli.Command{
+			{
 				Name:      "help",
 				Aliases:   []string{"h"},
 				Usage:     "Shows a list of commands or help for one command",
 				ArgsUsage: "[command]",
 				Action:    helpAction,
 			},
-			cli.Command{
+			{
 				Name:      "listen",
 				Aliases:   []string{"l"},
 				Usage:     "Listen a Kafka topic and wait for chunks",
@@ -58,7 +58,7 @@ func initCli(mainFunc func()) *cli.App {
 				},
 				Action: listenAction,
 			},
-			cli.Command{
+			{
 				Name:      "ack",
 				Usage:     "Send Ack to CDS",
 				ArgsUsage: "<kafka> <topic> <user> <cds-action json file> <OK|KO>",

--- a/engine/api/action_test.go
+++ b/engine/api/action_test.go
@@ -67,7 +67,7 @@ func Test_postActionImportHandler(t *testing.T) {
 			},
 		},
 		Parameters: map[string]exportentities.ParameterValue{
-			"param1": exportentities.ParameterValue{
+			"param1": {
 				Description:  "this is my param",
 				DefaultValue: "default value",
 			},

--- a/engine/api/environment/environment_importer_test.go
+++ b/engine/api/environment/environment_importer_test.go
@@ -65,17 +65,17 @@ func TestImportInto_Variable(t *testing.T) {
 		Name:      "testenv2",
 		ProjectID: proj.ID,
 		Variable: []sdk.Variable{
-			sdk.Variable{
+			{
 				Name:  "v1",
 				Type:  sdk.TextVariable,
 				Value: "value1bis",
 			},
-			sdk.Variable{
+			{
 				Name:  "v2",
 				Type:  sdk.StringVariable,
 				Value: "value2bis",
 			},
-			sdk.Variable{
+			{
 				Name:  "v3",
 				Type:  sdk.StringVariable,
 				Value: "value3",

--- a/engine/api/migrate/permissions_test.go
+++ b/engine/api/migrate/permissions_test.go
@@ -9,19 +9,19 @@ import (
 
 func Test_mergePermissions(t *testing.T) {
 	gps1 := []sdk.GroupPermission{
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 1,
 			},
 			Permission: 5,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 2,
 			},
 			Permission: 3,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 55,
 			},
@@ -29,19 +29,19 @@ func Test_mergePermissions(t *testing.T) {
 		},
 	}
 	gps2 := []sdk.GroupPermission{
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 1,
 			},
 			Permission: 3,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 2,
 			},
 			Permission: 7,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 66,
 			},
@@ -68,13 +68,13 @@ func Test_mergePermissions(t *testing.T) {
 
 func Test_diffPermissions(t *testing.T) {
 	gps1 := []sdk.GroupPermission{
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 1,
 			},
 			Permission: 5,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 2,
 			},
@@ -82,19 +82,19 @@ func Test_diffPermissions(t *testing.T) {
 		},
 	}
 	gps2 := []sdk.GroupPermission{
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 1,
 			},
 			Permission: 3,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 2,
 			},
 			Permission: 7,
 		},
-		sdk.GroupPermission{
+		{
 			Group: sdk.Group{
 				ID: 66,
 			},

--- a/engine/api/notification.go
+++ b/engine/api/notification.go
@@ -11,7 +11,7 @@ import (
 func (api *API) getUserNotificationTypeHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		return service.WriteJSON(w, map[string]sdk.UserNotificationSettings{
-			sdk.EmailUserNotification: sdk.UserNotificationSettings{
+			sdk.EmailUserNotification: {
 				OnSuccess:    sdk.UserNotificationChange,
 				OnFailure:    sdk.UserNotificationAlways,
 				OnStart:      &sdk.False,
@@ -19,7 +19,7 @@ func (api *API) getUserNotificationTypeHandler() service.Handler {
 				SendToGroups: &sdk.False,
 				Template:     &sdk.UserNotificationTemplateEmail,
 			},
-			sdk.JabberUserNotification: sdk.UserNotificationSettings{
+			sdk.JabberUserNotification: {
 				OnSuccess:    sdk.UserNotificationChange,
 				OnFailure:    sdk.UserNotificationAlways,
 				OnStart:      &sdk.False,

--- a/engine/api/pipeline/pipeline_importer_test.go
+++ b/engine/api/pipeline/pipeline_importer_test.go
@@ -100,11 +100,11 @@ func TestImportUpdate(t *testing.T) {
 			args.pip.ProjectKey = proj.Key
 			test.NoError(t, pipeline.InsertPipeline(db, cache, proj, args.pip, nil))
 			args.pip.Stages = []sdk.Stage{
-				sdk.Stage{
+				{
 					BuildOrder: 1,
 					Enabled:    true,
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: false,
 							Action: sdk.Action{
 								Name:        "Job 1",
@@ -156,7 +156,7 @@ func TestImportUpdate(t *testing.T) {
 					BuildOrder: 2,
 					Enabled:    true,
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: false,
 							Action: sdk.Action{
 								Name:        "Job 1",
@@ -281,13 +281,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the first stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -301,13 +301,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the second stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -370,13 +370,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the first stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -390,13 +390,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the second stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -454,13 +454,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the first stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -474,13 +474,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the second stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -531,13 +531,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the first stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",
@@ -551,13 +551,13 @@ func TestImportUpdate(t *testing.T) {
 					PipelineID: args.pip.ID,
 					Name:       "This is the second stage. It has 2 jobs",
 					Jobs: []sdk.Job{
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°1",
 							},
 						},
-						sdk.Job{
+						{
 							Enabled: true,
 							Action: sdk.Action{
 								Name: "Job n°2",

--- a/engine/api/pipeline_stage_test.go
+++ b/engine/api/pipeline_stage_test.go
@@ -350,11 +350,11 @@ func TestInsertAndLoadPipelineWith1StageWithoutPrerequisiteAnd1StageWith2Prerequ
 		BuildOrder: 2,
 		Enabled:    true,
 		Prerequisites: []sdk.Prerequisite{
-			sdk.Prerequisite{
+			{
 				Parameter:     ".git.branch",
 				ExpectedValue: "master",
 			},
-			sdk.Prerequisite{
+			{
 				Parameter:     ".git.author",
 				ExpectedValue: "someone@somewhere.com",
 			},
@@ -457,7 +457,7 @@ func TestDeleteStageByIDShouldDeleteStagePrerequisites(t *testing.T) {
 		BuildOrder: 1,
 		Enabled:    true,
 		Prerequisites: []sdk.Prerequisite{
-			sdk.Prerequisite{
+			{
 				Parameter:     ".git.branch",
 				ExpectedValue: "master",
 			},
@@ -515,7 +515,7 @@ func TestUpdateStageShouldUpdateStagePrerequisites(t *testing.T) {
 		BuildOrder: 1,
 		Enabled:    true,
 		Prerequisites: []sdk.Prerequisite{
-			sdk.Prerequisite{
+			{
 				Parameter:     ".git.branch",
 				ExpectedValue: "master",
 			},
@@ -527,11 +527,11 @@ func TestUpdateStageShouldUpdateStagePrerequisites(t *testing.T) {
 	test.NoError(t, pipeline.InsertStage(api.mustDB(), stage))
 
 	stage.Prerequisites = []sdk.Prerequisite{
-		sdk.Prerequisite{
+		{
 			Parameter:     "param1",
 			ExpectedValue: "value1",
 		},
-		sdk.Prerequisite{
+		{
 			Parameter:     "param2",
 			ExpectedValue: "value2",
 		},

--- a/engine/api/repositories_manager.go
+++ b/engine/api/repositories_manager.go
@@ -75,9 +75,9 @@ func (api *API) repositoriesManagerAuthorizeHandler() service.Handler {
 			"project_key":          proj.Key,
 			"last_modified":        strconv.FormatInt(time.Now().Unix(), 10),
 			"repositories_manager": rmName,
-			"url":           url,
-			"request_token": token,
-			"username":      deprecatedGetUser(ctx).Username,
+			"url":                  url,
+			"request_token":        token,
+			"username":             deprecatedGetUser(ctx).Username,
 		}
 
 		api.Cache.Set(cache.Key("reposmanager", "oauth", token), data)

--- a/engine/api/worker_model_test.go
+++ b/engine/api/worker_model_test.go
@@ -178,7 +178,7 @@ func Test_WorkerModelUsage(t *testing.T) {
 			Name:    "NewAction",
 			Enabled: true,
 			Requirements: []sdk.Requirement{
-				sdk.Requirement{
+				{
 					Name:  "Test1" + grName,
 					Type:  sdk.ModelRequirement,
 					Value: "Test1" + grName,

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -303,7 +303,7 @@ func TestInsertComplexeWorkflowAndExport(t *testing.T) {
 								PipelineID: pip4.ID,
 								Conditions: sdk.WorkflowNodeConditions{
 									PlainConditions: []sdk.WorkflowNodeCondition{
-										sdk.WorkflowNodeCondition{
+										{
 											Operator: "eq",
 											Value:    "master",
 											Variable: ".git.branch",

--- a/engine/api/workflow/execute_node_run.go
+++ b/engine/api/workflow/execute_node_run.go
@@ -430,13 +430,13 @@ func addJobsToQueue(ctx context.Context, db gorp.SqlExecutor, stage *sdk.Stage, 
 				spawnInfos.Args = append(spawnInfos.Args, sdk.Cause(e).Error())
 			}
 
-			wjob.SpawnInfos = []sdk.SpawnInfo{sdk.SpawnInfo{
+			wjob.SpawnInfos = []sdk.SpawnInfo{{
 				APITime:    time.Now(),
 				Message:    spawnInfos,
 				RemoteTime: time.Now(),
 			}}
 		} else {
-			wjob.SpawnInfos = []sdk.SpawnInfo{sdk.SpawnInfo{
+			wjob.SpawnInfos = []sdk.SpawnInfo{{
 				APITime:    time.Now(),
 				Message:    sdk.SpawnMsg{ID: sdk.MsgSpawnInfoJobInQueue.ID},
 				RemoteTime: time.Now(),

--- a/engine/api/workflow/hook_test.go
+++ b/engine/api/workflow/hook_test.go
@@ -22,15 +22,15 @@ func Test_mergeAndDiffHook(t *testing.T) {
 			name: "one to update",
 			args: args{
 				oldHooks: map[string]sdk.WorkflowNodeHook{
-					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+					"my-uuid-a": {Ref: "AAA", UUID: "my-uuid-a"},
 				},
 				newHooks: map[string]sdk.WorkflowNodeHook{
-					"my-uuid-b": sdk.WorkflowNodeHook{Ref: "BBB"},
-					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+					"my-uuid-b": {Ref: "BBB"},
+					"my-uuid-a": {Ref: "AAA", UUID: "my-uuid-a"},
 				},
 			},
 			wantHookToUpdate: map[string]sdk.WorkflowNodeHook{
-				"my-uuid-b": sdk.WorkflowNodeHook{Ref: "BBB"},
+				"my-uuid-b": {Ref: "BBB"},
 			},
 			wantHookToDelete: map[string]sdk.WorkflowNodeHook{},
 		},
@@ -38,13 +38,13 @@ func Test_mergeAndDiffHook(t *testing.T) {
 			name: "one delete",
 			args: args{
 				oldHooks: map[string]sdk.WorkflowNodeHook{
-					"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+					"my-uuid-a": {Ref: "AAA", UUID: "my-uuid-a"},
 				},
 				newHooks: map[string]sdk.WorkflowNodeHook{},
 			},
 			wantHookToUpdate: map[string]sdk.WorkflowNodeHook{},
 			wantHookToDelete: map[string]sdk.WorkflowNodeHook{
-				"my-uuid-a": sdk.WorkflowNodeHook{Ref: "AAA", UUID: "my-uuid-a"},
+				"my-uuid-a": {Ref: "AAA", UUID: "my-uuid-a"},
 			},
 		},
 	}

--- a/engine/api/workflow/run_workflow_test.go
+++ b/engine/api/workflow/run_workflow_test.go
@@ -479,7 +479,7 @@ func TestManualRun3(t *testing.T) {
 
 		//AddSpawnInfosNodeJobRun
 		err := workflow.AddSpawnInfosNodeJobRun(db, j.ID, []sdk.SpawnInfo{
-			sdk.SpawnInfo{
+			{
 				APITime:    time.Now(),
 				RemoteTime: time.Now(),
 				Message: sdk.SpawnMsg{
@@ -495,7 +495,7 @@ func TestManualRun3(t *testing.T) {
 
 		//TakeNodeJobRun
 		j, _, _ = workflow.TakeNodeJobRun(context.TODO(), func() *gorp.DbMap { return db }, db, cache, proj, j.ID, "model", "worker", "1", []sdk.SpawnInfo{
-			sdk.SpawnInfo{
+			{
 				APITime:    time.Now(),
 				RemoteTime: time.Now(),
 				Message: sdk.SpawnMsg{

--- a/engine/api/workflow/workflow_parser_test.go
+++ b/engine/api/workflow/workflow_parser_test.go
@@ -60,21 +60,21 @@ func TestParseAndImport(t *testing.T) {
 			input: &exportentities.Workflow{
 				Name: "test-1",
 				Workflow: map[string]exportentities.NodeEntry{
-					"root": exportentities.NodeEntry{
+					"root": {
 						PipelineName: "pipeline",
 					},
-					"first": exportentities.NodeEntry{
+					"first": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"root"},
 					},
-					"second": exportentities.NodeEntry{
+					"second": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"first"},
 					},
-					"fork": exportentities.NodeEntry{
+					"fork": {
 						DependsOn: []string{"root"},
 					},
-					"third": exportentities.NodeEntry{
+					"third": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"fork"},
 					},

--- a/engine/api/workflow_export_test.go
+++ b/engine/api/workflow_export_test.go
@@ -193,7 +193,7 @@ func Test_getWorkflowExportHandlerWithPermissions(t *testing.T) {
 		ProjectKey:    proj.Key,
 		HistoryLength: 25,
 		Groups: []sdk.GroupPermission{
-			sdk.GroupPermission{
+			{
 				Group:      *group2,
 				Permission: 7,
 			},

--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-  _ "k8s.io/client-go/plugin/pkg/client/auth"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/ovh/cds/engine/api"

--- a/engine/hatchery/kubernetes/services.go
+++ b/engine/hatchery/kubernetes/services.go
@@ -58,7 +58,7 @@ func (h *HatcheryKubernetes) getServicesLogs() error {
 				WorkflowNodeJobRunID:   serviceJobID,
 				ServiceRequirementID:   reqServiceID,
 				ServiceRequirementName: subsStr[0][2],
-				Val: string(logs),
+				Val:                    string(logs),
 			})
 		}
 	}

--- a/engine/hatchery/swarm/swarm_util_logs.go
+++ b/engine/hatchery/swarm/swarm_util_logs.go
@@ -71,7 +71,7 @@ func (h *HatcherySwarm) getServicesLogs() error {
 					WorkflowNodeJobRunID:   serviceJobID,
 					ServiceRequirementID:   reqServiceID,
 					ServiceRequirementName: cnt.Labels["service_req_name"],
-					Val: string(logs),
+					Val:                    string(logs),
 				})
 			}
 

--- a/engine/vcs/gitlab/gitlab.go
+++ b/engine/vcs/gitlab/gitlab.go
@@ -37,14 +37,14 @@ type gitlabConsumer struct {
 // New instanciate a new gitlab consumer
 func New(appID, clientSecret, URL, callbackURL, uiURL, proxyURL string, store cache.Store, disableStatus bool, disableStatusDetail bool) sdk.VCSServer {
 	return &gitlabConsumer{
-		URL:    URL,
-		secret: clientSecret,
-		cache:  store,
-		appID:  appID,
+		URL:                      URL,
+		secret:                   clientSecret,
+		cache:                    store,
+		appID:                    appID,
 		AuthorizationCallbackURL: callbackURL,
-		uiURL:               uiURL,
-		proxyURL:            proxyURL,
-		disableStatus:       disableStatus,
-		disableStatusDetail: disableStatusDetail,
+		uiURL:                    uiURL,
+		proxyURL:                 proxyURL,
+		disableStatus:            disableStatus,
+		disableStatusDetail:      disableStatusDetail,
 	}
 }

--- a/engine/worker/builtin_checkout_application.go
+++ b/engine/worker/builtin_checkout_application.go
@@ -34,8 +34,8 @@ func runCheckoutApplication(w *currentWorker) BuiltInAction {
 		var opts = &git.CloneOpts{
 			Recursive:               true,
 			NoStrictHostKeyChecking: true,
-			Depth: 50,
-			Tag:   tag,
+			Depth:                   50,
+			Tag:                     tag,
 		}
 		if branch != nil {
 			opts.Branch = branch.Value

--- a/engine/worker/builtin_gitclone.go
+++ b/engine/worker/builtin_gitclone.go
@@ -160,8 +160,8 @@ func runGitClone(w *currentWorker) BuiltInAction {
 		var opts = &git.CloneOpts{
 			Recursive:               true,
 			NoStrictHostKeyChecking: true,
-			Depth: 50,
-			Tag:   tag,
+			Depth:                   50,
+			Tag:                     tag,
 		}
 		if branch != nil {
 			opts.Branch = branch.Value

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/SermoDigital/jose v0.9.1 // indirect
 	github.com/Shopify/sarama v1.17.0
 	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
-	github.com/aokoli/goutils v1.0.1
 	github.com/araddon/gou v0.0.0-20180315155215-820e9f87cd05 // indirect
 	github.com/armon/consul-api v0.0.0-20150107205647-dcfedd50ed53 // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
@@ -125,7 +124,6 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/howeyc/gopass v0.0.0-20160303200116-66487b23f288
-	github.com/huandu/xstrings v0.0.0-20170908061042-d6590c0c31d1
 	github.com/imdario/mergo v0.0.0-20180119215619-163f41321a19 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -184,6 +182,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.1 // indirect
 	github.com/opencontainers/selinux v1.0.0-rc1 // indirect
 	github.com/ory-am/common v0.4.0 // indirect
+	github.com/ovh/cds/sdk/interpolate v0.0.0-20190319104452-71125b036b25
 	github.com/ovh/go-ovh v0.0.0-20171219162654-02f7e9439689 // indirect
 	github.com/ovh/venom v0.25.0
 	github.com/ovhlabs/izanami-go-client v0.0.0-20180321094556-73dedd898473
@@ -280,6 +279,8 @@ require (
 	k8s.io/apimachinery v0.0.0-20190223094358-dcb391cde5ca
 	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/klog v0.2.0 // indirect
+	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 
 )

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/Shopify/sarama v1.17.0 h1:Y2/FBwElFVwt7aLKL3fDG6hh+rrlywR6uLgTgKObwTc
 github.com/Shopify/sarama v1.17.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.3+incompatible h1:awiJqUYH4q4OmoBiRccJykjd7B+w0loJi2keSna4X/M=
 github.com/Shopify/toxiproxy v2.1.3+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
-github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
+github.com/aokoli/goutils v1.1.0 h1:jy4ghdcYvs5EIoGssZNslIASX5m+KNMfyyKvRQ0TEVE=
+github.com/aokoli/goutils v1.1.0/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/araddon/gou v0.0.0-20180315155215-820e9f87cd05 h1:MbFvRvOzFRujpuBALUI/2ll9+8PYi23cEp/DSQFEBfU=
 github.com/araddon/gou v0.0.0-20180315155215-820e9f87cd05/go.mod h1:ikc1XA58M+Rx7SEbf0bLJCfBkwayZ8T5jBo5FXK8Uz8=
 github.com/armon/consul-api v0.0.0-20150107205647-dcfedd50ed53 h1:8pC6As6jhkrfhotKRkEYqlaSekpGFu1NzQbhutWHVFw=
@@ -266,8 +266,8 @@ github.com/howeyc/gopass v0.0.0-20160303200116-66487b23f288 h1:oxyyMKe4Tdb237jLU
 github.com/howeyc/gopass v0.0.0-20160303200116-66487b23f288/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huandu/xstrings v0.0.0-20170908061042-d6590c0c31d1 h1:5sbhABS5wzLMXC69upO+ZpwdP3z+O9OszTijhBKLOh4=
-github.com/huandu/xstrings v0.0.0-20170908061042-d6590c0c31d1/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
+github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
+github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/imdario/mergo v0.0.0-20180119215619-163f41321a19 h1:geJOJJZwkYI1yqxWrAMcgrwDvy4P1XyNNgIyN9d6UXc=
 github.com/imdario/mergo v0.0.0-20180119215619-163f41321a19/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
@@ -399,6 +399,8 @@ github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory-am/common v0.4.0 h1:edGPoxYX4hno0IJHXh9TCMUPR6ZcJp+y6aClFYxeuUE=
 github.com/ory-am/common v0.4.0/go.mod h1:oCYGuwwM8FyYMKqh9vrhBaeUoyz/edx0bgJN6uS6/+k=
+github.com/ovh/cds/sdk/interpolate v0.0.0-20190319104452-71125b036b25 h1:pV462fyYKs6YRXCrj5OI0OgA6wVWSiQmtG8SAJdT1WQ=
+github.com/ovh/cds/sdk/interpolate v0.0.0-20190319104452-71125b036b25/go.mod h1:qrsz1nc0EPZnhuTLZpKK4Y7awUQdeKmkY5M6DbKi6Ws=
 github.com/ovh/go-ovh v0.0.0-20171219162654-02f7e9439689 h1:x9UmLJfoTojbsVpUh0sOpU42p7FqhlzaHKWj6Kcf6ew=
 github.com/ovh/go-ovh v0.0.0-20171219162654-02f7e9439689/go.mod h1:joRatxRJaZBsY3JAOEMcoOp05CnZzsx4scTxi95DHyQ=
 github.com/ovh/venom v0.25.0 h1:q0NC8KHuG1UoWNYXqhZUM/VbOnS8ciQJr6Afn230OIw=
@@ -632,5 +634,9 @@ k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUr
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=
+labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/sdk/cdsclient/client.go
+++ b/sdk/cdsclient/client.go
@@ -63,8 +63,8 @@ func New(c Config) Interface {
 // NewService returns client for a service
 func NewService(endpoint string, timeout time.Duration, insecureSkipVerifyTLS bool) Interface {
 	conf := Config{
-		Host:  endpoint,
-		Retry: 2,
+		Host:                  endpoint,
+		Retry:                 2,
 		InsecureSkipVerifyTLS: insecureSkipVerifyTLS,
 	}
 	cli := new(client)

--- a/sdk/cdsclient/client_project.go
+++ b/sdk/cdsclient/client_project.go
@@ -15,7 +15,7 @@ func (c *client) ProjectCreate(p *sdk.Project, groupName string) error {
 	if groupName != "" {
 		// if the group does not exist, POST /project will create it
 		p.ProjectGroups = []sdk.GroupPermission{
-			sdk.GroupPermission{
+			{
 				Group:      sdk.Group{Name: groupName},
 				Permission: permission.PermissionReadWriteExecute,
 			},

--- a/sdk/exportentities/workflow_test.go
+++ b/sdk/exportentities/workflow_test.go
@@ -14,21 +14,21 @@ import (
 
 func TestWorkflow_checkDependencies(t *testing.T) {
 	type fields struct {
-		Name                string
-		Description         string
-		Version             string
-		Workflow            map[string]NodeEntry
-		Hooks               map[string][]HookEntry
-		DependsOn           []string
-		Conditions          *sdk.WorkflowNodeConditions
-		When                []string
-		PipelineName        string
-		ApplicationName     string
-		EnvironmentName     string
+		Name                   string
+		Description            string
+		Version                string
+		Workflow               map[string]NodeEntry
+		Hooks                  map[string][]HookEntry
+		DependsOn              []string
+		Conditions             *sdk.WorkflowNodeConditions
+		When                   []string
+		PipelineName           string
+		ApplicationName        string
+		EnvironmentName        string
 		ProjectIntegrationName string
-		PipelineHooks       []HookEntry
-		Permissions         map[string]int
-		HistoryLength       int64
+		PipelineHooks          []HookEntry
+		Permissions            map[string]int
+		HistoryLength          int64
 	}
 	tests := []struct {
 		name    string
@@ -55,10 +55,10 @@ func TestWorkflow_checkDependencies(t *testing.T) {
 			name: "Complex Workflow with a dependency should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline",
 					},
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"root"},
 					},
@@ -70,18 +70,18 @@ func TestWorkflow_checkDependencies(t *testing.T) {
 			name: "Complex Workflow with a dependencies and a join should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline",
 					},
-					"first-child": NodeEntry{
-						PipelineName: "pipeline",
-						DependsOn:    []string{"root"},
-					},
-					"second-child": NodeEntry{
+					"first-child": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"root"},
 					},
-					"third-child": NodeEntry{
+					"second-child": {
+						PipelineName: "pipeline",
+						DependsOn:    []string{"root"},
+					},
+					"third-child": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"first-child", "second-child"},
 					},
@@ -93,20 +93,20 @@ func TestWorkflow_checkDependencies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := Workflow{
-				Name:                tt.fields.Name,
-				Description:         tt.fields.Description,
-				Version:             tt.fields.Version,
-				Workflow:            tt.fields.Workflow,
-				Hooks:               tt.fields.Hooks,
-				DependsOn:           tt.fields.DependsOn,
-				Conditions:          tt.fields.Conditions,
-				When:                tt.fields.When,
-				PipelineName:        tt.fields.PipelineName,
-				ApplicationName:     tt.fields.ApplicationName,
-				EnvironmentName:     tt.fields.EnvironmentName,
+				Name:                   tt.fields.Name,
+				Description:            tt.fields.Description,
+				Version:                tt.fields.Version,
+				Workflow:               tt.fields.Workflow,
+				Hooks:                  tt.fields.Hooks,
+				DependsOn:              tt.fields.DependsOn,
+				Conditions:             tt.fields.Conditions,
+				When:                   tt.fields.When,
+				PipelineName:           tt.fields.PipelineName,
+				ApplicationName:        tt.fields.ApplicationName,
+				EnvironmentName:        tt.fields.EnvironmentName,
 				ProjectIntegrationName: tt.fields.ProjectIntegrationName,
-				PipelineHooks:       tt.fields.PipelineHooks,
-				Permissions:         tt.fields.Permissions,
+				PipelineHooks:          tt.fields.PipelineHooks,
+				Permissions:            tt.fields.Permissions,
 			}
 			if err := w.checkDependencies(); (err != nil) != tt.wantErr {
 				t.Errorf("Workflow.checkDependencies() error = %v, wantErr %v", err, tt.wantErr)
@@ -117,19 +117,19 @@ func TestWorkflow_checkDependencies(t *testing.T) {
 
 func TestWorkflow_checkValidity(t *testing.T) {
 	type fields struct {
-		Name                string
-		Version             string
-		Workflow            map[string]NodeEntry
-		Hooks               map[string][]HookEntry
-		DependsOn           []string
-		Conditions          *sdk.WorkflowNodeConditions
-		When                []string
-		PipelineName        string
-		ApplicationName     string
-		EnvironmentName     string
+		Name                   string
+		Version                string
+		Workflow               map[string]NodeEntry
+		Hooks                  map[string][]HookEntry
+		DependsOn              []string
+		Conditions             *sdk.WorkflowNodeConditions
+		When                   []string
+		PipelineName           string
+		ApplicationName        string
+		EnvironmentName        string
 		ProjectIntegrationName string
-		PipelineHooks       []HookEntry
-		Permissions         map[string]int
+		PipelineHooks          []HookEntry
+		Permissions            map[string]int
 	}
 	tests := []struct {
 		name    string
@@ -141,10 +141,10 @@ func TestWorkflow_checkValidity(t *testing.T) {
 			fields: fields{
 				PipelineName: "pipeline",
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline",
 					},
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"root"},
 					},
@@ -156,10 +156,10 @@ func TestWorkflow_checkValidity(t *testing.T) {
 			name: "Should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline",
 					},
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"root"},
 					},
@@ -178,19 +178,19 @@ func TestWorkflow_checkValidity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := Workflow{
-				Name:                tt.fields.Name,
-				Version:             tt.fields.Version,
-				Workflow:            tt.fields.Workflow,
-				Hooks:               tt.fields.Hooks,
-				DependsOn:           tt.fields.DependsOn,
-				Conditions:          tt.fields.Conditions,
-				When:                tt.fields.When,
-				PipelineName:        tt.fields.PipelineName,
-				ApplicationName:     tt.fields.ApplicationName,
-				EnvironmentName:     tt.fields.EnvironmentName,
+				Name:                   tt.fields.Name,
+				Version:                tt.fields.Version,
+				Workflow:               tt.fields.Workflow,
+				Hooks:                  tt.fields.Hooks,
+				DependsOn:              tt.fields.DependsOn,
+				Conditions:             tt.fields.Conditions,
+				When:                   tt.fields.When,
+				PipelineName:           tt.fields.PipelineName,
+				ApplicationName:        tt.fields.ApplicationName,
+				EnvironmentName:        tt.fields.EnvironmentName,
 				ProjectIntegrationName: tt.fields.ProjectIntegrationName,
-				PipelineHooks:       tt.fields.PipelineHooks,
-				Permissions:         tt.fields.Permissions,
+				PipelineHooks:          tt.fields.PipelineHooks,
+				Permissions:            tt.fields.Permissions,
 			}
 			if err := w.checkValidity(); (err != nil) != tt.wantErr {
 				t.Errorf("Workflow.checkValidity() error = %v, wantErr %v", err, tt.wantErr)
@@ -201,21 +201,21 @@ func TestWorkflow_checkValidity(t *testing.T) {
 
 func TestWorkflow_GetWorkflow(t *testing.T) {
 	type fields struct {
-		Name                string
-		Description         string
-		Version             string
-		Workflow            map[string]NodeEntry
-		Hooks               map[string][]HookEntry
-		DependsOn           []string
-		Conditions          *sdk.WorkflowNodeConditions
-		When                []string
-		PipelineName        string
-		ApplicationName     string
-		EnvironmentName     string
+		Name                   string
+		Description            string
+		Version                string
+		Workflow               map[string]NodeEntry
+		Hooks                  map[string][]HookEntry
+		DependsOn              []string
+		Conditions             *sdk.WorkflowNodeConditions
+		When                   []string
+		PipelineName           string
+		ApplicationName        string
+		EnvironmentName        string
 		ProjectIntegrationName string
-		PipelineHooks       []HookEntry
-		Permissions         map[string]int
-		HistoryLength       int64
+		PipelineHooks          []HookEntry
+		Permissions            map[string]int
+		HistoryLength          int64
 	}
 	tsts := []struct {
 		name    string
@@ -276,10 +276,10 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Complexe workflow without joins should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline-root",
 					},
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline-child",
 						DependsOn:    []string{"root"},
 						OneAtATime:   &True,
@@ -318,10 +318,10 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Complexe workflow without joins with a default payload on a non root node should raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline-root",
 					},
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline-child",
 						DependsOn:    []string{"root"},
 						Payload: map[string]interface{}{
@@ -338,11 +338,11 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Complexe workflow unordered without joins should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"child": NodeEntry{
+					"child": {
 						PipelineName: "pipeline-child",
 						DependsOn:    []string{"root"},
 					},
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline-root",
 					},
 				},
@@ -380,14 +380,14 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Complexe workflow without joins should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"root": NodeEntry{
+					"root": {
 						PipelineName: "pipeline-root",
 					},
-					"first": NodeEntry{
+					"first": {
 						PipelineName: "pipeline-child",
 						DependsOn:    []string{"root"},
 					},
-					"second": NodeEntry{
+					"second": {
 						PipelineName: "pipeline-child",
 						DependsOn:    []string{"first"},
 					},
@@ -440,36 +440,36 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Complexe workflow with joins should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"A": NodeEntry{
+					"A": {
 						PipelineName: "pipeline",
 					},
-					"B": NodeEntry{
-						PipelineName: "pipeline",
-						DependsOn:    []string{"A"},
-					},
-					"C": NodeEntry{
+					"B": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"A"},
 					},
-					"D": NodeEntry{
+					"C": {
+						PipelineName: "pipeline",
+						DependsOn:    []string{"A"},
+					},
+					"D": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"B", "C"},
 					},
-					"E": NodeEntry{
+					"E": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"B", "C"},
 					},
-					"F": NodeEntry{
+					"F": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"B", "C"},
 					},
-					"G": NodeEntry{
+					"G": {
 						PipelineName: "pipeline",
 						DependsOn:    []string{"D", "E"},
 					},
 				},
 				Hooks: map[string][]HookEntry{
-					"A": []HookEntry{
+					"A": {
 						{
 							Model: "Scheduler",
 							Config: map[string]string{
@@ -605,7 +605,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 		{
 			name: "Complex workflow with integration should not raise an error",
 			fields: fields{
-				PipelineName:        "pipeline",
+				PipelineName:           "pipeline",
 				ProjectIntegrationName: "integration",
 			},
 			wantErr: false,
@@ -617,7 +617,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 						Ref:  "pipeline",
 						Type: "pipeline",
 						Context: &sdk.NodeContext{
-							PipelineName:        "pipeline",
+							PipelineName:           "pipeline",
 							ProjectIntegrationName: "integration",
 						},
 					},
@@ -628,10 +628,10 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			name: "Root and a outgoing hook should not raise an error",
 			fields: fields{
 				Workflow: map[string]NodeEntry{
-					"A": NodeEntry{
+					"A": {
 						PipelineName: "pipeline",
 					},
-					"B": NodeEntry{
+					"B": {
 						OutgoingHookModelName: "webhook",
 						OutgoingHookConfig: map[string]string{
 							"url": "https://www.ovh.com",
@@ -677,21 +677,21 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 	for _, tt := range tsts {
 		t.Run(tt.name, func(t *testing.T) {
 			w := Workflow{
-				Name:                tt.fields.Name,
-				Description:         tt.fields.Description,
-				Version:             tt.fields.Version,
-				Workflow:            tt.fields.Workflow,
-				Hooks:               tt.fields.Hooks,
-				DependsOn:           tt.fields.DependsOn,
-				Conditions:          tt.fields.Conditions,
-				When:                tt.fields.When,
-				PipelineName:        tt.fields.PipelineName,
-				ApplicationName:     tt.fields.ApplicationName,
-				EnvironmentName:     tt.fields.EnvironmentName,
+				Name:                   tt.fields.Name,
+				Description:            tt.fields.Description,
+				Version:                tt.fields.Version,
+				Workflow:               tt.fields.Workflow,
+				Hooks:                  tt.fields.Hooks,
+				DependsOn:              tt.fields.DependsOn,
+				Conditions:             tt.fields.Conditions,
+				When:                   tt.fields.When,
+				PipelineName:           tt.fields.PipelineName,
+				ApplicationName:        tt.fields.ApplicationName,
+				EnvironmentName:        tt.fields.EnvironmentName,
 				ProjectIntegrationName: tt.fields.ProjectIntegrationName,
-				PipelineHooks:       tt.fields.PipelineHooks,
-				Permissions:         tt.fields.Permissions,
-				HistoryLength:       &tt.fields.HistoryLength,
+				PipelineHooks:          tt.fields.PipelineHooks,
+				Permissions:            tt.fields.Permissions,
+				HistoryLength:          &tt.fields.HistoryLength,
 			}
 			got, err := w.GetWorkflow()
 			if (err != nil) != tt.wantErr {

--- a/sdk/log/hook/gelf.go
+++ b/sdk/log/hook/gelf.go
@@ -65,7 +65,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 
 	// merge serialized message + serialized extra map
 	b[len(b)-1] = ','
-	return append(b, eb[1:len(eb)]...), nil
+	return append(b, eb[1:]...), nil
 }
 
 func (m *Message) UnmarshalJSON(data []byte) error {

--- a/sdk/log/hook/hook.go
+++ b/sdk/log/hook/hook.go
@@ -258,7 +258,7 @@ func (hook *Hook) messageFromEntry(entry *logrus.Entry, file string, line int) *
 		Host:     hook.Hostname,
 		Short:    short,
 		Full:     full,
-		Time:     float64(entry.Time.UnixNano()) / 1E9,
+		Time:     float64(entry.Time.UnixNano()) / 1e9,
 		Level:    int32(priorities[entry.Level]),
 		Pid:      hook.pid,
 		Facility: hook.Facility,

--- a/sdk/log/hook/tcp.go
+++ b/sdk/log/hook/tcp.go
@@ -88,7 +88,7 @@ func (w *TCPWriter) Write(p []byte) (int, error) {
 		Host:     w.Hostname,
 		Short:    string(short),
 		Full:     string(full),
-		Time:     float64(time.Now().UnixNano()) / 1E9,
+		Time:     float64(time.Now().UnixNano()) / 1e9,
 		Level:    6, // info
 		Facility: w.Facility,
 		File:     file,

--- a/sdk/log/hook/udp.go
+++ b/sdk/log/hook/udp.go
@@ -209,7 +209,7 @@ func (w *UDPWriter) Write(p []byte) (n int, err error) {
 		Host:     w.hostname,
 		Short:    string(short),
 		Full:     string(full),
-		Time:     float64(time.Now().UnixNano()) / 1E9,
+		Time:     float64(time.Now().UnixNano()) / 1e9,
 		Level:    6, // info
 		Facility: w.Facility,
 		File:     file,

--- a/sdk/parameter_test.go
+++ b/sdk/parameter_test.go
@@ -42,11 +42,11 @@ func TestParameterMapMerge_WithExcludeGitParams(t *testing.T) {
 
 func TestParametersMerge(t *testing.T) {
 	original := []Parameter{
-		Parameter{Name: "test", Value: "value1"},
-		Parameter{Name: "default", Value: "ok"},
+		{Name: "test", Value: "value1"},
+		{Name: "default", Value: "ok"},
 	}
 	override := []Parameter{
-		Parameter{Name: "test", Value: "override"},
+		{Name: "test", Value: "override"},
 	}
 
 	res := ParametersMerge(original, override)


### PR DESCRIPTION
This makes Go 1.12's mod tidy happy.

And gofmt -s can remove lots of unnecessary redundant types, helping
readability.