### PR TITLE
fix(hatchery-kubernetes): remove default value for master-url

### DIFF
--- a/engine/hatchery/kubernetes/types.go
+++ b/engine/hatchery/kubernetes/types.go
@@ -34,7 +34,7 @@ type HatcheryConfiguration struct {
 	// Namespace is the kubernetes namespace in which workers are spawned"
 	Namespace string `mapstructure:"namespace" toml:"namespace" default:"cds" commented:"false" comment:"Kubernetes namespace in which workers are spawned" json:"namespace"`
 	// KubernetesMasterURL Address of kubernetes master
-	KubernetesMasterURL string `mapstructure:"kubernetesMasterURL" toml:"kubernetesMasterURL" default:"https://1.1.1.1:8443" commented:"false" comment:"Address of kubernetes master" json:"kubernetesMasterURL"`
+	KubernetesMasterURL string `mapstructure:"kubernetesMasterURL" toml:"kubernetesMasterURL" default:"" commented:"false" comment:"Address of kubernetes master" json:"kubernetesMasterURL"`
 	// KubernetesConfigFile Kubernetes config file in yaml
 	KubernetesConfigFile string `mapstructure:"kubernetesConfigFile" toml:"kubernetesConfigFile" default:"kubeconfig.yaml" commented:"false" comment:"Kubernetes config file in yaml" json:"kubernetesConfigFile"`
 	// KubernetesUsername Username to connect to kubernetes cluster (optional if config file is set)


### PR DESCRIPTION
1. Description
Avoiding duplicate configuration entry for KubernetesMasterURL.

1. Related issues
I got an issue on the hatchery kubernetes component when updating CDS from 0.38.1 to 0.39.0.

`Unable to init service hatchery:kubernetes: ApplyConfiguration: internal server error (caused by: Cannot create namespace cds in kubernetes: Post https://1.1.1.1:8443/api/v1/namespaces?timeout=10s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers))`

It appears that I had to add CDS_HATCHERY_KUBERNETES_KUBERNETESMASTERURL to environment variable (or in config.toml).

To avoid duplicate information (Kubernetes Master URL already present in kubeconfig.yaml), @yesnault suggested me to remove default value.

1. About tests
I test this code in my dev environment

1. Mentions
@ovh/cds
