### PR TITLE
fix(ui): change documentation link of requirements

### DIFF
--- a/ui/src/app/shared/requirements/form/requirements.form.html
+++ b/ui/src/app/shared/requirements/form/requirements.form.html
@@ -82,7 +82,7 @@
     </div>
     <p>
         <i class="fa fa-book"></i>
-        <a href="https://ovh.github.io/cds/docs/concepts/requirements/" target="_blank">
+        <a href="https://ovh.github.io/cds/docs/concepts/requirement/" target="_blank">
         {{ 'requirement_documentation' | translate }} </a>
     </p>
     <p [innerHtml]="getHelp()"></p>


### PR DESCRIPTION
Signed-off-by: Nicolas Crocfer <nicolas.crocfer@corp.ovh.com>

1. Description
The documentation link is not good in the "Requirements" modal box.

1. Related issues
1. About tests
1. Mentions

@ovh/cds
