### PR TITLE
fix(debPacker): allow absolute paths in copy-files and mkdirs

### DIFF
--- a/tools/debpacker/README.md
+++ b/tools/debpacker/README.md
@@ -1,0 +1,194 @@
+# DebPacker
+
+Creates a Debian package and a systemd configuration
+
+## prerequisite
+
+* You must have a sane instance of `go`
+* You must be in a debian environment (needs `dpkg`)
+
+## Usage
+
+The program needs a configuration file to work. This configuration file describes how to build the package
+
+### package-name
+
+**Type:** *string*
+
+Name of the debian package
+
+### architecture
+
+**Type:** *string*
+
+Architecture of the system. For instance `armhf`, `all`
+
+### binary-file
+
+**Type:** *string*
+
+local path to the binary file to execute
+
+### command
+
+**Type:** *string*
+
+Command
+
+### configuration-files
+
+**Type:** *string[]*
+
+List of configuration files
+
+### copy-files
+
+**Type:** *string[]*
+
+List of files to copy. Syntax: `path[:dest]`
+
+For instance:
+
+`./foo/*.txt` copy all files that match the pattern
+`./foo/*.txt:data` copy all files that match the pattern in `/var/lib/{package name}/data`
+`./foo/*.conf:/etc/foo` copy all files that match the pattern in `/etc/foo`
+
+### mkdirs
+
+**Type:** *string[]*
+
+List of folders to create
+
+For instance:
+
+`foo/mickey` creates the folder `/var/lib/{package name}/foo/mickey`
+`/etc/foo` creates the folder `/etc/foo`
+
+### version
+
+**Type:** *string*
+
+Package version
+
+### description
+
+**Type:** *string*
+
+Package description
+
+### maintainer
+
+**Type:** *string*
+
+Email of the maintener
+
+### dependencies
+
+**Type:** *string[]*
+
+List of dependancies
+
+### systemd-configuration
+
+Configure service
+
+#### after
+
+**Type:** *string*
+
+After
+
+#### user
+
+**Type:** *string*
+
+User that launch the binary
+
+#### args
+
+**Type:** *string[]*
+
+Arguments to pass to the binary
+
+#### stop-command
+
+**Type:** *string*
+
+Stop command
+
+#### restart
+
+**Type:** *string*
+
+Restart policy. For instance `always`
+
+#### wanted-by
+
+**Type:** *string*
+
+Wanted by
+
+#### environments
+
+**Type:** *dictionary*
+
+Environment variables
+
+#### working-directory
+
+**Type:** *string*
+
+Directory in which the binary is launched
+
+#### post-install-cmd
+
+**Type:** *string*
+
+Post install command
+
+#### auto-start
+
+**Type:** *boolean*
+
+If true, start the service during package installation
+
+## Examples
+
+### Executable
+
+```yaml
+package-name: "my-executable"
+architecture: "all"
+binary-file: "./my-exec"
+copy-files:
+  - "./data/*.txt:data"
+version: "0.0.1"
+description: "Executable example"
+maintainer: "mickey@mouse.com"
+systemd-configuration:
+  user: "root"
+  after: network.target
+  stop-command: /bin/kill $MAINPID
+  restart: always
+  wanted-by: multi-user.target
+  working-directory: "/var/lib/foo"
+```
+
+### html client
+
+```yaml
+package-name: "my-website"
+architecture: "all"
+binary-file: "./my-exec"
+copy-files:
+  - "./data/*:/var/www"
+version: "0.0.1"
+description: "Executable example"
+maintainer: "mickey@mouse.com"
+systemd-configuration:
+  user: "root"
+  after: network.target
+  wanted-by: multi-user.target
+  post-install-cmd: "systemctl restart nginx"
+
+```

--- a/tools/debpacker/debpacker.go
+++ b/tools/debpacker/debpacker.go
@@ -133,6 +133,14 @@ func (p Packer) Prepare() error {
 		return err
 	}
 
+	if err := p.writePostrmFile(); err != nil {
+		return err
+	}
+
+	if err := p.writePreinstFile(); err != nil {
+		return err
+	}
+
 	return p.writePostinstFile()
 }
 
@@ -227,6 +235,11 @@ func (p Packer) writeSystemdServiceFile() error {
 	return p.render(systemdServiceTmpl, filepath.Join(path, p.config.PackageName+".service"), os.FileMode(0644))
 }
 
+func (p Packer) writePreinstFile() error {
+	path := filepath.Join(p.outputDirectory, "DEBIAN", "preinst")
+	return p.render(preinstTmpl, path, os.FileMode(0755))
+}
+
 func (p Packer) writePostinstFile() error {
 	path := filepath.Join(p.outputDirectory, "DEBIAN", "postinst")
 	return p.render(postinstTmpl, path, os.FileMode(0755))
@@ -235,6 +248,11 @@ func (p Packer) writePostinstFile() error {
 func (p Packer) writePrermFile() error {
 	path := filepath.Join(p.outputDirectory, "DEBIAN", "prerm")
 	return p.render(prermTmpl, path, os.FileMode(0755))
+}
+
+func (p Packer) writePostrmFile() error {
+	path := filepath.Join(p.outputDirectory, "DEBIAN", "postrm")
+	return p.render(postrmTmpl, path, os.FileMode(0755))
 }
 
 func (p Packer) render(tmpl string, path string, perm os.FileMode) error {

--- a/tools/debpacker/tmpl.go
+++ b/tools/debpacker/tmpl.go
@@ -59,7 +59,9 @@ chmod 770 /var/lib/{{.PackageName}}
 echo "Service initialization"
 {{.SystemdServiceConfig.PostInstallCmd}}
 {{end -}}
+{{if .SystemdServiceConfig.ExecStart -}}
 chmod +x {{.SystemdServiceConfig.ExecStart}}
+{{end -}}
 
 set +e
 {{if  (.NeedsService) -}}

--- a/tools/debpacker/tmpl.go
+++ b/tools/debpacker/tmpl.go
@@ -35,6 +35,17 @@ Environment="{{$key}}={{$value}}"
 WantedBy={{.SystemdServiceConfig.WantedBy}}
 `
 
+	preinstTmpl = `#!/bin/bash
+set +e
+{{if  (.NeedsService) -}}
+if  [ -f "/lib/systemd/system/{{.PackageName}}.service" ];then
+	systemctl stop {{.PackageName}}
+	systemctl disable {{.PackageName}}
+fi
+systemctl daemon-reload
+{{end -}}
+`
+
 	postinstTmpl = `#!/bin/bash
 set -e
 echo "Create the {{.SystemdServiceConfig.User}} User, Group and Directories"
@@ -68,6 +79,13 @@ set +e
 {{if  (.NeedsService) -}}
 systemctl stop {{.PackageName}}
 systemctl disable {{.PackageName}}
+systemctl daemon-reload
+{{end -}}
+`
+
+	postrmTmpl = `#!/bin/bash
+set +e
+{{if  (.NeedsService) -}}
 systemctl daemon-reload
 {{end -}}
 `

--- a/tools/debpacker/tmpl.go
+++ b/tools/debpacker/tmpl.go
@@ -51,9 +51,24 @@ echo "Service initialization"
 chmod +x {{.SystemdServiceConfig.ExecStart}}
 
 set +e
+{{if  (.NeedsService) -}}
 echo "Service installed"
+systemctl daemon-reload
 systemctl enable {{.PackageName}}
-systemctl status {{.PackageName}}
+{{if  (.SystemdServiceConfig.AutoStart) -}}
+systemctl start {{.PackageName}}
+{{end -}}
+systemctl --no-pager status {{.PackageName}}
 echo "run systemctl start {{.PackageName}} to start"
+{{end -}}
+`
+
+	prermTmpl = `#!/bin/bash
+set +e
+{{if  (.NeedsService) -}}
+systemctl stop {{.PackageName}}
+systemctl disable {{.PackageName}}
+systemctl daemon-reload
+{{end -}}
 `
 )


### PR DESCRIPTION
* allow absolute paths in copy-files and mkdirs
* perform daemon-reload before starting service
* auto-start options to automatically start service
* "prerm" script to stop service before removing package files
* do not create a service if no binary specified
* documentation

