### PR TITLE
fix(contrib): fix separator for env variable in badge uservice

### DIFF
--- a/contrib/uservices/badge/src/configuration.rs
+++ b/contrib/uservices/badge/src/configuration.rs
@@ -74,7 +74,7 @@ pub fn get_configuration(filename: &str) -> Result<BadgeConfiguration, ConfigErr
   let mut settings = Config::default();
   settings
     .merge(File::with_name(filename))?
-    .merge(Environment::with_prefix("CDS"))?;
+    .merge(Environment::with_prefix("CDS").separator("_"))?;
 
   let conf: Configuration = settings.try_into()?;
   Ok(conf.badge)


### PR DESCRIPTION
Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
