### PR TITLE
fix(hatchery/openstack): manage multiple images with same name

### DIFF
--- a/engine/hatchery/openstack/spawn.go
+++ b/engine/hatchery/openstack/spawn.go
@@ -61,7 +61,8 @@ func (h *HatcheryOpenstack) SpawnWorker(ctx context.Context, spawnArgs hatchery.
 		log.Debug("spawnWorker> call images.List on openstack took %fs, nbImages:%d", time.Since(start).Seconds(), len(imgs))
 		for _, img := range imgs {
 			workerModelName, _ := img.Metadata["worker_model_name"]
-			if workerModelName == spawnArgs.Model.Name {
+			workerModelLastModified, _ := img.Metadata["worker_model_last_modified"]
+			if workerModelName == spawnArgs.Model.Name && workerModelLastModified == spawnArgs.Model.UserLastModified.Unix() {
 				withExistingImage = true
 				var jobInfo string
 				if spawnArgs.JobID != 0 {

--- a/engine/hatchery/openstack/spawn.go
+++ b/engine/hatchery/openstack/spawn.go
@@ -149,10 +149,10 @@ func (h *HatcheryOpenstack) SpawnWorker(ctx context.Context, spawnArgs hatchery.
 		server, err := r.Extract()
 		if err != nil {
 			if strings.Contains(err.Error(), "is already in use on instance") && try < maxTries { // Fixed IP address X.X.X.X is already in use on instance
-				log.Warning("SpawnWorker> Unable to create server: name:%s flavor:%s image:%s metadata:%v networks:%s err:%s body:%s - Try %d/%d", name, flavorID, imageID, meta, networks, err, r.Body, try, maxTries)
+				log.Warning("SpawnWorker> Unable to create server: name:%s flavor:%s image:%s metadata:%v networks:%s err:%v body:%s - Try %d/%d", name, flavorID, imageID, meta, networks, err, r.Body, try, maxTries)
 				continue
 			}
-			return "", fmt.Errorf("SpawnWorker> Unable to create server: name:%s flavor:%s image:%s metadata:%v networks:%s err:%s body:%s", name, flavorID, imageID, meta, networks, err, r.Body)
+			return "", fmt.Errorf("SpawnWorker> Unable to create server: name:%s flavor:%s image:%s metadata:%v networks:%s err:%v body:%s", name, flavorID, imageID, meta, networks, err, r.Body)
 		}
 		log.Debug("SpawnWorker> Created Server ID: %s", server.ID)
 		break


### PR DESCRIPTION
if multiple images (due to probably race-condition):
 - use the real image on spawn
 - delete all images with same name when uploading a new ones

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
