### PR TITLE
fix(api,ui,repositories): as-code migration

### DIFF
--- a/engine/api/workflow/as_code.go
+++ b/engine/api/workflow/as_code.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ovh/cds/engine/api/application"
 	"github.com/ovh/cds/engine/api/cache"
+	"github.com/ovh/cds/engine/api/event"
 	"github.com/ovh/cds/engine/api/repositoriesmanager"
 	"github.com/ovh/cds/engine/api/services"
 	"github.com/ovh/cds/sdk"
@@ -121,8 +122,8 @@ func CheckPullRequestStatus(ctx context.Context, client sdk.VCSAuthorizedClient,
 	return pr.Merged, pr.Closed, nil
 }
 
-// CheckAsCodeEvent checks if workflow as to become ascode
-func SyncAsCodeEvent(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, wf *sdk.Workflow) error {
+// SyncAsCodeEvent checks if workflow as to become ascode
+func SyncAsCodeEvent(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *sdk.Project, wf *sdk.Workflow, u *sdk.User) error {
 	if len(wf.AsCodeEvent) == 0 {
 		return nil
 	}
@@ -166,6 +167,7 @@ func SyncAsCodeEvent(ctx context.Context, db gorp.SqlExecutor, store cache.Store
 		}
 	}
 	wf.AsCodeEvent = eventLeft
+	event.PublishWorkflowUpdate(proj.Key, *wf, *wf, u)
 	return nil
 }
 

--- a/engine/api/workflow_ascode.go
+++ b/engine/api/workflow_ascode.go
@@ -55,25 +55,13 @@ func (api *API) postWorkflowAsCodeHandler() service.Handler {
 			return sdk.WrapError(errW, "unable to load workflow")
 		}
 
-		// Workflow must have a repository webhook on root node
-		found := false
-		for _, h := range wf.WorkflowData.Node.Hooks {
-			if h.HookModelName == sdk.RepositoryWebHookModel.Name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return sdk.NewErrorFrom(sdk.ErrWrongRequest, "Root node must have a repository web hook")
-		}
-
 		// Sync as code event
 		if len(wf.AsCodeEvent) > 0 {
 			tx, err := api.mustDB().Begin()
 			if err != nil {
 				return sdk.WrapError(err, "unable to start transaction")
 			}
-			if err := workflow.SyncAsCodeEvent(ctx, tx, api.Cache, proj, wf); err != nil {
+			if err := workflow.SyncAsCodeEvent(ctx, tx, api.Cache, proj, wf, u); err != nil {
 				tx.Rollback() // nolint
 				return err
 			}

--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -865,7 +865,7 @@ func (api *API) initWorkflowRun(ctx context.Context, db *gorp.DbMap, cache cache
 				report.Merge(r1, nil) // nolint
 				return
 			}
-			if err := workflow.SyncAsCodeEvent(ctx, tx, cache, p, wf); err != nil {
+			if err := workflow.SyncAsCodeEvent(ctx, tx, cache, p, wf, u); err != nil {
 				tx.Rollback() // nolint
 				r1 := failInitWorkflowRun(ctx, db, wfRun, sdk.WrapError(err, "unable to sync as code event"))
 				report.Merge(r1, nil) // nolint

--- a/engine/repositories/processor_common.go
+++ b/engine/repositories/processor_common.go
@@ -28,7 +28,8 @@ func (s *Service) processGitClone(op *sdk.Operation) (repo.Repo, string, string,
 	gitRepo, err := repo.New(r.Basedir, opts...)
 	if err != nil {
 		log.Info("Repositories> processGitClone> cloning %s into %s", r.URL, r.Basedir)
-		if _, err = repo.Clone(r.Basedir, r.URL, opts...); err != nil {
+		gitRepo, err = repo.Clone(r.Basedir, r.URL, opts...)
+		if err != nil {
 			log.Error("Repositories> processGitClone> Clone> [%s] error %v", op.UUID, err)
 			return gitRepo, "", "", err
 		}
@@ -39,6 +40,7 @@ func (s *Service) processGitClone(op *sdk.Operation) (repo.Repo, string, string,
 		log.Error("Repositories> processGitClone> gitRepo.FetchURL> [%s] Error: %v", op.UUID, err)
 		return gitRepo, "", "", err
 	}
+
 	d, err := gitRepo.DefaultBranch()
 	if err != nil {
 		log.Error("Repositories> processGitClone> DefaultBranch> [%s] Error: %v", op.UUID, err)

--- a/ui/src/app/app.service.ts
+++ b/ui/src/app/app.service.ts
@@ -260,7 +260,7 @@ export class AppService {
         this.store.selectOnce(WorkflowsState)
             .pipe(filter((wfs) => wfs != null))
             .subscribe((wfs: WorkflowsStateModel) => {
-                const wfKey = event.project_key + '-' + event.workflow_name;
+                const wfKey = `${event.project_key}/${event.workflow_name}`;
                 if (!wfs || !wfs.workflows || !wfs.workflows[wfKey]) {
                     return;
                 }


### PR DESCRIPTION
* automatically add repository web hook on as-code migration
* publish workflow event on ascodeEventSync to update UI on ascodeEvent updates
* first gitclone failed on ascode migration
* update UI workflow cache

related to #4170
