### PR TITLE
fix(api): ascode secret on branch should be available

### DIFF
--- a/sdk/variable.go
+++ b/sdk/variable.go
@@ -92,3 +92,23 @@ func VariablesPrefix(vars []Variable, prefix string) []Variable {
 	}
 	return res
 }
+
+// VariablesMerge adds data from right list to the left one and overrides existing variables.
+func VariablesMerge(left []Variable, right []Variable) []Variable {
+	m := make(map[string]Variable)
+
+	for i := range left {
+		m[left[i].Name] = left[i]
+	}
+
+	for i := range right {
+		m[right[i].Name] = right[i]
+	}
+
+	res := make([]Variable, 0, len(m))
+	for _, v := range m {
+		res = append(res, v)
+	}
+
+	return res
+}

--- a/sdk/variable_test.go
+++ b/sdk/variable_test.go
@@ -1,0 +1,44 @@
+package sdk_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func TestVariablesMerge(t *testing.T) {
+	left := []sdk.Variable{{
+		Name:  "A",
+		Value: "abc",
+	}, {
+		Name:  "B",
+		Value: "def",
+	}, {
+		Name:  "C",
+		Value: "ghi",
+	}}
+
+	right := []sdk.Variable{{
+		Name:  "B",
+		Value: "123",
+	}, {
+		Name:  "D",
+		Value: "456",
+	}}
+
+	res := sdk.VariablesMerge(left, right)
+	assert.Equal(t, 4, len(res))
+	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
+
+	assert.Equal(t, "A", res[0].Name)
+	assert.Equal(t, "abc", res[0].Value)
+	assert.Equal(t, "B", res[1].Name)
+	assert.Equal(t, "123", res[1].Value)
+	assert.Equal(t, "C", res[2].Name)
+	assert.Equal(t, "ghi", res[2].Value)
+	assert.Equal(t, "D", res[3].Name)
+	assert.Equal(t, "456", res[3].Value)
+}


### PR DESCRIPTION
1. Description
Work in progress. When getting jobs from a workflow run for a branch, workflow, application and environment modification are rollbacked and the workflow is saved directly on a new workflow run entry. 
The problem is that we lost the secret references imported because app and env were rollbacked. What we stored on the workflow run are just placeholder information (*******).
Then when a worker try to load secrets for the run, it will use information from the stored application (default branch version). 
This code is getting secret also from the workflowRun.workflow, but now we need to find a way to get the real value for the variables and not the placeholder.

First solution: maybe we can store ref instead of placeholder value in the workflowRun.workflow.
1. Related issues
#4265 
1. About tests
1. Mentions

@ovh/cds
