### PR TITLE
fix(api): 0x00/0xbf in spawnError

### DIFF
--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -338,13 +338,13 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 
 			if OS != "" && arch != "" {
 				if err := workermodel.UpdateOSAndArch(db, modelID, OS, arch); err != nil {
-					log.Warning("registerWorker> Cannot update os and arch for worker model %d : %s", modelID, err)
+					log.Warning("registerWorker> Cannot update os and arch for worker model %d : %v", modelID, err)
 					return
 				}
 			}
 
 			if err := ntx.Commit(); err != nil {
-				log.Warning("RegisterWorker> Unable to commit transaction: %s", err)
+				log.Warning("RegisterWorker> Unable to commit transaction: %v", err)
 			}
 		}()
 	}
@@ -352,7 +352,7 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 	// worker model for now (example: an alpine image on a fresh install cds)
 	if modelID != 0 {
 		if err := workermodel.UpdateRegistration(tx, modelID); err != nil {
-			log.Warning("registerWorker> Unable to update registration: %s", err)
+			log.Warning("registerWorker> Unable to update registration: %v", err)
 		}
 	}
 

--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -347,6 +347,10 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 				log.Warning("RegisterWorker> Unable to commit transaction: %s", err)
 			}
 		}()
+	}
+	// update the registration even if there is no capability detected on
+	// worker model for now (example: an alpine image on a fresh install cds)
+	if modelID != 0 {
 		if err := workermodel.UpdateRegistration(tx, modelID); err != nil {
 			log.Warning("registerWorker> Unable to update registration: %s", err)
 		}

--- a/engine/api/workermodel/registration.go
+++ b/engine/api/workermodel/registration.go
@@ -1,7 +1,6 @@
 package workermodel
 
 import (
-	"bytes"
 	"errors"
 	"strconv"
 	"strings"
@@ -81,10 +80,9 @@ func updateAllToCheckRegistration(db gorp.SqlExecutor) error {
 // UpdateSpawnErrorWorkerModel updates worker model error registration
 func UpdateSpawnErrorWorkerModel(db gorp.SqlExecutor, modelID int64, spawnError sdk.SpawnErrorForm) error {
 	// some times when the docker container fails to start, the docker logs is not empty but only contains utf8 null char
-	spawnError.Error = strings.ReplaceAll(spawnError.Error, string([]byte{0x00}), "")
-	spawnError.Error = strings.ReplaceAll(spawnError.Error, string([]byte{0xbf}), "")
-	spawnError.Logs = bytes.ReplaceAll(spawnError.Logs, []byte{0x00}, []byte(""))
-	spawnError.Logs = bytes.ReplaceAll(spawnError.Logs, []byte{0xbf}, []byte(""))
+	rs := strings.NewReplacer(string([]byte{0x00}), "", string([]byte{0xbf}), "")
+	spawnError.Error = rs.Replace(spawnError.Error)
+	spawnError.Logs = []byte(rs.Replace(string(spawnError.Logs)))
 
 	query := `UPDATE worker_model SET nb_spawn_err=nb_spawn_err+1, last_spawn_err=$3, last_spawn_err_log=$4, date_last_spawn_err=$2 WHERE id = $1`
 	res, err := db.Exec(query, modelID, time.Now(), spawnError.Error, spawnError.Logs)


### PR DESCRIPTION
Theses two sequences can happen.

This fix allows to have more info about spawn register, as:

```
l2019-06-07T20:39:09.266904200Z  fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
q2019-06-07T20:39:09.418793300Z  fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
J2019-06-07T20:39:09.510410800Z  (1/4) Installing nghttp2-libs (1.35.1-r0)
D2019-06-07T20:39:09.523838000Z  (2/4) Installing libssh2 (1.8.2-r0)
E2019-06-07T20:39:09.538660200Z  (3/4) Installing libcurl (7.64.0-r2)
B2019-06-07T20:39:09.568090800Z  (4/4) Installing curl (7.64.0-r2)
E2019-06-07T20:39:09.594085800Z  Executing busybox-1.29.3-r10.trigger
92019-06-07T20:39:09.609865100Z  OK: 7 MiB in 19 packages
p2019-06-07T20:39:09.633641200Z    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
n2019-06-07T20:39:09.635767500Z                                   Dload  Upload   Total   Spent    Left  Speed
2019-06-07T20:39:09.643114000Z
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    19  100    19    0     0   2111      0 --:--:-- --:--:-- --:--:--  2111
A2019-06-07T20:39:09.645015700Z  ./worker: line 1: 404: not found
```

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>

