### PR TITLE
fix(worker): change context timeout to be the same as in the api goroutine

### DIFF
--- a/engine/worker/run.go
+++ b/engine/worker/run.go
@@ -354,7 +354,8 @@ func workingDirectory(basedir string, jobInfo *sdk.WorkflowNodeJobRunData, suffi
 
 func (w *currentWorker) processJob(ctx context.Context, jobInfo *sdk.WorkflowNodeJobRunData) sdk.Result {
 	t0 := time.Now()
-	ctx, cancel := context.WithTimeout(ctx, 6*time.Hour)
+	// Timeout must be the same as the goroutine which stop jobs in package api/workflow
+	ctx, cancel := context.WithTimeout(ctx, 24*time.Hour)
 
 	defer func() { log.Info("processJob> Process Job Done (%s)", sdk.Round(time.Since(t0), time.Second).String()) }()
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
