### PR TITLE
fix(api, worker): some fixes about cache & subprocess

### DIFF
--- a/docs/content/docs/components/worker/_index.md
+++ b/docs/content/docs/components/worker/_index.md
@@ -19,7 +19,6 @@ worker [flags]
 
 ```
       --api string                   URL of CDS API
-      --auto-update                  Auto update worker binary from CDS API
       --basedir string               This directory (default TMPDIR os environment var) will contains worker working directory and temporary files
       --booked-job-id int            Booked job id
       --booked-workflow-job-id int   Booked Workflow job id
@@ -33,6 +32,7 @@ worker [flags]
       --grpc-api string              CDS GRPC tcp address
       --grpc-insecure                Disable GRPC TLS encryption
       --hatchery-name string         Hatchery Name spawing worker
+  -h, --help                         help for worker
       --insecure                     (SSL) This option explicitly allows curl to perform "insecure" SSL connections and transfers.
       --log-level string             Log Level: debug, info, notice, warning, critical (default "notice")
       --model int                    Model of worker

--- a/engine/api/permission.go
+++ b/engine/api/permission.go
@@ -59,6 +59,7 @@ func (api *API) deprecatedSetGroupsAndPermissionsFromGroupID(ctx context.Context
 
 func (api *API) checkWorkerPermission(ctx context.Context, db gorp.SqlExecutor, rc *service.HandlerConfig, routeVar map[string]string) bool {
 	if getWorker(ctx) == nil {
+		log.Error("checkWorkerPermission> no worker in ctx")
 		return false
 	}
 
@@ -90,6 +91,9 @@ func (api *API) checkWorkerPermission(ctx context.Context, db gorp.SqlExecutor, 
 
 		ok = runNodeJob.ID == getWorker(ctx).ActionBuildID
 		api.Cache.SetWithTTL(k, ok, 60*15)
+		if !ok {
+			log.Error("checkWorkerPermission> actionBuildID:%v runNodeJob.ID:%v", getWorker(ctx).ActionBuildID, runNodeJob.ID)
+		}
 		return ok
 	}
 	return true

--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -378,7 +378,7 @@ func SetStatus(db gorp.SqlExecutor, workerID string, status sdk.Status) error {
 }
 
 // SetToBuilding sets action_build_id and status to building on given worker
-func SetToBuilding(db gorp.SqlExecutor, workerID string, actionBuildID int64, jobType string) error {
+func SetToBuilding(db gorp.SqlExecutor, store cache.Store, workerID string, actionBuildID int64, jobType string) error {
 	query := `UPDATE worker SET status = $1, action_build_id = $2, job_type = $3 WHERE id = $4`
 
 	res, errE := db.Exec(query, sdk.StatusBuilding.String(), actionBuildID, jobType, workerID)
@@ -387,6 +387,8 @@ func SetToBuilding(db gorp.SqlExecutor, workerID string, actionBuildID int64, jo
 	}
 
 	_, err := res.RowsAffected()
+	// delete the worker from the cache
+	store.Delete(cache.Key("worker", workerID))
 	return err
 }
 

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -139,7 +139,7 @@ func takeJob(ctx context.Context, dbFunc func() *gorp.DbMap, store cache.Store, 
 	}
 
 	//Change worker status
-	if err := worker.SetToBuilding(tx, getWorker(ctx).ID, job.ID, sdk.JobTypeWorkflowNode); err != nil {
+	if err := worker.SetToBuilding(tx, store, getWorker(ctx).ID, job.ID, sdk.JobTypeWorkflowNode); err != nil {
 		return nil, sdk.WrapError(err, "Cannot update worker %s status", getWorker(ctx).Name)
 	}
 

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -958,7 +958,7 @@ func TestPostVulnerabilityReportHandler(t *testing.T) {
 	}
 	testRegisterWorker(t, api, router, &ctx)
 	ctx.worker.ActionBuildID = wrDB.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID
-	assert.NoError(t, worker.SetToBuilding(db, ctx.worker.ID, wrDB.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID, sdk.JobTypeWorkflowNode))
+	assert.NoError(t, worker.SetToBuilding(db, api.Cache, ctx.worker.ID, wrDB.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID, sdk.JobTypeWorkflowNode))
 
 	request := sdk.VulnerabilityWorkerReport{
 		Vulnerabilities: []sdk.Vulnerability{
@@ -1262,7 +1262,7 @@ func TestInsertNewCodeCoverageReport(t *testing.T) {
 	}
 	testRegisterWorker(t, api, router, &ctx)
 	ctx.worker.ActionBuildID = wrr.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID
-	assert.NoError(t, worker.SetToBuilding(db, ctx.worker.ID, wrr.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID, sdk.JobTypeWorkflowNode))
+	assert.NoError(t, worker.SetToBuilding(db, api.Cache, ctx.worker.ID, wrr.WorkflowNodeRuns[w.WorkflowData.Node.ID][0].Stages[0].RunJobs[0].ID, sdk.JobTypeWorkflowNode))
 
 	uri := router.GetRoute("POST", api.postWorkflowJobCoverageResultsHandler, vars)
 	test.NotEmpty(t, uri)

--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -1,13 +1,7 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-
 	"github.com/spf13/cobra"
-
-	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/log"
 )
 
 func cmdMain(w *currentWorker) *cobra.Command {
@@ -15,57 +9,10 @@ func cmdMain(w *currentWorker) *cobra.Command {
 		Use:   "worker",
 		Short: "CDS Worker",
 		Long:  "A pipeline is structured in sequential stages containing one or multiple concurrent jobs. A Job will be executed by a worker.",
-		Run:   mainCommandRun(w),
+		Run:   runCmd(w),
 	}
 
 	initFlagsRun(mainCmd)
 
 	return mainCmd
-}
-
-func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		var autoUpdate = FlagBool(cmd, flagAutoUpdate)
-		var singleUse = FlagBool(cmd, flagSingleUse)
-
-		log.Initialize(&log.Conf{})
-
-		if autoUpdate {
-			updateCmd(w)(cmd, args)
-		}
-
-		for {
-			execWorker()
-			if singleUse {
-				log.Info("single-use true, worker will be shutdown...")
-				break
-			} else {
-				log.Info("Restarting worker...")
-			}
-		}
-		log.Info("Stopping worker...")
-	}
-}
-
-func execWorker() {
-	current, errExec := os.Executable()
-	if errExec != nil {
-		sdk.Exit("Error on getting current binary worker", errExec)
-	}
-
-	log.Info("Current binary: %s", current)
-	args := []string{"run"}
-	args = append(args, os.Args[1:]...)
-	cmd := exec.Command(current, args...)
-	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Start(); err != nil {
-		log.Error("start err:%s", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		log.Error("wait err:%s", err)
-	}
 }

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -20,7 +20,6 @@ import (
 const (
 	envFlagPrefix           = "cds_"
 	flagSingleUse           = "single-use"
-	flagAutoUpdate          = "auto-update"
 	flagFromGithub          = "from-github"
 	flagForceExit           = "force-exit"
 	flagBaseDir             = "basedir"
@@ -46,7 +45,6 @@ const (
 func initFlagsRun(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.Bool(flagSingleUse, false, "Exit after executing an action")
-	flags.Bool(flagAutoUpdate, false, "Auto update worker binary from CDS API")
 	flags.Bool(flagFromGithub, false, "Update binary from latest github release")
 	flags.Bool(flagForceExit, false, "If single_use=true, force exit. This is useful if it's spawned by an Hatchery (default: worker wait 30min for being killed by hatchery)")
 	flags.String(flagBaseDir, "", "This directory (default TMPDIR os environment var) will contains worker working directory and temporary files")
@@ -190,7 +188,6 @@ func initFlags(cmd *cobra.Command, w *currentWorker) {
 
 	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name, cdsclient.NewHTTPClient(time.Second*360, FlagBool(cmd, flagInsecure)))
 
-	w.autoUpdate = FlagBool(cmd, flagAutoUpdate)
 	w.singleUse = FlagBool(cmd, flagSingleUse)
 	w.grpc.address = FlagString(cmd, flagGRPCAPI)
 	w.grpc.insecure = FlagBool(cmd, flagGRPCInsecure)

--- a/engine/worker/main.go
+++ b/engine/worker/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 type currentWorker struct {
-	autoUpdate    bool
 	singleUse     bool
 	apiEndpoint   string
 	token         string

--- a/engine/worker/register.go
+++ b/engine/worker/register.go
@@ -40,10 +40,6 @@ func (w *currentWorker) register(form sdk.WorkerRegistrationForm) error {
 	w.initGRPCConn()
 
 	if !uptodate {
-		if w.autoUpdate {
-			log.Warning("-=-=-=-=- your worker binary is not up to date %s %s %s. Auto-updating it... -=-=-=-=-", sdk.VERSION, sdk.GOOS, sdk.GOARCH)
-			sdk.Exit("Exiting this cds worker process - auto updating worker")
-		}
 		log.Warning("-=-=-=-=- Please update your worker binary - Worker Version %s %s %s -=-=-=-=-", sdk.VERSION, sdk.GOOS, sdk.GOARCH)
 	}
 

--- a/engine/worker/run.go
+++ b/engine/worker/run.go
@@ -307,6 +307,9 @@ func (w *currentWorker) updateStepStatus(ctx context.Context, buildID int64, ste
 			return nil
 		}
 		cancel()
+		if ctx.Err() != nil {
+			return fmt.Errorf("updateStepStatus> step:%d job:%d worker is cancelled", stepOrder, buildID)
+		}
 		log.Warning("updateStepStatus> Cannot send step %d result: HTTP %d err: %s - try: %d - new try in 15s", stepOrder, code, lasterr, try)
 		time.Sleep(15 * time.Second)
 	}
@@ -356,6 +359,7 @@ func (w *currentWorker) processJob(ctx context.Context, jobInfo *sdk.WorkflowNod
 	t0 := time.Now()
 	// Timeout must be the same as the goroutine which stop jobs in package api/workflow
 	ctx, cancel := context.WithTimeout(ctx, 24*time.Hour)
+	log.Info("processJob> Process Job")
 
 	defer func() { log.Info("processJob> Process Job Done (%s)", sdk.Round(time.Since(t0), time.Second).String()) }()
 	defer cancel()

--- a/engine/worker/take_workflow_node_run_job.go
+++ b/engine/worker/take_workflow_node_run_job.go
@@ -126,6 +126,10 @@ func (w *currentWorker) takeWorkflowJob(ctx context.Context, job sdk.WorkflowNod
 			return false, nil
 		}
 		cancelSendResult()
+		if ctx.Err() != nil {
+			log.Info("takeWorkflowJob> Cannot send build result: HTTP %v - worker cancelled - giving up", lasterr)
+			return false, nil
+		}
 		log.Warning("takeWorkflowJob> Cannot send build result: HTTP %v - try: %d - new try in 15s", lasterr, try)
 		time.Sleep(15 * time.Second)
 	}


### PR DESCRIPTION
rm auto-update flag, worker will be launched only by hatchery, this flag is no need anymore
rm sub-process
kill process -> try to send result only 1 time

close #3963 (linked to cache worker on api side)

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
