### PR TITLE
fix(worker): fetch given hash only if branch or tag info not given

### DIFF
--- a/sdk/vcs/git/git_clone.go
+++ b/sdk/vcs/git/git_clone.go
@@ -85,10 +85,11 @@ func prepareGitCloneCommands(repo string, path string, opts *CloneOpts) (string,
 	allCmd = append(allCmd, gitcmd)
 
 	// if a specific commit hash is given, try to reset current repo to this commit
+	// when a tag is given the commit hash is ignored
 	if opts != nil && opts.CheckoutCommit != "" && opts.Tag == "" {
-		// if no branch or tag given, this means that we cloned the repo on the default branch, we need to fetch the target commit hash
+		// if no branch was given, this means that we cloned the repo on the default branch, we need to fetch the target commit hash
 		// fetching a specific commit hash will not work for old git version (1.7 for example)
-		if opts.Branch == "" && opts.Tag == "" {
+		if opts.Branch == "" {
 			fetchCmd := cmd{
 				cmd:  "git",
 				args: []string{"fetch", "origin", opts.CheckoutCommit},
@@ -105,13 +106,13 @@ func prepareGitCloneCommands(repo string, path string, opts *CloneOpts) (string,
 			allCmd = append(allCmd, fetchCmd)
 		}
 
-		// even if we cloned the right branch or tag, we need to reset to the given commit hash that could be different than HEAD
+		// even if we cloned the right branch, we need to reset to the given commit hash that could be different than HEAD
 		resetCmd := cmd{
 			cmd:  "git",
 			args: []string{"reset", "--hard", opts.CheckoutCommit},
 		}
 		userLogCommand += "\n\rExecuting: git " + strings.Join(resetCmd.args, " ")
-		//Locate the git reset cmd to the right directory
+		// locate the git reset cmd to the right directory
 		if path == "" {
 			t := strings.Split(repo, "/")
 			resetCmd.dir = strings.TrimSuffix(t[len(t)-1], ".git")

--- a/sdk/vcs/git/git_clone.go
+++ b/sdk/vcs/git/git_clone.go
@@ -84,22 +84,28 @@ func prepareGitCloneCommands(repo string, path string, opts *CloneOpts) (string,
 
 	allCmd = append(allCmd, gitcmd)
 
+	// if a specific commit hash is given, try to reset current repo to this commit
 	if opts != nil && opts.CheckoutCommit != "" && opts.Tag == "" {
-		fetchCmd := cmd{
-			cmd:  "git",
-			args: []string{"fetch", "origin", opts.CheckoutCommit},
-		}
-		userLogCommand += "\n\rExecuting: git " + strings.Join(fetchCmd.args, " ")
-		//Locate the git reset cmd to the right directory
-		if path == "" {
-			t := strings.Split(repo, "/")
-			fetchCmd.dir = strings.TrimSuffix(t[len(t)-1], ".git")
-		} else {
-			fetchCmd.dir = path
+		// if no branch or tag given, this means that we cloned the repo on the default branch, we need to fetch the target commit id
+		// fetching a specific commit hash will not work for old git version (1.7 for example)
+		if opts.Branch == "" && opts.Tag == "" {
+			fetchCmd := cmd{
+				cmd:  "git",
+				args: []string{"fetch", "origin", opts.CheckoutCommit},
+			}
+			userLogCommand += "\n\rExecuting: git " + strings.Join(fetchCmd.args, " ")
+			//Locate the git reset cmd to the right directory
+			if path == "" {
+				t := strings.Split(repo, "/")
+				fetchCmd.dir = strings.TrimSuffix(t[len(t)-1], ".git")
+			} else {
+				fetchCmd.dir = path
+			}
+
+			allCmd = append(allCmd, fetchCmd)
 		}
 
-		allCmd = append(allCmd, fetchCmd)
-
+		// even if we cloned the right branch or tag, we need to reset to the given commit hash that could be different than HEAD
 		resetCmd := cmd{
 			cmd:  "git",
 			args: []string{"reset", "--hard", opts.CheckoutCommit},

--- a/sdk/vcs/git/git_clone.go
+++ b/sdk/vcs/git/git_clone.go
@@ -86,7 +86,7 @@ func prepareGitCloneCommands(repo string, path string, opts *CloneOpts) (string,
 
 	// if a specific commit hash is given, try to reset current repo to this commit
 	if opts != nil && opts.CheckoutCommit != "" && opts.Tag == "" {
-		// if no branch or tag given, this means that we cloned the repo on the default branch, we need to fetch the target commit id
+		// if no branch or tag given, this means that we cloned the repo on the default branch, we need to fetch the target commit hash
 		// fetching a specific commit hash will not work for old git version (1.7 for example)
 		if opts.Branch == "" && opts.Tag == "" {
 			fetchCmd := cmd{

--- a/sdk/vcs/git/git_test.go
+++ b/sdk/vcs/git/git_test.go
@@ -195,7 +195,7 @@ func Test_gitCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "Clone public repo over http with options and checkout commit",
+			name: "Clone public repo over http with branch and checkout commit",
 			args: args{
 				repo: "https://github.com/ovh/cds.git",
 				path: "/tmp/Test_gitCommand-3",
@@ -207,6 +207,21 @@ func Test_gitCommand(t *testing.T) {
 			},
 			want: []string{
 				"git clone --quiet --branch master https://github.com/ovh/cds.git /tmp/Test_gitCommand-3",
+				"git reset --hard eb8b87a",
+			},
+		},
+		{
+			name: "Clone public repo over http with only checkout commit",
+			args: args{
+				repo: "https://github.com/ovh/cds.git",
+				path: "/tmp/Test_gitCommand-3",
+				opts: &CloneOpts{
+					Quiet:          true,
+					CheckoutCommit: "eb8b87a",
+				},
+			},
+			want: []string{
+				"git clone --quiet https://github.com/ovh/cds.git /tmp/Test_gitCommand-3",
 				"git fetch origin eb8b87a",
 				"git reset --hard eb8b87a",
 			},


### PR DESCRIPTION
1. Description
Fetching the hash is useless if branch info already given, the commit hash should be part of the branch history that was fetched on git clone.
Also because old git version don't support fetching a specific commit hash, this will remove the breaking change introduced with fetch.

1. Related issues
1. About tests
1. Mentions

@ovh/cds
