### PR TITLE
feat(vcs): update github vcs provider to use github enterprise

### DIFF
--- a/engine/vcs/github/client_rate_limit.go
+++ b/engine/vcs/github/client_rate_limit.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"encoding/json"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ovh/cds/sdk"
@@ -24,6 +26,10 @@ func (g *githubClient) RateLimit() error {
 	if err != nil {
 		log.Warning("githubClient.RateLimit> Error %s", err)
 		return err
+	}
+	// If the GitHub instance does not have Rate Limitting enabled you will see a 404.
+	if status == http.StatusNotFound && strings.Contains(string(body), "Rate limiting is not enabled.") {
+		return nil
 	}
 	if status >= 400 {
 		return sdk.NewError(sdk.ErrUnknownError, errorAPI(body))

--- a/engine/vcs/github/github.go
+++ b/engine/vcs/github/github.go
@@ -1,12 +1,15 @@
 package github
 
 import (
+	"fmt"
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/sdk"
 )
 
 // githubClient is a github.com wrapper for CDS vcs. interface
 type githubClient struct {
+	GitHubURL           string
+	GitHubAPIURL        string
 	ClientID            string
 	OAuthToken          string
 	DisableStatus       bool
@@ -24,6 +27,8 @@ type githubConsumer struct {
 	ClientID            string `json:"client-id"`
 	ClientSecret        string `json:"-"`
 	Cache               cache.Store
+	GitHubURL           string
+	GitHubAPIURL        string
 	uiURL               string
 	apiURL              string
 	proxyURL            string
@@ -34,10 +39,29 @@ type githubConsumer struct {
 }
 
 //New creates a new GithubConsumer
-func New(ClientID, ClientSecret string, apiURL, uiURL, proxyURL, username, token string, store cache.Store, disableStatus, disableStatusDetail bool) sdk.VCSServer {
+func New(ClientID, ClientSecret, githubURL, githubAPIURL, apiURL, uiURL, proxyURL, username, token string, store cache.Store, disableStatus, disableStatusDetail bool) sdk.VCSServer {
+	//Github const
+	const (
+		URL    = "https://github.com"
+		APIURL = "https://api.github.com"
+	)
+	// if the github GitHubURL is passed as an empty string default it to public GitHub
+	if githubURL == "" {
+		githubURL = URL
+	}
+	// if the githubAPIURL is empty first check if githubURL was passed in, if not set to default
+	if githubAPIURL == "" {
+		if githubURL == "" {
+			githubAPIURL = APIURL
+		} else {
+			githubAPIURL = fmt.Sprintf("%s/api/v3", githubURL)
+		}
+	}
 	return &githubConsumer{
 		ClientID:            ClientID,
 		ClientSecret:        ClientSecret,
+		GitHubURL:           githubURL,
+		GitHubAPIURL:        githubAPIURL,
 		Cache:               store,
 		apiURL:              apiURL,
 		uiURL:               uiURL,

--- a/engine/vcs/github/github.go
+++ b/engine/vcs/github/github.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"fmt"
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/sdk"
 )
@@ -42,20 +41,16 @@ type githubConsumer struct {
 func New(ClientID, ClientSecret, githubURL, githubAPIURL, apiURL, uiURL, proxyURL, username, token string, store cache.Store, disableStatus, disableStatusDetail bool) sdk.VCSServer {
 	//Github const
 	const (
-		URL    = "https://github.com"
-		APIURL = "https://api.github.com"
+		publicURL    = "https://github.com"
+		publicAPIURL = "https://api.github.com"
 	)
-	// if the github GitHubURL is passed as an empty string default it to public GitHub
+	// if the githubURL is passed as an empty string default it to public GitHub
 	if githubURL == "" {
-		githubURL = URL
+		githubURL = publicURL
 	}
-	// if the githubAPIURL is empty first check if githubURL was passed in, if not set to default
+	// if the githubAPIURL is passed as an empty string default it to public GitHub
 	if githubAPIURL == "" {
-		if githubURL == "" {
-			githubAPIURL = APIURL
-		} else {
-			githubAPIURL = fmt.Sprintf("%s/api/v3", githubURL)
-		}
+		githubAPIURL = publicAPIURL
 	}
 	return &githubConsumer{
 		ClientID:            ClientID,

--- a/engine/vcs/github/http.go
+++ b/engine/vcs/github/http.go
@@ -31,7 +31,7 @@ var (
 func (g *githubConsumer) postForm(path string, data url.Values, headers map[string][]string) (int, []byte, error) {
 	body := strings.NewReader(data.Encode())
 
-	req, err := http.NewRequest(http.MethodPost, URL+path, body)
+	req, err := http.NewRequest(http.MethodPost, g.GitHubURL+path, body)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -122,8 +122,8 @@ func (c *githubClient) post(path string, bodyType string, body io.Reader, opts *
 	if opts == nil {
 		opts = new(postOptions)
 	}
-	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, APIURL) {
-		path = APIURL + path
+	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, c.GitHubAPIURL) {
+		path = c.GitHubAPIURL + path
 	}
 
 	req, err := http.NewRequest(http.MethodPost, path, body)
@@ -149,8 +149,8 @@ func (c *githubClient) patch(path string, opts *postOptions) (*http.Response, er
 	if opts == nil {
 		opts = new(postOptions)
 	}
-	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, APIURL) {
-		path = APIURL + path
+	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, c.GitHubAPIURL) {
+		path = c.GitHubAPIURL + path
 	}
 
 	req, err := http.NewRequest(http.MethodPatch, path, nil)
@@ -175,8 +175,8 @@ func (c *githubClient) put(path string, bodyType string, body io.Reader, opts *p
 	if opts == nil {
 		opts = new(postOptions)
 	}
-	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, APIURL) {
-		path = APIURL + path
+	if !opts.skipDefaultBaseURL && !strings.HasPrefix(path, c.GitHubAPIURL) {
+		path = c.GitHubAPIURL + path
 	}
 
 	req, err := http.NewRequest(http.MethodPut, path, body)
@@ -203,8 +203,8 @@ func (c *githubClient) get(path string, opts ...getArgFunc) (int, []byte, http.H
 		return 0, nil, nil, ErrorRateLimit
 	}
 
-	if !strings.HasPrefix(path, APIURL) {
-		path = APIURL + path
+	if !strings.HasPrefix(path, c.GitHubAPIURL) {
+		path = c.GitHubAPIURL + path
 	}
 
 	callURL, err := url.ParseRequestURI(path)
@@ -229,7 +229,7 @@ func (c *githubClient) get(path string, opts ...getArgFunc) (int, []byte, http.H
 		}
 	}
 
-	log.Debug("Github API>> Request URL %s", req.URL.String())
+	log.Debug("Github API>> Request GitHubURL %s", req.URL.String())
 
 	res, err := httpClient.Do(req)
 	if err != nil {
@@ -275,8 +275,8 @@ func (c *githubClient) delete(path string) error {
 		return ErrorRateLimit
 	}
 
-	if !strings.HasPrefix(path, APIURL) {
-		path = APIURL + path
+	if !strings.HasPrefix(path, c.GitHubAPIURL) {
+		path = c.GitHubAPIURL + path
 	}
 
 	req, err := http.NewRequest(http.MethodDelete, path, nil)

--- a/engine/vcs/github/oauth_consumer.go
+++ b/engine/vcs/github/oauth_consumer.go
@@ -12,17 +12,11 @@ import (
 )
 
 //Github const
-const (
-	URL    = "https://github.com"
-	APIURL = "https://api.github.com"
-)
-
-//Github const
 var (
 	requestedScope = []string{"user:email", "repo", "admin:repo_hook"} //https://developer.github.com/v3/oauth/#scopes
 )
 
-//AuthorizeRedirect returns the request token, the Authorize URL
+//AuthorizeRedirect returns the request token, the Authorize GitHubURL
 //doc: https://developer.github.com/v3/oauth/#web-application-flow
 func (g *githubConsumer) AuthorizeRedirect(ctx context.Context) (string, string, error) {
 	// GET https://github.com/login/oauth/authorize
@@ -38,7 +32,7 @@ func (g *githubConsumer) AuthorizeRedirect(ctx context.Context) (string, string,
 	val.Add("scope", strings.Join(requestedScope, " "))
 	val.Add("state", requestToken)
 
-	authorizeURL := fmt.Sprintf("%s/login/oauth/authorize?%s", URL, val.Encode())
+	authorizeURL := fmt.Sprintf("%s/login/oauth/authorize?%s", g.GitHubURL, val.Encode())
 
 	return requestToken, authorizeURL, nil
 }
@@ -93,6 +87,8 @@ func (g *githubConsumer) GetAuthorizedClient(ctx context.Context, accessToken, a
 		c = &githubClient{
 			ClientID:            g.ClientID,
 			OAuthToken:          accessToken,
+			GitHubURL:           g.GitHubURL,
+			GitHubAPIURL:        g.GitHubAPIURL,
 			Cache:               g.Cache,
 			uiURL:               g.uiURL,
 			DisableStatus:       g.disableStatus,

--- a/engine/vcs/types.go
+++ b/engine/vcs/types.go
@@ -55,6 +55,7 @@ type ServerConfiguration struct {
 type GithubServerConfiguration struct {
 	ClientID     string `toml:"clientId" json:"-" comment:"#######\n CDS <-> Github. Documentation on https://ovh.github.io/cds/hosting/repositories-manager/github/ \n#######\n Github OAuth Application Client ID"`
 	ClientSecret string `toml:"clientSecret" json:"-"  comment:"Github OAuth Application Client Secret"`
+	APIURL       string `toml:"apiUrl" json:"-" comment:"The URL for the GitHub API."`
 	Status       struct {
 		Disable    bool `toml:"disable" default:"false" commented:"true" comment:"Set to true if you don't want CDS to push statuses on the VCS server" json:"disable"`
 		ShowDetail bool `toml:"showDetail" default:"false" commented:"true" comment:"Set to true if you don't want CDS to push CDS URL in statuses on the VCS server" json:"show_detail"`

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -78,6 +78,8 @@ func (s *Service) getConsumer(name string) (sdk.VCSServer, error) {
 		return github.New(
 			serverCfg.Github.ClientID,
 			serverCfg.Github.ClientSecret,
+			serverCfg.URL,
+			serverCfg.Github.APIURL,
 			s.Cfg.API.HTTP.URL,
 			s.Cfg.UI.HTTP.URL,
 			serverCfg.Github.ProxyWebhook,

--- a/engine/vcs/vcs_handlers_test.go
+++ b/engine/vcs/vcs_handlers_test.go
@@ -114,13 +114,17 @@ func Test_getAllVCSServersHandler(t *testing.T) {
 }
 
 func Test_accessTokenAuth(t *testing.T) {
+	cfg := test.LoadTestingConf(t)
+
 	//Bootstrap the service
 	s, err := newTestService(t)
 	test.NoError(t, err)
 
+	checkConfigGithub(cfg, t)
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     "client_id",
 			ClientSecret: "client_secret",
 		},
@@ -156,8 +160,9 @@ func Test_getReposHandler(t *testing.T) {
 
 	checkConfigGithub(cfg, t)
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -195,8 +200,9 @@ func Test_getRepoHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -206,8 +212,8 @@ func Test_getRepoHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":  "github",
-		"owner": "ovh",
-		"repo":  "cds",
+		"owner": cfg["githubOwner"],
+		"repo":  cfg["githubRepo"],
 	}
 	uri := s.Router.GetRoute("GET", s.getRepoHandler, vars)
 	test.NotEmpty(t, uri)
@@ -236,8 +242,9 @@ func Test_getBranchesHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -247,8 +254,8 @@ func Test_getBranchesHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":  "github",
-		"owner": "ovh",
-		"repo":  "cds",
+		"owner": cfg["githubOwner"],
+		"repo":  cfg["githubRepo"],
 	}
 	uri := s.Router.GetRoute("GET", s.getBranchesHandler, vars)
 	test.NotEmpty(t, uri)
@@ -277,8 +284,9 @@ func Test_getBranchHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -288,14 +296,14 @@ func Test_getBranchHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":  "github",
-		"owner": "ovh",
-		"repo":  "cds",
+		"owner": cfg["githubOwner"],
+		"repo":  cfg["githubRepo"],
 	}
 	uri := s.Router.GetRoute("GET", s.getBranchHandler, vars)
 	test.NotEmpty(t, uri)
 	req := newRequest(t, s, "GET", uri, nil)
 	q := req.URL.Query()
-	q.Set("branch", "vcs/old-code")
+	q.Set("branch", cfg["githubBranch"])
 	req.URL.RawQuery = q.Encode()
 
 	token := base64.StdEncoding.EncodeToString([]byte(cfg["githubAccessToken"]))
@@ -321,8 +329,9 @@ func Test_getCommitsHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -332,15 +341,16 @@ func Test_getCommitsHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":  "github",
-		"owner": "fsamin",
-		"repo":  "go-dump",
+		"owner": cfg["githubCommitOwner"],
+		"repo":  cfg["githubCommitRepo"],
 	}
+
 	uri := s.Router.GetRoute("GET", s.getCommitsHandler, vars)
 	test.NotEmpty(t, uri)
 	req := newRequest(t, s, "GET", uri, nil)
 	q := req.URL.Query()
-	q.Set("since", "61dc819dc47bc6b556b2c4e1293f919d492f1f5a")
-	q.Set("branch", "fsamin/fix-2017-07-28-10-07-56")
+	q.Set("since", cfg["githubCommitSince"])
+	q.Set("branch", cfg["githubCommitBranch"])
 	req.URL.RawQuery = q.Encode()
 
 	token := base64.StdEncoding.EncodeToString([]byte(cfg["githubAccessToken"]))
@@ -366,8 +376,9 @@ func Test_getCommitHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -377,9 +388,9 @@ func Test_getCommitHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":   "github",
-		"owner":  "ovh",
-		"repo":   "cds",
-		"commit": "a38dfc7cc835aadf6a112e8a540dd52cca79cc29",
+		"owner":  cfg["githubOwner"],
+		"repo":   cfg["githubRepo"],
+		"commit": cfg["githubCommit"],
 	}
 	uri := s.Router.GetRoute("GET", s.getCommitHandler, vars)
 	test.NotEmpty(t, uri)
@@ -408,8 +419,9 @@ func Test_getCommitStatusHandler(t *testing.T) {
 	checkConfigGithub(cfg, t)
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 		},
@@ -419,9 +431,9 @@ func Test_getCommitStatusHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":   "github",
-		"owner":  "ovh",
-		"repo":   "cds",
-		"commit": "a38dfc7cc835aadf6a112e8a540dd52cca79cc29",
+		"owner":  cfg["githubOwner"],
+		"repo":   cfg["githubRepo"],
+		"commit": cfg["githubCommit"],
 	}
 	uri := s.Router.GetRoute("GET", s.getCommitStatusHandler, vars)
 	test.NotEmpty(t, uri)
@@ -443,6 +455,37 @@ func Test_getCommitStatusHandler(t *testing.T) {
 }
 
 func checkConfigGithub(cfg map[string]string, t *testing.T) {
+	if cfg["githubURL"] == "" {
+		cfg["githubURL"] = "https://github.com"
+	}
+	if cfg["githubAPIURL"] == "" {
+		cfg["githubAPIURL"] = "https://api.github.com"
+	}
+	if cfg["githubRepo"] == "" {
+		cfg["githubRepo"] = "cds"
+	}
+	if cfg["githubOwner"] == "" {
+		cfg["githubOwner"] = "ovh"
+	}
+	if cfg["githubBranch"] == "" {
+		cfg["githubBranch"] = "gh-pages"
+	}
+	if cfg["githubCommit"] == "" {
+		cfg["githubCommit"] = "a38dfc7cc835aadf6a112e8a540dd52cca79cc29"
+	}
+	if cfg["githubCommitOwner"] == "" {
+		cfg["githubCommitOwner"] = "fsamin"
+	}
+	if cfg["githubCommitRepo"] == "" {
+		cfg["githubCommitRepo"] = "go-dump"
+	}
+	if cfg["githubCommitSince"] == "" {
+		cfg["githubCommitSince"] = "6e06b7fed23aeed808b4d60e8a085f9b9c4b45af"
+	}
+	if cfg["githubCommitBranch"] == "" {
+		cfg["githubCommitBranch"] = "master"
+	}
+
 	if cfg["githubClientID"] == "" || cfg["githubClientSecret"] == "" {
 		log.Debug("Skip Github Test - no configuration")
 		t.SkipNow()
@@ -461,8 +504,9 @@ func Test_postRepoGrantHandler(t *testing.T) {
 	t.Logf("Testing grant with %s", cfg["githubUsername"])
 
 	err = s.addServerConfiguration("github", ServerConfiguration{
-		URL: "https://github.com",
+		URL: cfg["githubURL"],
 		Github: &GithubServerConfiguration{
+			APIURL:       cfg["githubAPIURL"],
 			ClientID:     cfg["githubClientID"],
 			ClientSecret: cfg["githubClientSecret"],
 			Username:     cfg["githubUsername"],
@@ -474,8 +518,8 @@ func Test_postRepoGrantHandler(t *testing.T) {
 	//Prepare request
 	vars := map[string]string{
 		"name":  "github",
-		"owner": "fsamin",
-		"repo":  "go-dump",
+		"owner": cfg["githubCommitOwner"],
+		"repo":  cfg["githubCommitRepo"],
 	}
 	uri := s.Router.GetRoute("POST", s.postRepoGrantHandler, vars)
 	test.NotEmpty(t, uri)


### PR DESCRIPTION
1. Description: The existing GitHub VCS provider only allows functionality to public GitHub where the BitBucket and GitLab allow for custom URLs. This aims to fix this by using the URL config for GitHub as well as adding an APIURL config option so enterprises with custom endpoints can use this as well.
1. Related issues : None
1. About tests: Have not added additional tests, am open to suggestions about how to best test the changes.
1. Mentions
@ovh/cds
