### PR TITLE
fix(api): when update workflow via ascode, keep the icon #4397

### DIFF
--- a/engine/api/workflow/workflow_importer.go
+++ b/engine/api/workflow/workflow_importer.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-gorp/gorp"
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/engine/api/event"
@@ -46,6 +47,10 @@ func Import(ctx context.Context, db gorp.SqlExecutor, store cache.Store, proj *s
 		}
 
 		return nil
+	}
+
+	if oldW.Icon != "" && w.Icon == "" {
+		w.Icon = oldW.Icon
 	}
 
 	if !force {


### PR DESCRIPTION
Signed-off-by: Benjamin Coenen <benjamin.coenen@corp.ovh.com>

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
