### PR TITLE
fix(hatchery/local): check requirement os/arch

### DIFF
--- a/engine/hatchery/local/local.go
+++ b/engine/hatchery/local/local.go
@@ -460,6 +460,12 @@ func (h *HatcheryLocal) checkRequirement(r sdk.Requirement) (bool, error) {
 		return true, nil
 	case sdk.PluginRequirement:
 		return true, nil
+	case sdk.OSArchRequirement:
+		osarch := strings.Split(r.Value, "/")
+		if len(osarch) != 2 {
+			return false, fmt.Errorf("invalid requirement %s", r.Value)
+		}
+		return osarch[0] == strings.ToLower(sdk.GOOS) && osarch[1] == strings.ToLower(sdk.GOARCH), nil
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
This is must have if:
- osDefault != osHatchery
- provision 0 on hatchery local

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>