### PR TITLE
fix(vcs): inverted base and head refs for bitbucket pull requests

### DIFF
--- a/engine/api/workflow/workflow_run_event.go
+++ b/engine/api/workflow/workflow_run_event.go
@@ -330,7 +330,7 @@ func sendVCSEventStatus(ctx context.Context, db gorp.SqlExecutor, store cache.St
 						log.Error("sendVCSEventStatus> unable to send PR report%v", err)
 						return nil
 					}
-					// if we found the pull request for head branch we can't break (only one PR for the branch should exist)
+					// if we found the pull request for head branch we can break (only one PR for the branch should exist)
 					break
 				}
 			}

--- a/engine/api/workflow/workflow_run_event.go
+++ b/engine/api/workflow/workflow_run_event.go
@@ -325,11 +325,13 @@ func sendVCSEventStatus(ctx context.Context, db gorp.SqlExecutor, store cache.St
 		//Send comment on pull request
 		if nodeRun.Status == sdk.StatusFail.String() || nodeRun.Status == sdk.StatusStopped.String() {
 			for _, pr := range prs {
-				if pr.Head.Branch.DisplayID == nodeRun.VCSBranch && pr.Head.Branch.LatestCommit == nodeRun.VCSHash {
+				if pr.Head.Branch.DisplayID == nodeRun.VCSBranch && pr.Head.Branch.LatestCommit == nodeRun.VCSHash && !pr.Merged && !pr.Closed {
 					if err := client.PullRequestComment(ctx, app.RepositoryFullname, pr.ID, report); err != nil {
 						log.Error("sendVCSEventStatus> unable to send PR report%v", err)
 						return nil
 					}
+					// if we found the pull request for head branch we can't break (only one PR for the branch should exist)
+					break
 				}
 			}
 		}

--- a/engine/vcs/bitbucket/client_pull_request.go
+++ b/engine/vcs/bitbucket/client_pull_request.go
@@ -135,21 +135,26 @@ func (b *bitbucketClient) PullRequestCreate(ctx context.Context, repo string, pr
 
 func (b *bitbucketClient) ToVCSPullRequest(ctx context.Context, repo string, pullRequest PullRequest) (sdk.VCSPullRequest, error) {
 	pr := sdk.VCSPullRequest{
-		ID: pullRequest.ID,
+		ID:     pullRequest.ID,
+		Closed: pullRequest.Closed,
+		Merged: pullRequest.State == "MERGED",
+		Base: sdk.VCSPushEvent{
+			Branch: sdk.VCSBranch{
+				ID:           strings.Replace(pullRequest.ToRef.ID, "refs/heads/", "", 1),
+				DisplayID:    pullRequest.ToRef.DisplayID,
+				LatestCommit: pullRequest.ToRef.LatestCommit,
+			},
+		},
+		Head: sdk.VCSPushEvent{
+			Branch: sdk.VCSBranch{
+				ID:           strings.Replace(pullRequest.FromRef.ID, "refs/heads/", "", 1),
+				DisplayID:    pullRequest.FromRef.DisplayID,
+				LatestCommit: pullRequest.FromRef.LatestCommit,
+			},
+		},
 	}
 	if len(pullRequest.Links.Self) > 0 {
 		pr.URL = pullRequest.Links.Self[0].Href
-	}
-
-	pr.Base = sdk.VCSPushEvent{
-		Branch: sdk.VCSBranch{
-			ID: strings.Replace(pullRequest.ToRef.ID, "refs/heads/", "", 1),
-		},
-	}
-	pr.Head = sdk.VCSPushEvent{
-		Branch: sdk.VCSBranch{
-			ID: strings.Replace(pullRequest.FromRef.ID, "refs/heads/", "", 1),
-		},
 	}
 	if pullRequest.Author != nil {
 		pr.User = sdk.VCSAuthor{
@@ -159,19 +164,5 @@ func (b *bitbucketClient) ToVCSPullRequest(ctx context.Context, repo string, pul
 		}
 	}
 
-	pr.Base.Branch = sdk.VCSBranch{
-		ID:           pullRequest.FromRef.ID,
-		DisplayID:    pullRequest.FromRef.DisplayID,
-		LatestCommit: pullRequest.FromRef.LatestCommit,
-	}
-
-	pr.Head.Branch = sdk.VCSBranch{
-		ID:           pullRequest.ToRef.ID,
-		DisplayID:    pullRequest.ToRef.DisplayID,
-		LatestCommit: pullRequest.ToRef.LatestCommit,
-	}
-
-	pr.Closed = pullRequest.Closed
-	pr.Merged = pullRequest.State == "MERGED"
 	return pr, nil
 }


### PR DESCRIPTION
1. Description
Refs were inverted when translating bitbucket PR to CDS PR.
Before this fix, comments on PR can't work for bitbucket.
Also if current node branch is the repo default branch this will create many comments on all PRs.
In addition because there should be only on PR for a given branch, we can stop to iterate over PRs when the PR was found.

1. Related issues
1. About tests
1. Mentions

@ovh/cds
