### PR TITLE
refactor(hatchery): graceTime not needed anymore

### DIFF
--- a/engine/worker/cmd_run.go
+++ b/engine/worker/cmd_run.go
@@ -157,7 +157,7 @@ func runCmd(w *currentWorker) func(cmd *cobra.Command, args []string) {
 		}
 
 		go func(ctx context.Context, exceptID *int64) {
-			if err := w.client.QueuePolling(ctx, wjobs, errs, 2*time.Second, 0, "", nil, exceptID); err != nil {
+			if err := w.client.QueuePolling(ctx, wjobs, errs, 2*time.Second, "", nil, exceptID); err != nil {
 				log.Info("Queues polling stopped: %v", err)
 			}
 		}(ctx, &exceptJobID)

--- a/sdk/cdsclient/client_queue.go
+++ b/sdk/cdsclient/client_queue.go
@@ -51,7 +51,7 @@ func shrinkQueue(queue *sdk.WorkflowQueue, nbJobsToKeep int) time.Time {
 	return t0
 }
 
-func (c *client) QueuePolling(ctx context.Context, jobs chan<- sdk.WorkflowNodeJobRun, errs chan<- error, delay time.Duration, graceTime int, modelType string, ratioService *int, exceptWfJobID *int64) error {
+func (c *client) QueuePolling(ctx context.Context, jobs chan<- sdk.WorkflowNodeJobRun, errs chan<- error, delay time.Duration, modelType string, ratioService *int, exceptWfJobID *int64) error {
 	jobsTicker := time.NewTicker(delay)
 
 	// This goroutine call the SSE route
@@ -87,9 +87,7 @@ func (c *client) QueuePolling(ctx context.Context, jobs chan<- sdk.WorkflowNodeJ
 				jobRunID, ok := apiEvent.Payload["ID"].(float64)
 				status, okStatus := apiEvent.Payload["Status"].(string)
 				if ok && okStatus && status == sdk.StatusWaiting.String() {
-					// wait for the grace time before pushing the job in the channel
 					go func() {
-						time.Sleep(time.Duration(graceTime) * time.Second)
 						job, err := c.QueueJobInfo(int64(jobRunID))
 
 						// Do not log the error if the job does not exist

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -233,7 +233,7 @@ type ProjectVariablesClient interface {
 type QueueClient interface {
 	QueueWorkflowNodeJobRun(status ...sdk.Status) ([]sdk.WorkflowNodeJobRun, error)
 	QueueCountWorkflowNodeJobRun(since *time.Time, until *time.Time, modelType string, ratioService *int) (sdk.WorkflowNodeJobRunCount, error)
-	QueuePolling(ctx context.Context, jobs chan<- sdk.WorkflowNodeJobRun, errs chan<- error, delay time.Duration, graceTime int, modelType string, ratioService *int, exceptWfJobID *int64) error
+	QueuePolling(ctx context.Context, jobs chan<- sdk.WorkflowNodeJobRun, errs chan<- error, delay time.Duration, modelType string, ratioService *int, exceptWfJobID *int64) error
 	QueueTakeJob(ctx context.Context, job sdk.WorkflowNodeJobRun, isBooked bool) (*sdk.WorkflowNodeJobRunData, error)
 	QueueJobBook(ctx context.Context, id int64) error
 	QueueJobRelease(id int64) error

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -102,7 +102,7 @@ func Create(ctx context.Context, h Interface) error {
 
 	sdk.GoRoutine(ctx, "queuePolling",
 		func(ctx context.Context) {
-			if err := h.CDSClient().QueuePolling(ctx, wjobs, errs, 20*time.Second, h.Configuration().Provision.GraceTimeQueued, h.ModelType(), h.Hatchery().RatioService, nil); err != nil {
+			if err := h.CDSClient().QueuePolling(ctx, wjobs, errs, 20*time.Second, h.ModelType(), h.Hatchery().RatioService, nil); err != nil {
 				log.Error("Queues polling stopped: %v", err)
 				cancel()
 			}

--- a/sdk/hatchery/types.go
+++ b/sdk/hatchery/types.go
@@ -36,7 +36,6 @@ type CommonConfiguration struct {
 		MaxWorker                 int  `toml:"maxWorker" default:"10" comment:"Maximum allowed simultaneous workers" json:"maxWorker"`
 		MaxConcurrentProvisioning int  `toml:"maxConcurrentProvisioning" default:"10" comment:"Maximum allowed simultaneous workers provisioning" json:"maxConcurrentProvisioning"`
 		MaxConcurrentRegistering  int  `toml:"maxConcurrentRegistering" default:"2" comment:"Maximum allowed simultaneous workers registering. -1 to disable registering on this hatchery" json:"maxConcurrentRegistering"`
-		GraceTimeQueued           int  `toml:"graceTimeQueued" default:"4" comment:"if worker is queued less than this value (seconds), hatchery does not take care of it" json:"graceTimeQueued"`
 		RegisterFrequency         int  `toml:"registerFrequency" default:"60" comment:"Check if some worker model have to be registered each n Seconds" json:"registerFrequency"`
 		WorkerLogsOptions         struct {
 			Graylog struct {


### PR DESCRIPTION
The spawning time is now really-really low, no need to provision, no need to use graceTime anymore.
This PR removes only the graceTime's Hack

close #1214

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
