### PR TITLE
fix(worker): one process

### DIFF
--- a/engine/worker/cmd_main.go
+++ b/engine/worker/cmd_main.go
@@ -1,13 +1,7 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-
 	"github.com/spf13/cobra"
-
-	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/log"
 )
 
 func cmdMain(w *currentWorker) *cobra.Command {
@@ -15,57 +9,10 @@ func cmdMain(w *currentWorker) *cobra.Command {
 		Use:   "worker",
 		Short: "CDS Worker",
 		Long:  "A pipeline is structured in sequential stages containing one or multiple concurrent jobs. A Job will be executed by a worker.",
-		Run:   mainCommandRun(w),
+		Run:   runCmd(w),
 	}
 
 	initFlagsRun(mainCmd)
 
 	return mainCmd
-}
-
-func mainCommandRun(w *currentWorker) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		var autoUpdate = FlagBool(cmd, flagAutoUpdate)
-		var singleUse = FlagBool(cmd, flagSingleUse)
-
-		log.Initialize(&log.Conf{})
-
-		if autoUpdate {
-			updateCmd(w)(cmd, args)
-		}
-
-		for {
-			execWorker()
-			if singleUse {
-				log.Info("single-use true, worker will be shutdown...")
-				break
-			} else {
-				log.Info("Restarting worker...")
-			}
-		}
-		log.Info("Stopping worker...")
-	}
-}
-
-func execWorker() {
-	current, errExec := os.Executable()
-	if errExec != nil {
-		sdk.Exit("Error on getting current binary worker", errExec)
-	}
-
-	log.Info("Current binary: %s", current)
-	args := []string{"run"}
-	args = append(args, os.Args[1:]...)
-	cmd := exec.Command(current, args...)
-	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Start(); err != nil {
-		log.Error("start err:%s", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		log.Error("wait err:%s", err)
-	}
 }

--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -48,7 +48,6 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		log.Info("CDS Worker starting")
 		log.Info("version: %s", sdk.VERSION)
 		log.Info("hostname: %s", hostname)
-		log.Info("auto-update: %t", w.autoUpdate)
 		log.Info("single-use: %t", w.singleUse)
 
 		httpServerCtx, stopHTTPServer := context.WithCancel(context.Background())
@@ -67,7 +66,7 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		go func() {
 			select {
 			case <-c:
-				defer cancel()
+				cancel()
 				return
 			case <-ctx.Done():
 				return
@@ -99,8 +98,6 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		registerTick := time.NewTicker(10 * time.Second)
 		refreshTick := time.NewTicker(30 * time.Second)
 
-		updateTick := time.NewTicker(5 * time.Minute)
-
 		// start logger routine with a large buffer
 		w.logger.logChan = make(chan sdk.Log, 100000)
 		go w.logProcessor(ctx)
@@ -115,7 +112,6 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 			w.drainLogsAndCloseLogger(ctx)
 			registerTick.Stop()
 			refreshTick.Stop()
-			updateTick.Stop()
 			w.unregister()
 			cancel()
 			stopHTTPServer()
@@ -290,8 +286,6 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 				// Unregister from engine
 				log.Info("Job is done. Unregistering...")
 				cancel()
-			case <-updateTick.C:
-				w.doUpdate()
 			}
 		}
 	}
@@ -338,18 +332,6 @@ func (w *currentWorker) processBookedWJob(ctx context.Context, wjobs chan<- sdk.
 	wjobs <- *wjob
 
 	return nil
-}
-
-func (w *currentWorker) doUpdate() {
-	if w.autoUpdate {
-		version, err := w.client.Version()
-		if err != nil {
-			log.Error("Error while getting version from CDS API: %s", err)
-		}
-		if version.Version != sdk.VERSION {
-			sdk.Exit("Exiting this CDS Worker process - auto updating worker")
-		}
-	}
 }
 
 func (w *currentWorker) doRegister() error {

--- a/engine/worker/init.go
+++ b/engine/worker/init.go
@@ -20,7 +20,6 @@ import (
 const (
 	envFlagPrefix           = "cds_"
 	flagSingleUse           = "single-use"
-	flagAutoUpdate          = "auto-update"
 	flagFromGithub          = "from-github"
 	flagForceExit           = "force-exit"
 	flagBaseDir             = "basedir"
@@ -46,7 +45,6 @@ const (
 func initFlagsRun(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.Bool(flagSingleUse, false, "Exit after executing an action")
-	flags.Bool(flagAutoUpdate, false, "Auto update worker binary from CDS API")
 	flags.Bool(flagFromGithub, false, "Update binary from latest github release")
 	flags.Bool(flagForceExit, false, "If single_use=true, force exit. This is useful if it's spawned by an Hatchery (default: worker wait 30min for being killed by hatchery)")
 	flags.String(flagBaseDir, "", "This directory (default TMPDIR os environment var) will contains worker working directory and temporary files")
@@ -190,7 +188,6 @@ func initFlags(cmd *cobra.Command, w *currentWorker) {
 
 	w.client = cdsclient.NewWorker(w.apiEndpoint, w.status.Name, cdsclient.NewHTTPClient(time.Second*360, FlagBool(cmd, flagInsecure)))
 
-	w.autoUpdate = FlagBool(cmd, flagAutoUpdate)
 	w.singleUse = FlagBool(cmd, flagSingleUse)
 	w.grpc.address = FlagString(cmd, flagGRPCAPI)
 	w.grpc.insecure = FlagBool(cmd, flagGRPCInsecure)

--- a/engine/worker/main.go
+++ b/engine/worker/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 type currentWorker struct {
-	autoUpdate    bool
 	singleUse     bool
 	apiEndpoint   string
 	token         string

--- a/engine/worker/register.go
+++ b/engine/worker/register.go
@@ -16,7 +16,7 @@ func (w *currentWorker) register(form sdk.WorkerRegistrationForm) error {
 
 	requirements, errR := w.client.Requirements()
 	if errR != nil {
-		log.Warning("register> unable to get requirements : %s", errR)
+		log.Warning("register> unable to get requirements: %v", errR)
 		return errR
 	}
 
@@ -40,10 +40,6 @@ func (w *currentWorker) register(form sdk.WorkerRegistrationForm) error {
 	w.initGRPCConn()
 
 	if !uptodate {
-		if w.autoUpdate {
-			log.Warning("-=-=-=-=- your worker binary is not up to date %s %s %s. Auto-updating it... -=-=-=-=-", sdk.VERSION, sdk.GOOS, sdk.GOARCH)
-			sdk.Exit("Exiting this cds worker process - auto updating worker")
-		}
 		log.Warning("-=-=-=-=- Please update your worker binary - Worker Version %s %s %s -=-=-=-=-", sdk.VERSION, sdk.GOOS, sdk.GOARCH)
 	}
 

--- a/engine/worker/run.go
+++ b/engine/worker/run.go
@@ -307,6 +307,9 @@ func (w *currentWorker) updateStepStatus(ctx context.Context, buildID int64, ste
 			return nil
 		}
 		cancel()
+		if ctx.Err() != nil {
+			return fmt.Errorf("updateStepStatus> step:%d job:%d worker is cancelled", stepOrder, buildID)
+		}
 		log.Warning("updateStepStatus> Cannot send step %d result: HTTP %d err: %s - try: %d - new try in 15s", stepOrder, code, lasterr, try)
 		time.Sleep(15 * time.Second)
 	}
@@ -356,6 +359,7 @@ func (w *currentWorker) processJob(ctx context.Context, jobInfo *sdk.WorkflowNod
 	t0 := time.Now()
 	// Timeout must be the same as the goroutine which stop jobs in package api/workflow
 	ctx, cancel := context.WithTimeout(ctx, 24*time.Hour)
+	log.Info("processJob> Process Job")
 
 	defer func() { log.Info("processJob> Process Job Done (%s)", sdk.Round(time.Since(t0), time.Second).String()) }()
 	defer cancel()

--- a/engine/worker/take_workflow_node_run_job.go
+++ b/engine/worker/take_workflow_node_run_job.go
@@ -126,6 +126,10 @@ func (w *currentWorker) takeWorkflowJob(ctx context.Context, job sdk.WorkflowNod
 			return false, nil
 		}
 		cancelSendResult()
+		if ctx.Err() != nil {
+			log.Info("takeWorkflowJob> Cannot send build result: HTTP %v - worker cancelled - giving up", lasterr)
+			return false, nil
+		}
 		log.Warning("takeWorkflowJob> Cannot send build result: HTTP %v - try: %d - new try in 15s", lasterr, try)
 		time.Sleep(15 * time.Second)
 	}


### PR DESCRIPTION
rm auto-update flag, worker will be launched only by hatchery, this flag is no need anymore
rm sub-process

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
