### PR TITLE
fix(contrib/helm): replace --decode by -d to be compatible with more distribs / os

### DIFF
--- a/contrib/helm/cds/templates/api-deployment.yaml
+++ b/contrib/helm/cds/templates/api-deployment.yaml
@@ -87,7 +87,7 @@ spec:
               name: {{ template "cds.fullname" . }}
               key: cds-api_secrets_key
         command: ["/bin/sh"]
-        args: ["-c", "echo $CDS_CONFIG_FILE | base64 --decode > config.toml && /app/cds-engine-linux-amd64 start api --config config.toml"]
+        args: ["-c", "echo $CDS_CONFIG_FILE | base64 -d > config.toml && /app/cds-engine-linux-amd64 start api --config config.toml"]
         ports:
         - name: http
           containerPort: 8081

--- a/contrib/helm/cds/templates/elasticsearch-deployment.yaml
+++ b/contrib/helm/cds/templates/elasticsearch-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         - name: CDS_LOG_LEVEL
           value: {{ default "" .Values.logLevel | quote }}
         command: ["/bin/sh"]
-        args: ["-c", "echo $CDS_CONFIG_FILE | base64 --decode > config.toml && /app/cds-engine-linux-amd64 start elasticsearch --config config.toml"]
+        args: ["-c", "echo $CDS_CONFIG_FILE | base64 -d > config.toml && /app/cds-engine-linux-amd64 start elasticsearch --config config.toml"]
         ports:
         - name: http
           containerPort: 8084

--- a/contrib/helm/cds/templates/hooks-deployment.yaml
+++ b/contrib/helm/cds/templates/hooks-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - name: CDS_LOG_LEVEL
           value: {{ default "" .Values.logLevel | quote }}
         command: ["/bin/sh"]
-        args: ["-c", "echo $CDS_CONFIG_FILE | base64 --decode > config.toml && /app/cds-engine-linux-amd64 start hooks --config config.toml"]
+        args: ["-c", "echo $CDS_CONFIG_FILE | base64 -d > config.toml && /app/cds-engine-linux-amd64 start hooks --config config.toml"]
         ports:
         - name: http
           containerPort: 8084

--- a/contrib/helm/cds/templates/repositories-deployment.yaml
+++ b/contrib/helm/cds/templates/repositories-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - name: CDS_LOG_LEVEL
           value: {{ default "" .Values.logLevel | quote }}
         command: ["/bin/sh"]
-        args: ["-c", "echo $CDS_CONFIG_FILE | base64 --decode > config.toml && /app/cds-engine-linux-amd64 start repositories --config config.toml"]
+        args: ["-c", "echo $CDS_CONFIG_FILE | base64 -d > config.toml && /app/cds-engine-linux-amd64 start repositories --config config.toml"]
         ports:
         - name: http
           containerPort: 8084

--- a/contrib/helm/cds/templates/vcs-deployment.yaml
+++ b/contrib/helm/cds/templates/vcs-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - name: CDS_LOG_LEVEL
           value: {{ default "" .Values.logLevel | quote }}
         command: ["/bin/sh"]
-        args: ["-c", "echo $CDS_CONFIG_FILE | base64 --decode > config.toml && /app/cds-engine-linux-amd64 start vcs --config config.toml"]
+        args: ["-c", "echo $CDS_CONFIG_FILE | base64 -d > config.toml && /app/cds-engine-linux-amd64 start vcs --config config.toml"]
         ports:
         - name: http
           containerPort: 8084


### PR DESCRIPTION
replace --decode by -d to be compatible with more distribs / os

1. Description
base64 --decode is not working on alpine, whereas base64 -d is working on alpine, debian, darwin ... 

2. Related issues
None

3. About tests
tested on debian, macos, alpine

4. Mentions
@bnjjj 
@ovh/cds
