### PR TITLE
fix(cdsctl): Add user/pass error check on login

### DIFF
--- a/cli/cdsctl/login.go
+++ b/cli/cdsctl/login.go
@@ -220,6 +220,9 @@ func doLogin(url, username, password string, env, insecureSkipVerifyTLS bool) er
 		if strings.HasSuffix(url, "/") {
 			fmt.Fprintf(os.Stderr, "Invalid URL. Remove trailing '/'\n")
 		}
+		if sdk.ErrorIs(err, sdk.ErrInvalidUser) {
+			return fmt.Errorf(sdk.ErrInvalidUser.Error())
+		}
 		return fmt.Errorf("Please check CDS API URL")
 	}
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Raphael Westphal <westphal.raphael@gmail.com>

1. Description
During login, if the username/password is wrong, cdsctl returns "Please check CDS API URL" instead of "invalid user or password"
1. Related issues
1. About tests
1. Mentions

@ovh/cds
