### PR TITLE
fix(vcs/gitlab): wrong callbackurl variable in config.toml

### DIFF
--- a/docs/content/docs/integrations/gitlab.md
+++ b/docs/content/docs/integrations/gitlab.md
@@ -63,6 +63,9 @@ Set value to `appId` and `secret`
         # proxyWebhook = ""
         secret = "xxxx"
 
+        # OAuth Application Callback URL
+        OAuthCallbackURL = "http://your-cds-api:8081/repositories_manager/oauth2/callback"
+
         [vcs.servers.Gitlab.gitlab.Status]
 
           # Set to true if you don't want CDS to push statuses on the VCS server

--- a/engine/vcs/types.go
+++ b/engine/vcs/types.go
@@ -87,7 +87,7 @@ var errGithubConfigurationError = fmt.Errorf("Github configuration Error")
 type GitlabServerConfiguration struct {
 	AppID            string `toml:"appId" json:"-" comment:"#######\n CDS <-> Gitlab. Documentation on https://ovh.github.io/cds/hosting/repositories-manager/gitlab/ \n#######"`
 	Secret           string `toml:"secret" json:"-"`
-	OAuthCallbackURL string `toml:"callbackUrl" json:"callbackUrl" default:"http://localhost:8081/repositories_manager/oauth2/callback" comment:"OAuth Application Callback URL"`
+	OAuthCallbackURL string `toml:"OAuthCallbackURL" json:"OAuthCallbackURL" default:"http://localhost:8081/repositories_manager/oauth2/callback" comment:"OAuth Application Callback URL"`
 	Status           struct {
 		Disable    bool `toml:"disable" default:"false" commented:"true" comment:"Set to true if you don't want CDS to push statuses on the VCS server" json:"disable"`
 		ShowDetail bool `toml:"showDetail" default:"false" commented:"true" comment:"Set to true if you don't want CDS to push CDS URL in statuses on the VCS server" json:"show_detail"`


### PR DESCRIPTION
1. Description
Default value when you generate CDS configuration with cds-engine config new is wrong for the callback URL
CDS + GitLab link doesn't work with : 
 
`[vcs.servers.Gitlab.gitlab]
        appId = "xxxx"
        callbackUrl = ""
        disablePolling = false
        disableWebHooks = false
        # proxyWebhook = ""
        secret = "xxxx"`

but works with
`[vcs.servers.Gitlab.gitlab]
        appId = "xxxx"
        OAuthCallbackURL = ""
        disablePolling = false
        disableWebHooks = false
        # proxyWebhook = ""
        secret = "xxxx"`
 
2. Related issues
Not created, but related to https://github.com/ovh/cds/pull/4168

3. About tests
It's ok on our side, but you can still test with the container located at docker.io/asforge/cds-engine:0.39.3-60

4. Mentions
@ovh/cds
