### PR TITLE
chore(contrib/helm): update deployment k8s api and enable rolling update

### DIFF
--- a/contrib/helm/cds/templates/api-deployment.yaml
+++ b/contrib/helm/cds/templates/api-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-api
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-api
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/elasticsearch-deployment.yaml
+++ b/contrib/helm/cds/templates/elasticsearch-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-elasticsearch
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-elasticsearch
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/hatchery-k8s-deployment.yaml
+++ b/contrib/helm/cds/templates/hatchery-k8s-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-hatchery-k8s
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-hatchery-k8s
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/hooks-deployment.yaml
+++ b/contrib/helm/cds/templates/hooks-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-hooks
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-hooks
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/repositories-deployment.yaml
+++ b/contrib/helm/cds/templates/repositories-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-repositories
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-repositories
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/ui-deployment.yaml
+++ b/contrib/helm/cds/templates/ui-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-ui
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-ui
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/contrib/helm/cds/templates/vcs-deployment.yaml
+++ b/contrib/helm/cds/templates/vcs-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cds.fullname" . }}-vcs
@@ -9,6 +9,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cds.fullname" . }}-vcs
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
1. Description
Update kubernetes deployment api from extension/v1beta2 to apps/v1 to allow rolling update (deployments without downtime, if numbers of replica greater than 1)

2. Related issues
None

3. About tests
I didn't did tests, because I'm not using helm to deploy cds on ours environments, but my yaml k8s config file looks like this. 

4. Mentions
@bnjjj 
@ovh/cds
