### PR TITLE
refactor(api): redisStore with err

### DIFF
--- a/engine/api/accesstoken/accesstoken.go
+++ b/engine/api/accesstoken/accesstoken.go
@@ -129,7 +129,11 @@ func CheckXSRFToken(store cache.Store, accessToken sdk.AccessToken, xsrfToken st
 	log.Debug("accesstoken.CheckXSRFToken")
 	var expectedXSRFfToken string
 	var k = cache.Key("token", "xsrf", accessToken.ID)
-	if store.Get(k, &expectedXSRFfToken) {
+	find, err := store.Get(k, &expectedXSRFfToken)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
+	if find {
 		return expectedXSRFfToken == xsrfToken
 	}
 	return false

--- a/engine/api/accesstoken/accesstoken.go
+++ b/engine/api/accesstoken/accesstoken.go
@@ -120,7 +120,9 @@ func StoreXSRFToken(store cache.Store, accessToken sdk.AccessToken) string {
 	log.Debug("accesstoken.StoreXSRFToken")
 	var xsrfToken = sdk.UUID()
 	var k = cache.Key("token", "xsrf", accessToken.ID)
-	store.SetWithTTL(k, &xsrfToken, _XSRFTokenDuration)
+	if err := store.SetWithTTL(k, &xsrfToken, _XSRFTokenDuration); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 	return xsrfToken
 }
 

--- a/engine/api/admin.go
+++ b/engine/api/admin.go
@@ -18,10 +18,10 @@ import (
 func (api *API) postMaintenanceHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		enable := FormString(r, "enable")
-		api.Cache.Publish(sdk.MaintenanceQueueName, enable)
-		return nil
+		return api.Cache.Publish(sdk.MaintenanceQueueName, enable)
 	}
 }
+
 func (api *API) adminTruncateWarningsHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		if _, err := api.mustDB().Exec("delete from warning"); err != nil {

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -713,7 +713,9 @@ func (a *API) Serve(ctx context.Context) error {
 
 	log.Info("Initializing internal routines...")
 	sdk.GoRoutine(ctx, "maintenance.Subscribe", func(ctx context.Context) {
-		a.listenMaintenance(ctx)
+		if err := a.listenMaintenance(ctx); err != nil {
+			log.Error("error while initializing listen maintenance routine: %s", err)
+		}
 	}, a.PanicDump())
 
 	sdk.GoRoutine(ctx, "workermodel.Initialize", func(ctx context.Context) {

--- a/engine/api/auth/auth.go
+++ b/engine/api/auth/auth.go
@@ -98,7 +98,10 @@ func GetWorker(db *gorp.DbMap, store cache.Store, workerID, workerName string) (
 	var w = &sdk.Worker{}
 
 	key := cache.Key("worker", workerID)
-	b := store.Get(key, w)
+	b, err := store.Get(key, w)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", key, err)
+	}
 	if !b || w.ActionBuildID == 0 {
 		var err error
 		w, err = worker.LoadWorker(db, workerID)
@@ -118,8 +121,11 @@ func GetService(db *gorp.DbMap, store cache.Store, hash string) (*sdk.Service, e
 	//TODO: this should be embeded in the repository layer
 	var srv = &sdk.Service{}
 	key := cache.Key("services", hash)
-	// Else load it from DB
-	if !store.Get(key, srv) {
+	find, err := store.Get(key, srv)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", key, err)
+	}
+	if !find { // Else load it from DB
 		var err error
 		srv, err = services.FindByHash(db, hash)
 		if err != nil {

--- a/engine/api/auth/auth.go
+++ b/engine/api/auth/auth.go
@@ -105,7 +105,9 @@ func GetWorker(db *gorp.DbMap, store cache.Store, workerID, workerName string) (
 		if err != nil {
 			return nil, fmt.Errorf("cannot load worker '%s': %s", workerName, err)
 		}
-		store.Set(key, w)
+		if err := store.Set(key, w); err != nil {
+			log.Error("unable to cache set %v: %v", key, err)
+		}
 	}
 	return w, nil
 }
@@ -127,7 +129,9 @@ func GetService(db *gorp.DbMap, store cache.Store, hash string) (*sdk.Service, e
 			srv.IsSharedInfra = true
 			srv.Uptodate = srv.Version == sdk.VERSION
 		}
-		store.Set(key, srv)
+		if err := store.Set(key, srv); err != nil {
+			log.Error("unable to cache set %v: %v", key, err)
+		}
 	}
 	return srv, nil
 }

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -25,7 +25,7 @@ type Store interface {
 	Get(key string, value interface{}) bool
 	Set(key string, value interface{})
 	SetWithTTL(key string, value interface{}, ttl int)
-	UpdateTTL(key string, ttl int)
+	UpdateTTL(key string, ttl int) error
 	Delete(key string)
 	DeleteAll(key string)
 	Enqueue(queueName string, value interface{}) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -31,7 +31,7 @@ type Store interface {
 	Enqueue(queueName string, value interface{}) error
 	DequeueWithContext(c context.Context, queueName string, value interface{}) error
 	QueueLen(queueName string) (int, error)
-	RemoveFromQueue(queueName string, memberKey string)
+	RemoveFromQueue(queueName string, memberKey string) error
 	Publish(queueName string, value interface{})
 	Subscribe(queueName string) PubSub
 	GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -22,7 +22,7 @@ func Key(args ...string) string {
 
 //Store is an interface
 type Store interface {
-	Get(key string, value interface{}) bool
+	Get(key string, value interface{}) (bool, error)
 	Set(key string, value interface{}) error
 	SetWithTTL(key string, value interface{}, ttl int) error
 	UpdateTTL(key string, ttl int) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -33,7 +33,7 @@ type Store interface {
 	QueueLen(queueName string) (int, error)
 	RemoveFromQueue(queueName string, memberKey string) error
 	Publish(queueName string, value interface{}) error
-	Subscribe(queueName string) PubSub
+	Subscribe(queueName string) (PubSub, error)
 	GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)
 	Status() sdk.MonitoringStatusLine
 	SetAdd(rootKey string, memberKey string, member interface{}) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -23,8 +23,8 @@ func Key(args ...string) string {
 //Store is an interface
 type Store interface {
 	Get(key string, value interface{}) bool
-	Set(key string, value interface{})
-	SetWithTTL(key string, value interface{}, ttl int)
+	Set(key string, value interface{}) error
+	SetWithTTL(key string, value interface{}, ttl int) error
 	UpdateTTL(key string, ttl int) error
 	Delete(key string) error
 	DeleteAll(key string) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -30,7 +30,7 @@ type Store interface {
 	DeleteAll(key string)
 	Enqueue(queueName string, value interface{}) error
 	DequeueWithContext(c context.Context, queueName string, value interface{}) error
-	QueueLen(queueName string) int
+	QueueLen(queueName string) (int, error)
 	RemoveFromQueue(queueName string, memberKey string)
 	Publish(queueName string, value interface{})
 	Subscribe(queueName string) PubSub

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -32,7 +32,7 @@ type Store interface {
 	DequeueWithContext(c context.Context, queueName string, value interface{}) error
 	QueueLen(queueName string) (int, error)
 	RemoveFromQueue(queueName string, memberKey string) error
-	Publish(queueName string, value interface{})
+	Publish(queueName string, value interface{}) error
 	Subscribe(queueName string) PubSub
 	GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)
 	Status() sdk.MonitoringStatusLine

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -37,7 +37,7 @@ type Store interface {
 	GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)
 	Status() sdk.MonitoringStatusLine
 	SetAdd(rootKey string, memberKey string, member interface{})
-	SetRemove(rootKey string, memberKey string, member interface{})
+	SetRemove(rootKey string, memberKey string, member interface{}) error
 	SetCard(key string) int
 	SetScan(key string, members ...interface{}) error
 	ZScan(key, pattern string) ([]string, error)

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 // PubSub represents a subscriber
@@ -67,6 +68,8 @@ type writerCloser struct {
 }
 
 func (w *writerCloser) Close() error {
-	w.store.SetWithTTL(w.key, w.String(), w.ttl)
+	if err := w.store.SetWithTTL(w.key, w.String(), w.ttl); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", w.key, err)
+	}
 	return nil
 }

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -38,7 +38,7 @@ type Store interface {
 	Status() sdk.MonitoringStatusLine
 	SetAdd(rootKey string, memberKey string, member interface{}) error
 	SetRemove(rootKey string, memberKey string, member interface{}) error
-	SetCard(key string) int
+	SetCard(key string) (int, error)
 	SetScan(key string, members ...interface{}) error
 	ZScan(key, pattern string) ([]string, error)
 	Lock(key string, expiration time.Duration, retryWaitDurationMillisecond int, retryCount int) bool

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -29,7 +29,7 @@ type Store interface {
 	Delete(key string)
 	DeleteAll(key string)
 	Enqueue(queueName string, value interface{}) error
-	DequeueWithContext(c context.Context, queueName string, value interface{})
+	DequeueWithContext(c context.Context, queueName string, value interface{}) error
 	QueueLen(queueName string) int
 	RemoveFromQueue(queueName string, memberKey string)
 	Publish(queueName string, value interface{})

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -41,8 +41,8 @@ type Store interface {
 	SetCard(key string) (int, error)
 	SetScan(key string, members ...interface{}) error
 	ZScan(key, pattern string) ([]string, error)
-	Lock(key string, expiration time.Duration, retryWaitDurationMillisecond int, retryCount int) bool
-	Unlock(key string)
+	Lock(key string, expiration time.Duration, retryWaitDurationMillisecond int, retryCount int) (bool, error)
+	Unlock(key string) error
 }
 
 //New init a cache

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -28,8 +28,7 @@ type Store interface {
 	UpdateTTL(key string, ttl int)
 	Delete(key string)
 	DeleteAll(key string)
-	Enqueue(queueName string, value interface{})
-	Dequeue(queueName string, value interface{})
+	Enqueue(queueName string, value interface{}) error
 	DequeueWithContext(c context.Context, queueName string, value interface{})
 	QueueLen(queueName string) int
 	RemoveFromQueue(queueName string, memberKey string)

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -36,7 +36,7 @@ type Store interface {
 	Subscribe(queueName string) PubSub
 	GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)
 	Status() sdk.MonitoringStatusLine
-	SetAdd(rootKey string, memberKey string, member interface{})
+	SetAdd(rootKey string, memberKey string, member interface{}) error
 	SetRemove(rootKey string, memberKey string, member interface{}) error
 	SetCard(key string) int
 	SetScan(key string, members ...interface{}) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -26,7 +26,7 @@ type Store interface {
 	Set(key string, value interface{})
 	SetWithTTL(key string, value interface{}, ttl int)
 	UpdateTTL(key string, ttl int) error
-	Delete(key string)
+	Delete(key string) error
 	DeleteAll(key string) error
 	Enqueue(queueName string, value interface{}) error
 	DequeueWithContext(c context.Context, queueName string, value interface{}) error

--- a/engine/api/cache/cache.go
+++ b/engine/api/cache/cache.go
@@ -27,7 +27,7 @@ type Store interface {
 	SetWithTTL(key string, value interface{}, ttl int)
 	UpdateTTL(key string, ttl int) error
 	Delete(key string)
-	DeleteAll(key string)
+	DeleteAll(key string) error
 	Enqueue(queueName string, value interface{}) error
 	DequeueWithContext(c context.Context, queueName string, value interface{}) error
 	QueueLen(queueName string) (int, error)

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -399,7 +399,7 @@ func (s *RedisStore) ZScan(key, pattern string) ([]string, error) {
 	return keys, nil
 }
 
-func (s *RedisStore) Lock(key string, expiration time.Duration, retrywdMillisecond int, retryCount int) bool {
+func (s *RedisStore) Lock(key string, expiration time.Duration, retrywdMillisecond int, retryCount int) (bool, error) {
 	var errRedis error
 	var res bool
 	if retrywdMillisecond == -1 {
@@ -415,12 +415,10 @@ func (s *RedisStore) Lock(key string, expiration time.Duration, retrywdMilliseco
 		}
 		time.Sleep(time.Duration(retrywdMillisecond) * time.Millisecond)
 	}
-	if errRedis != nil {
-		log.Error("redis> set error %s: %v", key, errRedis)
-	}
-	return res
+	return res, sdk.WrapError(errRedis, "redis> set error %s", key)
 }
 
-func (s *RedisStore) Unlock(key string) {
+func (s *RedisStore) Unlock(key string) error {
 	s.Delete(key)
+	return nil
 }

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -174,19 +174,17 @@ func (s *RedisStore) Enqueue(queueName string, value interface{}) error {
 }
 
 //QueueLen returns the length of a queue
-func (s *RedisStore) QueueLen(queueName string) int {
+func (s *RedisStore) QueueLen(queueName string) (int, error) {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return 0
+		return 0, fmt.Errorf("redis> cannot get redis client")
 	}
-
 	var errRedis error
 	var res int64
 	res, errRedis = s.Client.LLen(queueName).Result()
 	if errRedis != nil {
-		log.Warning("redis> Cannot read %s :%s", queueName, errRedis)
+		return 0, sdk.WrapError(errRedis, "redis> Cannot read %s", queueName)
 	}
-	return int(res)
+	return int(res), nil
 }
 
 //DequeueWithContext gets from queue This is blocking while there is nothing in the queue, it can be cancelled with a context.Context

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -251,12 +251,11 @@ func (s *RedisStore) Publish(channel string, value interface{}) error {
 }
 
 // Subscribe to a channel
-func (s *RedisStore) Subscribe(channel string) PubSub {
+func (s *RedisStore) Subscribe(channel string) (PubSub, error) {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return nil
+		return nil, fmt.Errorf("redis> cannot get redis client")
 	}
-	return s.Client.Subscribe(channel)
+	return s.Client.Subscribe(channel), nil
 }
 
 // GetMessageFromSubscription from a redis PubSub

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -140,22 +140,21 @@ func (s *RedisStore) Delete(key string) {
 }
 
 //DeleteAll delete all mathing keys in redis
-func (s *RedisStore) DeleteAll(pattern string) {
+func (s *RedisStore) DeleteAll(pattern string) error {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 	keys, err := s.Client.Keys(pattern).Result()
 	if err != nil {
-		log.Warning("redis> Error deleting %s : %s", pattern, err)
-		return
+		return sdk.WrapError(err, "redis> Error deleting %s", pattern)
 	}
 	if len(keys) == 0 {
-		return
+		return nil
 	}
 	if err := s.Client.Del(keys...).Err(); err != nil {
-		log.Warning("redis> Error deleting %s : %s", pattern, err)
+		return sdk.WrapError(err, "redis> Error deleting %s", pattern)
 	}
+	return nil
 }
 
 //Enqueue pushes to queue

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -311,8 +311,11 @@ func (s *RedisStore) Status() sdk.MonitoringStatusLine {
 }
 
 // RemoveFromQueue removes a member from a list
-func (s *RedisStore) RemoveFromQueue(rootKey string, memberKey string) {
-	s.Client.LRem(rootKey, 0, memberKey)
+func (s *RedisStore) RemoveFromQueue(rootKey string, memberKey string) error {
+	if err := s.Client.LRem(rootKey, 0, memberKey).Err(); err != nil {
+		return sdk.WrapError(err, "error on RemoveFromQueue: rooKey:%v memberKey:%v", rootKey, memberKey)
+	}
+	return nil
 }
 
 // SetAdd add a member (identified by a key) in the cached set

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -317,12 +317,16 @@ func (s *RedisStore) RemoveFromQueue(rootKey string, memberKey string) error {
 }
 
 // SetAdd add a member (identified by a key) in the cached set
-func (s *RedisStore) SetAdd(rootKey string, memberKey string, member interface{}) {
-	s.Client.ZAdd(rootKey, redis.Z{
+func (s *RedisStore) SetAdd(rootKey string, memberKey string, member interface{}) error {
+	err := s.Client.ZAdd(rootKey, redis.Z{
 		Member: memberKey,
 		Score:  float64(time.Now().UnixNano()),
-	})
+	}).Err()
+	if err != nil {
+		return sdk.WrapError(err, "error on SetAdd")
+	}
 	s.SetWithTTL(Key(rootKey, memberKey), member, -1)
+	return nil
 }
 
 // SetRemove removes a member from a set

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -128,15 +128,15 @@ func (s *RedisStore) Set(key string, value interface{}) {
 }
 
 //Delete a key in redis
-func (s *RedisStore) Delete(key string) {
+func (s *RedisStore) Delete(key string) error {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 
 	if err := s.Client.Del(key).Err(); err != nil {
-		log.Error("redis> error deleting %s : %s", key, err)
+		return sdk.WrapError(err, "redis> error deleting %s", key)
 	}
+	return nil
 }
 
 //DeleteAll delete all mathing keys in redis

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -113,7 +113,7 @@ func (s *RedisStore) SetWithTTL(key string, value interface{}, ttl int) {
 //UpdateTTL update the ttl linked to the key
 func (s *RedisStore) UpdateTTL(key string, ttl int) error {
 	if s.Client == nil {
-		return fmt.Errorf("redis> cannot get redis client")
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 
 	if err := s.Client.Expire(key, time.Duration(ttl)*time.Second).Err(); err != nil {
@@ -160,7 +160,7 @@ func (s *RedisStore) DeleteAll(pattern string) error {
 //Enqueue pushes to queue
 func (s *RedisStore) Enqueue(queueName string, value interface{}) error {
 	if s.Client == nil {
-		return fmt.Errorf("redis> cannot get redis client")
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 	b, err := json.Marshal(value)
 	if err != nil {
@@ -189,7 +189,7 @@ func (s *RedisStore) QueueLen(queueName string) (int, error) {
 //DequeueWithContext gets from queue This is blocking while there is nothing in the queue, it can be cancelled with a context.Context
 func (s *RedisStore) DequeueWithContext(c context.Context, queueName string, value interface{}) error {
 	if s.Client == nil {
-		return fmt.Errorf("redis> cannot get redis client")
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 
 	var elem string
@@ -225,7 +225,7 @@ func (s *RedisStore) DequeueWithContext(c context.Context, queueName string, val
 // Publish a msg in a channel
 func (s *RedisStore) Publish(channel string, value interface{}) error {
 	if s.Client == nil {
-		return fmt.Errorf("redis> cannot get redis client")
+		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
 
 	msg, err := json.Marshal(value)
@@ -417,6 +417,7 @@ func (s *RedisStore) Lock(key string, expiration time.Duration, retrywdMilliseco
 	return res, sdk.WrapError(errRedis, "redis> set error %s", key)
 }
 
+// Unlock deletes a key from cache
 func (s *RedisStore) Unlock(key string) error {
 	s.Delete(key)
 	return nil

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -224,22 +224,19 @@ func (s *RedisStore) DequeueWithContext(c context.Context, queueName string, val
 }
 
 // Publish a msg in a channel
-func (s *RedisStore) Publish(channel string, value interface{}) {
+func (s *RedisStore) Publish(channel string, value interface{}) error {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return
+		return fmt.Errorf("redis> cannot get redis client")
 	}
 
 	msg, err := json.Marshal(value)
 	if err != nil {
-		log.Warning("redis.Publish> Marshall error, cannot push in channel %s: %v", channel, err)
-		return
+		return sdk.WrapError(err, "redis.Publish> Marshall error, cannot push in channel %s", channel)
 	}
 
 	iUnquoted, err := strconv.Unquote(string(msg))
 	if err != nil {
-		log.Warning("redis.Publish> Unquote error, cannot push in channel %s: %v", channel, err)
-		return
+		return sdk.WrapError(err, "redis.Publish> Unquote error, cannot push in channel %s", channel)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -250,6 +247,7 @@ func (s *RedisStore) Publish(channel string, value interface{}) {
 		log.Warning("redis.Publish> Unable to publish in channel %s: %v", channel, errP)
 		time.Sleep(100 * time.Millisecond)
 	}
+	return nil
 }
 
 // Subscribe to a channel

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -326,9 +326,12 @@ func (s *RedisStore) SetAdd(rootKey string, memberKey string, member interface{}
 }
 
 // SetRemove removes a member from a set
-func (s *RedisStore) SetRemove(rootKey string, memberKey string, member interface{}) {
-	s.Client.ZRem(rootKey, memberKey)
+func (s *RedisStore) SetRemove(rootKey string, memberKey string, member interface{}) error {
+	if err := s.Client.ZRem(rootKey, memberKey).Err(); err != nil {
+		return sdk.WrapError(err, "error on SetRemove")
+	}
 	s.Delete(Key(rootKey, memberKey))
+	return nil
 }
 
 // SetCard returns the cardinality of a ZSet

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -339,8 +339,9 @@ func (s *RedisStore) SetRemove(rootKey string, memberKey string, member interfac
 }
 
 // SetCard returns the cardinality of a ZSet
-func (s *RedisStore) SetCard(key string) int {
-	return int(s.Client.ZCard(key).Val())
+func (s *RedisStore) SetCard(key string) (int, error) {
+	v := s.Client.ZCard(key)
+	return int(v.Val()), v.Err()
 }
 
 // SetScan scans a ZSet

--- a/engine/api/cache/redis.go
+++ b/engine/api/cache/redis.go
@@ -111,15 +111,15 @@ func (s *RedisStore) SetWithTTL(key string, value interface{}, ttl int) {
 }
 
 //UpdateTTL update the ttl linked to the key
-func (s *RedisStore) UpdateTTL(key string, ttl int) {
+func (s *RedisStore) UpdateTTL(key string, ttl int) error {
 	if s.Client == nil {
-		log.Error("redis> cannot get redis client")
-		return
+		return fmt.Errorf("redis> cannot get redis client")
 	}
 
 	if err := s.Client.Expire(key, time.Duration(ttl)*time.Second).Err(); err != nil {
-		log.Error("redis>UpdateTTL> set error %s: %v", key, err)
+		return sdk.WrapError(err, "redis>UpdateTTL> set error %s", key)
 	}
+	return nil
 }
 
 //Set a value in redis

--- a/engine/api/error.go
+++ b/engine/api/error.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 type graylogResponse struct {
@@ -84,7 +85,11 @@ func (api *API) getPanicDumpHandler() service.Handler {
 
 		k := cache.Key("api", "panic_dump", id)
 		var data string
-		if !api.Cache.Get(k, &data) {
+		find, err := api.Cache.Get(k, &data)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
+		if !find {
 			return sdk.ErrNotFound
 		}
 		w.Write([]byte(data)) // nolint

--- a/engine/api/event/event.go
+++ b/engine/api/event/event.go
@@ -140,7 +140,10 @@ func Subscribe(ch chan<- sdk.Event) {
 func DequeueEvent(c context.Context, db *gorp.DbMap) {
 	for {
 		e := sdk.Event{}
-		store.DequeueWithContext(c, "events", &e)
+		if err := store.DequeueWithContext(c, "events", &e); err != nil {
+			log.Error("Event.DequeueEvent> store.DequeueWithContext err: %v", err)
+			continue
+		}
 		if err := c.Err(); err != nil {
 			log.Error("Exiting event.DequeueEvent : %v", err)
 			return

--- a/engine/api/event/publish.go
+++ b/engine/api/event/publish.go
@@ -41,12 +41,10 @@ func publishEvent(e sdk.Event) error {
 	if err != nil {
 		return sdk.WrapError(err, "Cannot marshal event %+v", e)
 	}
-	store.Publish("events_pubsub", string(b))
-	return nil
+	return store.Publish("events_pubsub", string(b))
 }
 
 // Publish sends a event to a queue
-//func Publish(event sdk.Event, eventType string) {
 func Publish(payload interface{}, u *sdk.User) {
 	p := structs.Map(payload)
 	var projectKey, applicationName, pipelineName, environmentName, workflowName string

--- a/engine/api/event/publish.go
+++ b/engine/api/event/publish.go
@@ -9,17 +9,18 @@ import (
 
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/sdk"
-	"github.com/ovh/cds/sdk/log"
 )
 
 var store cache.Store
 
-func publishEvent(e sdk.Event) {
+func publishEvent(e sdk.Event) error {
 	if store == nil {
-		return
+		return nil
 	}
 
-	store.Enqueue("events", e)
+	if err := store.Enqueue("events", e); err != nil {
+		return err
+	}
 
 	// send to cache for cds repositories manager
 	var toSkipSendReposManager bool
@@ -31,15 +32,17 @@ func publishEvent(e sdk.Event) {
 		}
 	}
 	if !toSkipSendReposManager {
-		store.Enqueue("events_repositoriesmanager", e)
+		if err := store.Enqueue("events_repositoriesmanager", e); err != nil {
+			return err
+		}
 	}
 
 	b, err := json.Marshal(e)
 	if err != nil {
-		log.Warning("%v", sdk.WrapError(err, "Cannot marshal event %+v", e))
-		return
+		return sdk.WrapError(err, "Cannot marshal event %+v", e)
 	}
 	store.Publish("events_pubsub", string(b))
+	return nil
 }
 
 // Publish sends a event to a queue

--- a/engine/api/events.go
+++ b/engine/api/events.go
@@ -69,8 +69,11 @@ func (b *eventsBroker) cacheSubscribe(c context.Context, cacheMsgChan chan<- sdk
 	if cacheMsgChan == nil {
 		return
 	}
-
-	pubSub := store.Subscribe("events_pubsub")
+	pubSub, err := store.Subscribe("events_pubsub")
+	if err != nil {
+		log.Error("events.cacheSubscribe> Exiting on error: %v", err)
+		return
+	}
 	tick := time.NewTicker(50 * time.Millisecond)
 	defer tick.Stop()
 	for {

--- a/engine/api/feature.go
+++ b/engine/api/feature.go
@@ -10,7 +10,6 @@ import (
 
 func (api *API) cleanFeatureHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		feature.Clean(api.Cache)
-		return nil
+		return feature.Clean(api.Cache)
 	}
 }

--- a/engine/api/feature/flipping.go
+++ b/engine/api/feature/flipping.go
@@ -49,7 +49,12 @@ func SetClient(c *izanami.Client) {
 func GetFeatures(store cache.Store, projectKey string) map[string]bool {
 	projFeats := ProjectFeatures{}
 
-	if store.Get(cacheFeatureKey+projectKey, &projFeats) {
+	k := cacheFeatureKey + projectKey
+	find, err := store.Get(k, &projFeats)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
+	if find {
 		// if missing features, invalidate cache and rebuild data from Izanami
 		var missingFeature bool
 		for _, f := range List() {

--- a/engine/api/feature/flipping.go
+++ b/engine/api/feature/flipping.go
@@ -70,7 +70,9 @@ func GetFeatures(store cache.Store, projectKey string) map[string]bool {
 	}
 
 	// no expiration delay is set, the cache is cleared by Izanami calls on /feature/clean
-	store.Set(cacheFeatureKey+projectKey, projFeats)
+	if err := store.Set(cacheFeatureKey+projectKey, projFeats); err != nil {
+		log.Error("unable to cache set %v: %v", cacheFeatureKey+projectKey, err)
+	}
 
 	return projFeats.Features
 }

--- a/engine/api/feature/flipping.go
+++ b/engine/api/feature/flipping.go
@@ -108,7 +108,7 @@ func getStatusFromIzanami(featureID string, projectKey string) bool {
 }
 
 // Clean the feature cache
-func Clean(store cache.Store) {
+func Clean(store cache.Store) error {
 	keys := cache.Key(cacheFeatureKey, "*")
-	store.DeleteAll(keys)
+	return store.DeleteAll(keys)
 }

--- a/engine/api/maintenance.go
+++ b/engine/api/maintenance.go
@@ -9,16 +9,18 @@ import (
 	"github.com/ovh/cds/sdk/log"
 )
 
-func (a *API) listenMaintenance(c context.Context) {
-	pubSub := a.Cache.Subscribe(sdk.MaintenanceQueueName)
+func (a *API) listenMaintenance(c context.Context) error {
+	pubSub, err := a.Cache.Subscribe(sdk.MaintenanceQueueName)
+	if err != nil {
+		return sdk.WrapError(err, "listenMaintenance> unable to subscribe to %s", sdk.MaintenanceQueueName)
+	}
 	tick := time.NewTicker(50 * time.Millisecond)
 	defer tick.Stop()
 	for {
 		select {
 		case <-c.Done():
 			if c.Err() != nil {
-				log.Error("listenMaintenance> Exiting: %v", c.Err())
-				return
+				return sdk.WrapError(c.Err(), "listenMaintenance> Exiting")
 			}
 		case <-tick.C:
 			msg, err := a.Cache.GetMessageFromSubscription(c, pubSub)

--- a/engine/api/observability/helper.go
+++ b/engine/api/observability/helper.go
@@ -124,7 +124,9 @@ func findPrimaryKeyFromRequest(req *http.Request, db gorp.SqlExecutor, store cac
 					log.Error("tracingMiddleware> %v", err)
 					return "", false
 				}
-				store.SetWithTTL(cacheKey, pkey, 60*15)
+				if err := store.SetWithTTL(cacheKey, pkey, 60*15); err != nil {
+					log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+				}
 			}
 		}
 	}

--- a/engine/api/observability/helper.go
+++ b/engine/api/observability/helper.go
@@ -114,7 +114,11 @@ func findPrimaryKeyFromRequest(req *http.Request, db gorp.SqlExecutor, store cac
 		if id != 0 {
 			var err error
 			cacheKey := cache.Key("api:FindProjetKeyForNodeRunJob:", fmt.Sprintf("%v", id))
-			if !store.Get(cacheKey, &pkey) {
+			find, errGet := store.Get(cacheKey, &pkey)
+			if errGet != nil {
+				log.Error("cannot get from cache %s: %v", cacheKey, errGet)
+			}
+			if !find {
 				pkey, err = findProjetKeyForNodeRunJob(db, id)
 				if err != nil {
 					log.Error("tracingMiddleware> %v", err)

--- a/engine/api/permission.go
+++ b/engine/api/permission.go
@@ -80,7 +80,11 @@ func (api *API) checkWorkerPermission(ctx context.Context, db gorp.SqlExecutor, 
 	//IF it is POSTEXECUTE, it means that the job is must be taken by the worker
 	if rc.Options["isExecution"] == "true" {
 		k := cache.Key("workers", getWorker(ctx).ID, "perm", idS)
-		if api.Cache.Get(k, &ok) {
+		find, err := api.Cache.Get(k, &ok)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
+		if find {
 			if ok {
 				return ok
 			}

--- a/engine/api/permission.go
+++ b/engine/api/permission.go
@@ -97,7 +97,9 @@ func (api *API) checkWorkerPermission(ctx context.Context, db gorp.SqlExecutor, 
 		}
 
 		ok = runNodeJob.ID == getWorker(ctx).ActionBuildID
-		api.Cache.SetWithTTL(k, ok, 60*15)
+		if err := api.Cache.SetWithTTL(k, ok, 60*15); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 		if !ok {
 			log.Error("checkWorkerPermission> actionBuildID:%v runNodeJob.ID:%v", getWorker(ctx).ActionBuildID, runNodeJob.ID)
 		}

--- a/engine/api/repositories_manager.go
+++ b/engine/api/repositories_manager.go
@@ -395,7 +395,9 @@ func (api *API) getReposFromRepositoriesManagerHandler() service.Handler {
 
 		cacheKey := cache.Key("reposmanager", "repos", projectKey, rmName)
 		if sync {
-			api.Cache.Delete(cacheKey)
+			if err := api.Cache.Delete(cacheKey); err != nil {
+				log.Error("getReposFromRepositoriesManagerHandler> error on delete cache key %v: %s", cacheKey, err)
+			}
 		}
 
 		var repos []sdk.VCSRepo

--- a/engine/api/repositories_manager.go
+++ b/engine/api/repositories_manager.go
@@ -90,7 +90,10 @@ func (api *API) repositoriesManagerAuthorizeHandler() service.Handler {
 			data["auth_type"] = "basic"
 		}
 
-		api.Cache.Set(cache.Key("reposmanager", "oauth", token), data)
+		keyr := cache.Key("reposmanager", "oauth", token)
+		if err := api.Cache.Set(keyr, data); err != nil {
+			log.Error("unable to cache set %v: %v", keyr, err)
+		}
 		return service.WriteJSON(w, data, http.StatusOK)
 	}
 }

--- a/engine/api/repositories_manager.go
+++ b/engine/api/repositories_manager.go
@@ -416,7 +416,9 @@ func (api *API) getReposFromRepositoriesManagerHandler() service.Handler {
 		if !find || len(repos) == 0 {
 			var errRepos error
 			repos, errRepos = client.Repos(ctx)
-			api.Cache.SetWithTTL(cacheKey, repos, 0)
+			if err := api.Cache.SetWithTTL(cacheKey, repos, 0); err != nil {
+				log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+			}
 			if errRepos != nil {
 				return sdk.WrapError(errRepos, "getReposFromRepositoriesManagerHandler> Cannot get repos: %v", errRepos)
 			}

--- a/engine/api/repositories_manager.go
+++ b/engine/api/repositories_manager.go
@@ -114,7 +114,12 @@ func (api *API) repositoriesManagerOAuthCallbackHandler() service.Handler {
 
 		data := map[string]string{}
 
-		if !api.Cache.Get(cache.Key("reposmanager", "oauth", state), &data) {
+		key := cache.Key("reposmanager", "oauth", state)
+		find, err := api.Cache.Get(key, &data)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", key, err)
+		}
+		if !find {
 			return sdk.WrapError(sdk.ErrForbidden, "repositoriesManagerAuthorizeCallback> Error")
 		}
 		projectKey := data["project_key"]
@@ -404,7 +409,11 @@ func (api *API) getReposFromRepositoriesManagerHandler() service.Handler {
 		}
 
 		var repos []sdk.VCSRepo
-		if !api.Cache.Get(cacheKey, &repos) || len(repos) == 0 {
+		find, err := api.Cache.Get(cacheKey, &repos)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", cacheKey, err)
+		}
+		if !find || len(repos) == 0 {
 			var errRepos error
 			repos, errRepos = client.Repos(ctx)
 			api.Cache.SetWithTTL(cacheKey, repos, 0)

--- a/engine/api/repositoriesmanager/events.go
+++ b/engine/api/repositoriesmanager/events.go
@@ -16,7 +16,10 @@ import (
 func ReceiveEvents(c context.Context, DBFunc func() *gorp.DbMap, store cache.Store) {
 	for {
 		e := sdk.Event{}
-		store.DequeueWithContext(c, "events_repositoriesmanager", &e)
+		if err := store.DequeueWithContext(c, "events_repositoriesmanager", &e); err != nil {
+			log.Error("repositoriesmanager.ReceiveEvents > store.DequeueWithContext err: %v", err)
+			continue
+		}
 		if err := c.Err(); err != nil {
 			log.Error("Exiting repositoriesmanager.ReceiveEvents: %v", err)
 			return

--- a/engine/api/router_util.go
+++ b/engine/api/router_util.go
@@ -21,8 +21,12 @@ func (api *API) deleteUserPermissionCache(ctx context.Context, store cache.Store
 		username := deprecatedGetUser(ctx).Username
 		kp := cache.Key("users", username, "perms")
 		kg := cache.Key("users", username, "groups")
-		store.Delete(kp)
-		store.Delete(kg)
+		if err := store.Delete(kp); err != nil {
+			log.Error("error on delete cache perms %v: %v", kp, err)
+		}
+		if err := store.Delete(kg); err != nil {
+			log.Error("error on delete cache groups %v: %v", kg, err)
+		}
 	}
 }
 

--- a/engine/api/sessionstore/sessionstore.go
+++ b/engine/api/sessionstore/sessionstore.go
@@ -58,7 +58,9 @@ func (s *sessionstore) New(session SessionKey) (SessionKey, error) {
 	}
 
 	k := cache.Key(cacheSessionStore, string(session))
-	s.cache.SetWithTTL(k, 1, s.ttl)
+	if err := s.cache.SetWithTTL(k, 1, s.ttl); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 	return session, nil
 }
 
@@ -71,7 +73,9 @@ func (s *sessionstore) Exists(session SessionKey) (bool, error) {
 	}
 
 	if exist {
-		s.cache.SetWithTTL(k, 1, s.ttl)
+		if err := s.cache.SetWithTTL(k, 1, s.ttl); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 	return exist, nil
 }
@@ -92,7 +96,9 @@ func (s *sessionstore) Get(session SessionKey, subkey string, i interface{}) err
 	if err != nil {
 		log.Error("cannot get from cache %s: %v", ks, err)
 	}
-	s.cache.SetWithTTL(ks, i, s.ttl)
+	if err := s.cache.SetWithTTL(ks, i, s.ttl); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", ks, err)
+	}
 	return nil
 }
 
@@ -108,7 +114,9 @@ func (s *sessionstore) Set(session SessionKey, subkey string, i interface{}) err
 	}
 
 	ks := cache.Key(k, subkey)
-	s.cache.SetWithTTL(ks, i, s.ttl)
+	if err := s.cache.SetWithTTL(ks, i, s.ttl); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", ks, err)
+	}
 
 	return nil
 }

--- a/engine/api/sessionstore/sessionstore.go
+++ b/engine/api/sessionstore/sessionstore.go
@@ -125,7 +125,10 @@ func (s *sessionstore) Delete(session SessionKey) error {
 	k := cache.Key(cacheSessionStore, string(session))
 	ks := cache.Key(cacheSessionStore, string(session), "*")
 	if err := s.cache.DeleteAll(k); err != nil {
-		return err
+		log.Error("unable to cache deleteAll %s: %v", k, err)
 	}
-	return s.cache.DeleteAll(ks)
+	if err := s.cache.DeleteAll(ks); err != nil {
+		log.Error("unable to cache deleteAll %s: %v", ks, err)
+	}
+	return nil
 }

--- a/engine/api/sessionstore/sessionstore.go
+++ b/engine/api/sessionstore/sessionstore.go
@@ -109,7 +109,8 @@ func (s *sessionstore) Set(session SessionKey, subkey string, i interface{}) err
 func (s *sessionstore) Delete(session SessionKey) error {
 	k := cache.Key(cacheSessionStore, string(session))
 	ks := cache.Key(cacheSessionStore, string(session), "*")
-	s.cache.DeleteAll(k)
-	s.cache.DeleteAll(ks)
-	return nil
+	if err := s.cache.DeleteAll(k); err != nil {
+		return err
+	}
+	return s.cache.DeleteAll(ks)
 }

--- a/engine/api/user.go
+++ b/engine/api/user.go
@@ -611,7 +611,12 @@ func (api *API) loginUserCallbackHandler() service.Handler {
 		}
 
 		var accessToken sdk.AccessToken
-		if !api.Cache.Get("api:loginUserHandler:RequestToken:"+request.RequestToken, &accessToken) {
+		key := "api:loginUserHandler:RequestToken:" + request.RequestToken
+		find, err := api.Cache.Get(key, &accessToken)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", key, err)
+		}
+		if !find {
 			return sdk.ErrNotFound
 		}
 

--- a/engine/api/user.go
+++ b/engine/api/user.go
@@ -502,7 +502,10 @@ func (api *API) loginUserHandler() service.Handler {
 			if err != nil {
 				return sdk.WithStack(err)
 			}
-			api.Cache.SetWithTTL("api:loginUserHandler:RequestToken:"+loginUserRequest.RequestToken, token, 30*60)
+			k := "api:loginUserHandler:RequestToken:" + loginUserRequest.RequestToken
+			if err := api.Cache.SetWithTTL(k, token, 30*60); err != nil {
+				log.Error("cannot SetWithTTL: %s: %v", k, err)
+			}
 		}
 
 		if err := group.CheckUserInDefaultGroup(api.mustDB(), u.ID); err != nil {

--- a/engine/api/worker.go
+++ b/engine/api/worker.go
@@ -105,7 +105,9 @@ func (api *API) disableWorkerHandler() service.Handler {
 
 		//Remove the worker from the cache
 		key := cache.Key("worker", id)
-		api.Cache.Delete(key)
+		if err := api.Cache.Delete(key); err != nil {
+			log.Error("disableWorkerHandler> unable to delete cache key %v: %v", key, err)
+		}
 
 		return nil
 	}

--- a/engine/api/worker.go
+++ b/engine/api/worker.go
@@ -144,7 +144,9 @@ func (api *API) workerCheckingHandler() service.Handler {
 		}
 		key := cache.Key("worker", wk.ID)
 		wk.Status = sdk.StatusChecking
-		api.Cache.Set(key, wk)
+		if err := api.Cache.Set(key, wk); err != nil {
+			log.Error("unable to cache set %v: %v", key, err)
+		}
 
 		return nil
 	}
@@ -172,7 +174,9 @@ func (api *API) workerWaitingHandler() service.Handler {
 		}
 		key := cache.Key("worker", wk.ID)
 		wk.Status = sdk.StatusWaiting
-		api.Cache.Set(key, wk)
+		if err := api.Cache.Set(key, wk); err != nil {
+			log.Error("unable to cache set %v: %v", key, err)
+		}
 
 		return nil
 	}

--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -367,7 +367,10 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 		return w, err
 	}
 	// delete from cache by group
-	store.Delete(cache.Key("api:workermodels:bygroup", fmt.Sprintf("%d", t.GroupID)))
+	keyGroup := cache.Key("api:workermodels:bygroup", fmt.Sprintf("%d", t.GroupID))
+	if err := store.Delete(keyGroup); err != nil {
+		log.Error("error on delete cache key %v: %v", keyGroup, err)
+	}
 
 	return w, nil
 }
@@ -396,7 +399,10 @@ func SetToBuilding(db gorp.SqlExecutor, store cache.Store, workerID string, acti
 
 	_, err := res.RowsAffected()
 	// delete the worker from the cache
-	store.Delete(cache.Key("worker", workerID))
+	key := cache.Key("worker", workerID)
+	if err := store.Delete(key); err != nil {
+		log.Error("setToBuilding> error while delete cache key %v", key)
+	}
 	return err
 }
 

--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -364,7 +364,7 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 	// FIXME should me managed by worker model package
 	keyWorkerModel := workermodel.KeyBookWorkerModel(modelID)
 	if err := store.UpdateTTL(keyWorkerModel, workermodel.CacheTTLInSeconds+10); err != nil {
-		return w, err
+		log.Error("cannot UpdateTTL in cache %s: %v", keyWorkerModel, err)
 	}
 	// delete from cache by group
 	keyGroup := cache.Key("api:workermodels:bygroup", fmt.Sprintf("%d", t.GroupID))

--- a/engine/api/worker/worker.go
+++ b/engine/api/worker/worker.go
@@ -363,7 +363,9 @@ func RegisterWorker(db *gorp.DbMap, store cache.Store, name string, key string, 
 	// Useful to let models cache in hatchery refresh
 	// FIXME should me managed by worker model package
 	keyWorkerModel := workermodel.KeyBookWorkerModel(modelID)
-	store.UpdateTTL(keyWorkerModel, workermodel.CacheTTLInSeconds+10)
+	if err := store.UpdateTTL(keyWorkerModel, workermodel.CacheTTLInSeconds+10); err != nil {
+		return w, err
+	}
 	// delete from cache by group
 	store.Delete(cache.Key("api:workermodels:bygroup", fmt.Sprintf("%d", t.GroupID)))
 

--- a/engine/api/worker_model.go
+++ b/engine/api/worker_model.go
@@ -45,7 +45,9 @@ func (api *API) postWorkerModelHandler() service.Handler {
 		}
 
 		key := cache.Key("api:workermodels:*")
-		api.Cache.DeleteAll(key)
+		if err := api.Cache.DeleteAll(key); err != nil {
+			return err
+		}
 
 		// reload complete worker model
 		new, err := workermodel.LoadByID(api.mustDB(), model.ID)
@@ -111,7 +113,9 @@ func (api *API) putWorkerModelHandler() service.Handler {
 		}
 
 		key := cache.Key("api:workermodels:*")
-		api.Cache.DeleteAll(key)
+		if err := api.Cache.DeleteAll(key); err != nil {
+			return err
+		}
 
 		new, err := workermodel.LoadByID(api.mustDB(), model.ID)
 		if err != nil {
@@ -155,9 +159,7 @@ func (api *API) deleteWorkerModelHandler() service.Handler {
 		}
 
 		key := cache.Key("api:workermodels:*")
-		api.Cache.DeleteAll(key)
-
-		return nil
+		return api.Cache.DeleteAll(key)
 	}
 }
 

--- a/engine/api/worker_model_hatchery.go
+++ b/engine/api/worker_model_hatchery.go
@@ -61,7 +61,9 @@ func (api *API) spawnErrorWorkerModelHandler() service.Handler {
 		}
 
 		key := cache.Key("api:workermodels:*")
-		api.Cache.DeleteAll(key)
+		if err := api.Cache.DeleteAll(key); err != nil {
+			return err
+		}
 		workermodel.UnbookForRegister(api.Cache, workerModelID)
 
 		return service.WriteJSON(w, nil, http.StatusOK)

--- a/engine/api/workermodel/dao.go
+++ b/engine/api/workermodel/dao.go
@@ -170,7 +170,9 @@ func LoadAllByUser(db gorp.SqlExecutor, store cache.Store, user *sdk.User, opts 
 		return nil, errl
 	}
 
-	store.SetWithTTL(key, models, CacheTTLInSeconds)
+	if err := store.SetWithTTL(key, models, CacheTTLInSeconds); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", key, err)
+	}
 	return models, nil
 }
 
@@ -226,7 +228,9 @@ func LoadAllUsableOnGroupWithClearPassword(db gorp.SqlExecutor, store cache.Stor
 		}
 	}
 
-	store.SetWithTTL(key, models, CacheTTLInSeconds)
+	if err := store.SetWithTTL(key, models, CacheTTLInSeconds); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", key, err)
+	}
 
 	return models, nil
 }

--- a/engine/api/workermodel/registration.go
+++ b/engine/api/workermodel/registration.go
@@ -152,5 +152,7 @@ func BookForRegister(store cache.Store, id int64, hatchery *sdk.Service) (*sdk.S
 // UnbookForRegister release the book
 func UnbookForRegister(store cache.Store, id int64) {
 	k := KeyBookWorkerModel(id)
-	store.Delete(k)
+	if err := store.Delete(k); err != nil {
+		log.Error("unable to delete cache key %v: %v", k, err)
+	}
 }

--- a/engine/api/workermodel/registration.go
+++ b/engine/api/workermodel/registration.go
@@ -141,7 +141,11 @@ func KeyBookWorkerModel(id int64) string {
 func BookForRegister(store cache.Store, id int64, hatchery *sdk.Service) (*sdk.Service, error) {
 	k := KeyBookWorkerModel(id)
 	h := sdk.Service{}
-	if !store.Get(k, &h) {
+	find, err := store.Get(k, &h)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
+	if !find {
 		// worker model not already booked, book it for 6 min
 		store.SetWithTTL(k, hatchery, bookRegisterTTLInSeconds)
 		return nil, nil

--- a/engine/api/workermodel/registration.go
+++ b/engine/api/workermodel/registration.go
@@ -147,7 +147,9 @@ func BookForRegister(store cache.Store, id int64, hatchery *sdk.Service) (*sdk.S
 	}
 	if !find {
 		// worker model not already booked, book it for 6 min
-		store.SetWithTTL(k, hatchery, bookRegisterTTLInSeconds)
+		if err := store.SetWithTTL(k, hatchery, bookRegisterTTLInSeconds); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 		return nil, nil
 	}
 	return &h, sdk.WrapError(sdk.ErrWorkerModelAlreadyBooked, "worker model %d already booked by %s (%d)", id, h.Name, h.ID)

--- a/engine/api/workflow/as_code.go
+++ b/engine/api/workflow/as_code.go
@@ -105,7 +105,10 @@ func UpdateAsCode(ctx context.Context, db *gorp.DbMap, store cache.Store, proj *
 	if err := PostRepositoryOperation(ctx, db, *proj, &ope, multipartData); err != nil {
 		return nil, sdk.WrapError(err, "unable to post repository operation")
 	}
-	store.SetWithTTL(cache.Key(CacheOperationKey, ope.UUID), ope, 300)
+	k := cache.Key(CacheOperationKey, ope.UUID)
+	if err := store.SetWithTTL(k, ope, 300); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	return &ope, nil
 }
@@ -175,7 +178,10 @@ func SyncAsCodeEvent(ctx context.Context, db gorp.SqlExecutor, store cache.Store
 func UpdateWorkflowAsCodeResult(ctx context.Context, db *gorp.DbMap, store cache.Store, p *sdk.Project, ope *sdk.Operation, wf *sdk.Workflow, u *sdk.User) {
 	counter := 0
 	defer func() {
-		store.SetWithTTL(cache.Key(CacheOperationKey, ope.UUID), ope, 300)
+		k := cache.Key(CacheOperationKey, ope.UUID)
+		if err := store.SetWithTTL(k, ope, 300); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}()
 	for {
 		counter++

--- a/engine/api/workflow/dao_node_run_job.go
+++ b/engine/api/workflow/dao_node_run_job.go
@@ -367,7 +367,12 @@ func keyBookJob(id int64) string {
 
 func getHatcheryInfo(store cache.Store, j *JobRun) {
 	h := sdk.Service{}
-	if store.Get(keyBookJob(j.ID), &h) {
+	k := keyBookJob(j.ID)
+	find, err := store.Get(k, &h)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
+	if find {
 		j.BookedBy = h
 	}
 }

--- a/engine/api/workflow/execute_node_job_run.go
+++ b/engine/api/workflow/execute_node_job_run.go
@@ -528,8 +528,9 @@ func FreeNodeJobRun(store cache.Store, id int64) error {
 	k := keyBookJob(id)
 	h := sdk.Service{}
 	if store.Get(k, &h) {
-		// job not already booked, book it for 2 min
-		store.Delete(k)
+		if err := store.Delete(k); err != nil {
+			log.Error("error on cache delete %v: %v", k, err)
+		}
 		return nil
 	}
 	return sdk.WrapError(sdk.ErrJobNotBooked, "BookNodeJobRun> job %d already released", id)

--- a/engine/api/workflow/execute_node_job_run.go
+++ b/engine/api/workflow/execute_node_job_run.go
@@ -522,7 +522,9 @@ func BookNodeJobRun(store cache.Store, id int64, hatchery *sdk.Service) (*sdk.Se
 	}
 	if !find {
 		// job not already booked, book it for 2 min
-		store.SetWithTTL(k, hatchery, 120)
+		if err := store.SetWithTTL(k, hatchery, 120); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 		return nil, nil
 	}
 	if h.ID == hatchery.ID {

--- a/engine/api/workflow/execute_node_run.go
+++ b/engine/api/workflow/execute_node_run.go
@@ -1021,6 +1021,8 @@ func getVCSInfos(ctx context.Context, db gorp.SqlExecutor, store cache.Store, pr
 		vcsInfos.Message = commit.Message
 	}
 
-	store.Set(cacheKey, vcsInfos)
+	if err := store.Set(cacheKey, vcsInfos); err != nil {
+		log.Error("unable to cache set %v: %v", cacheKey, err)
+	}
 	return &vcsInfos, nil
 }

--- a/engine/api/workflow/execute_node_run.go
+++ b/engine/api/workflow/execute_node_run.go
@@ -944,7 +944,11 @@ func getVCSInfos(ctx context.Context, db gorp.SqlExecutor, store cache.Store, pr
 
 	// Try to get the data from cache
 	cacheKey := cache.Key("api:workflow:getVCSInfos:", applicationVCSServer, applicationRepositoryFullname, vcsInfos.String())
-	if store.Get(cacheKey, &vcsInfos) {
+	find, err := store.Get(cacheKey, &vcsInfos)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", cacheKey, err)
+	}
+	if find {
 		log.Debug("completeVCSInfos> load from cache: %s", cacheKey)
 		return &vcsInfos, nil
 	}

--- a/engine/api/workflow_ascode.go
+++ b/engine/api/workflow_ascode.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovh/cds/engine/api/workflow"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 func (api *API) getWorkflowAsCodeHandler() service.Handler {
@@ -20,7 +21,11 @@ func (api *API) getWorkflowAsCodeHandler() service.Handler {
 		uuid := vars["uuid"]
 
 		var ope sdk.Operation
-		b := api.Cache.Get(cache.Key(workflow.CacheOperationKey, uuid), &ope)
+		k := cache.Key(workflow.CacheOperationKey, uuid)
+		b, err := api.Cache.Get(k, &ope)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
 		if !b {
 			return sdk.ErrNotFound
 		}

--- a/engine/api/workflow_queue_storage.go
+++ b/engine/api/workflow_queue_storage.go
@@ -262,7 +262,11 @@ func (api *API) postWorkflowJobArtifactWithTempURLCallbackHandler() service.Hand
 
 		cacheKey := cache.Key("workflows:artifacts", art.GetPath(), art.GetName())
 		cachedArt := sdk.WorkflowNodeRunArtifact{}
-		if !api.Cache.Get(cacheKey, &cachedArt) {
+		find, err := api.Cache.Get(cacheKey, &cachedArt)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", cacheKey, err)
+		}
+		if !find {
 			return sdk.WrapError(sdk.ErrNotFound, "postWorkflowJobArtifactWithTempURLCallbackHandler> Unable to find artifact, key:%s", cacheKey)
 		}
 

--- a/engine/api/workflow_queue_storage.go
+++ b/engine/api/workflow_queue_storage.go
@@ -374,7 +374,10 @@ func (api *API) postWorkflowJobArtifacWithTempURLHandler() service.Handler {
 		art.TempURLSecretKey = key
 
 		cacheKey := cache.Key("workflows:artifacts", art.GetPath(), art.GetName())
-		api.Cache.SetWithTTL(cacheKey, art, 60*60) //Put this in cache for 1 hour
+		//Put this in cache for 1 hour
+		if err := api.Cache.SetWithTTL(cacheKey, art, 60*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+		}
 
 		return service.WriteJSON(w, art, http.StatusOK)
 	}

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -12,7 +12,10 @@ type dao struct {
 }
 
 func (d *dao) FindAllTasks() ([]sdk.Task, error) {
-	nbTasks := d.store.SetCard(rootKey)
+	nbTasks, err := d.store.SetCard(rootKey)
+	if err != nil {
+		return nil, sdk.WrapError(err, "unsable to setCard %v", rootKey)
+	}
 	tasks := make([]*sdk.Task, nbTasks, nbTasks)
 	for i := 0; i < nbTasks; i++ {
 		tasks[i] = &sdk.Task{}
@@ -85,7 +88,10 @@ func (d *dao) QueueLen() (int, error) {
 }
 
 func (d *dao) FindAllTaskExecutions(t *sdk.Task) ([]sdk.TaskExecution, error) {
-	nbExecutions := d.store.SetCard(cache.Key(executionRootKey, t.Type, t.UUID))
+	nbExecutions, err := d.store.SetCard(cache.Key(executionRootKey, t.Type, t.UUID))
+	if err != nil {
+		return nil, sdk.WrapError(err, "unable to setCard %s", cache.Key(executionRootKey, t.Type, t.UUID))
+	}
 	execs := make([]*sdk.TaskExecution, nbExecutions, nbExecutions)
 	for i := 0; i < nbExecutions; i++ {
 		execs[i] = &sdk.TaskExecution{}

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -73,7 +73,7 @@ func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) error {
 	return d.store.Enqueue(schedulerQueueKey, k)
 }
 
-func (d *dao) QueueLen() int {
+func (d *dao) QueueLen() (int, error) {
 	return d.store.QueueLen(schedulerQueueKey)
 }
 

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 type dao struct {
@@ -39,7 +40,11 @@ func (d *dao) FindAllKeysMatchingPattern(pattern string) ([]string, error) {
 func (d *dao) FindTask(uuid string) *sdk.Task {
 	key := cache.Key(rootKey, uuid)
 	t := &sdk.Task{}
-	if d.store.Get(key, t) {
+	find, err := d.store.Get(key, t)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", key, err)
+	}
+	if find {
 		return t
 	}
 	return nil

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -83,7 +83,7 @@ func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) error {
 	k := cache.Key(executionRootKey, r.Type, r.UUID, fmt.Sprintf("%d", r.Timestamp))
 	// before enqueue, be sure that it's not in queue
 	if err := d.store.RemoveFromQueue(schedulerQueueKey, k); err != nil {
-		return err
+		log.Error("error on cache RemoveFromQueue %s: %v", schedulerQueueKey, err)
 	}
 	return d.store.Enqueue(schedulerQueueKey, k)
 }

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -46,12 +46,17 @@ func (d *dao) SaveTask(r *sdk.Task) {
 	d.store.SetAdd(rootKey, r.UUID, r)
 }
 
-func (d *dao) DeleteTask(r *sdk.Task) {
-	d.store.SetRemove(rootKey, r.UUID, r)
+func (d *dao) DeleteTask(r *sdk.Task) error {
+	if err := d.store.SetRemove(rootKey, r.UUID, r); err != nil {
+		return err
+	}
 	execs, _ := d.FindAllTaskExecutions(r)
 	for _, e := range execs {
-		d.DeleteTaskExecution(&e)
+		if err := d.DeleteTaskExecution(&e); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (d *dao) SaveTaskExecution(r *sdk.TaskExecution) {
@@ -60,10 +65,10 @@ func (d *dao) SaveTaskExecution(r *sdk.TaskExecution) {
 	d.store.SetAdd(setKey, execKey, r)
 }
 
-func (d *dao) DeleteTaskExecution(r *sdk.TaskExecution) {
+func (d *dao) DeleteTaskExecution(r *sdk.TaskExecution) error {
 	setKey := cache.Key(executionRootKey, r.Type, r.UUID)
 	execKey := fmt.Sprintf("%d", r.Timestamp)
-	d.store.SetRemove(setKey, execKey, r)
+	return d.store.SetRemove(setKey, execKey, r)
 }
 
 func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) error {

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -42,8 +42,8 @@ func (d *dao) FindTask(uuid string) *sdk.Task {
 	return nil
 }
 
-func (d *dao) SaveTask(r *sdk.Task) {
-	d.store.SetAdd(rootKey, r.UUID, r)
+func (d *dao) SaveTask(r *sdk.Task) error {
+	return d.store.SetAdd(rootKey, r.UUID, r)
 }
 
 func (d *dao) DeleteTask(r *sdk.Task) error {
@@ -59,10 +59,10 @@ func (d *dao) DeleteTask(r *sdk.Task) error {
 	return nil
 }
 
-func (d *dao) SaveTaskExecution(r *sdk.TaskExecution) {
+func (d *dao) SaveTaskExecution(r *sdk.TaskExecution) error {
 	setKey := cache.Key(executionRootKey, r.Type, r.UUID)
 	execKey := fmt.Sprintf("%d", r.Timestamp)
-	d.store.SetAdd(setKey, execKey, r)
+	return d.store.SetAdd(setKey, execKey, r)
 }
 
 func (d *dao) DeleteTaskExecution(r *sdk.TaskExecution) error {

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -66,11 +66,11 @@ func (d *dao) DeleteTaskExecution(r *sdk.TaskExecution) {
 	d.store.SetRemove(setKey, execKey, r)
 }
 
-func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) {
+func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) error {
 	k := cache.Key(executionRootKey, r.Type, r.UUID, fmt.Sprintf("%d", r.Timestamp))
 	// before enqueue, be sure that it's not in queue
 	d.store.RemoveFromQueue(schedulerQueueKey, k)
-	d.store.Enqueue(schedulerQueueKey, k)
+	return d.store.Enqueue(schedulerQueueKey, k)
 }
 
 func (d *dao) QueueLen() int {

--- a/engine/hooks/dao.go
+++ b/engine/hooks/dao.go
@@ -69,7 +69,9 @@ func (d *dao) DeleteTaskExecution(r *sdk.TaskExecution) {
 func (d *dao) EnqueueTaskExecution(r *sdk.TaskExecution) error {
 	k := cache.Key(executionRootKey, r.Type, r.UUID, fmt.Sprintf("%d", r.Timestamp))
 	// before enqueue, be sure that it's not in queue
-	d.store.RemoveFromQueue(schedulerQueueKey, k)
+	if err := d.store.RemoveFromQueue(schedulerQueueKey, k); err != nil {
+		return err
+	}
 	return d.store.Enqueue(schedulerQueueKey, k)
 }
 

--- a/engine/hooks/gerrit.go
+++ b/engine/hooks/gerrit.go
@@ -214,7 +214,9 @@ func (s *Service) ComputeGerritStreamEvent(ctx context.Context, vcsServer string
 				s.Dao.SaveTaskExecution(exec)
 
 				//Push the webhook execution in the queue, so it will be executed
-				s.Dao.EnqueueTaskExecution(exec)
+				if err := s.Dao.EnqueueTaskExecution(exec); err != nil {
+					log.Error("ComputeGerritStreamEvent > error on EnqueueTaskExecution %v", err)
+				}
 			}
 		}
 	}

--- a/engine/hooks/gerrit.go
+++ b/engine/hooks/gerrit.go
@@ -36,7 +36,10 @@ func (d *dao) RemoveGerritRepoHook(vcsServer string, repo string, g gerritTaskIn
 // FindGerritTasksByRepo get all gerrit hooks on the given repository
 func (d *dao) FindGerritTasksByRepo(vcsServer string, repo string) ([]gerritTaskInfo, error) {
 	key := cache.Key(gerritRepoKey, vcsServer, repo)
-	nbGerritHooks := d.store.SetCard(key)
+	nbGerritHooks, err := d.store.SetCard(key)
+	if err != nil {
+		return nil, sdk.WrapError(err, "unable to setCard %v", key)
+	}
 
 	hooks := make([]*gerritTaskInfo, nbGerritHooks)
 	for i := 0; i < nbGerritHooks; i++ {

--- a/engine/hooks/gerrit.go
+++ b/engine/hooks/gerrit.go
@@ -25,8 +25,8 @@ type gerritTaskInfo struct {
 }
 
 // RegisterGerritRepoHook register hook on gerrit repository
-func (d *dao) RegisterGerritRepoHook(vcsServer string, repo string, g gerritTaskInfo) {
-	d.store.SetAdd(cache.Key(gerritRepoKey, vcsServer, repo), g.UUID, g)
+func (d *dao) RegisterGerritRepoHook(vcsServer string, repo string, g gerritTaskInfo) error {
+	return d.store.SetAdd(cache.Key(gerritRepoKey, vcsServer, repo), g.UUID, g)
 }
 
 func (d *dao) RemoveGerritRepoHook(vcsServer string, repo string, g gerritTaskInfo) {

--- a/engine/hooks/hooks_handlers.go
+++ b/engine/hooks/hooks_handlers.go
@@ -247,11 +247,13 @@ func (s *Service) putTaskHandler() service.Handler {
 		}
 
 		//Save it
-		s.Dao.SaveTask(t)
+		if err := s.Dao.SaveTask(t); err != nil {
+			return sdk.WrapError(err, "Unable to save task %v", t)
+		}
 
 		//Start the task
 		if _, err := s.startTask(ctx, t); err != nil {
-			return sdk.WrapError(err, "Unable start task %+v", t)
+			return sdk.WrapError(err, "Unable start task %v", t)
 		}
 
 		return nil
@@ -423,11 +425,13 @@ func (s *Service) addTask(ctx context.Context, h *sdk.NodeHook) error {
 	}
 
 	//Save the task
-	s.Dao.SaveTask(t)
+	if err := s.Dao.SaveTask(t); err != nil {
+		return sdk.WrapError(err, "unable to addTask %v", t)
+	}
 
 	//Start the task
 	if _, err := s.startTask(ctx, t); err != nil {
-		return sdk.WrapError(err, "Unable start task %+v", t)
+		return sdk.WrapError(err, "Unable start task %v", t)
 	}
 	return nil
 }
@@ -439,7 +443,9 @@ func (s *Service) addAndExecuteTask(ctx context.Context, nr sdk.WorkflowNodeRun)
 		return t, sdk.TaskExecution{}, sdk.WrapError(err, "Hooks> addAndExecuteTask> Unable to parse node run (%+v)", nr)
 	}
 	// Save the task
-	s.Dao.SaveTask(&t)
+	if err := s.Dao.SaveTask(&t); err != nil {
+		return t, sdk.TaskExecution{}, sdk.WrapError(err, "unable to save task %v", t)
+	}
 
 	// Start the task
 	e, err := s.startTask(ctx, &t)
@@ -478,7 +484,9 @@ func (s *Service) updateTask(ctx context.Context, h *sdk.NodeHook) error {
 		return sdk.WrapError(err, "Unable start task %+v", t)
 	}
 	// Save the task
-	s.Dao.SaveTask(t)
+	if err := s.Dao.SaveTask(t); err != nil {
+		return sdk.WrapError(err, "unable to save task %v", t)
+	}
 	return nil
 }
 

--- a/engine/hooks/hooks_handlers.go
+++ b/engine/hooks/hooks_handlers.go
@@ -498,7 +498,10 @@ func (s *Service) Status() sdk.MonitoringStatus {
 
 	// hook queue in status
 	status := sdk.MonitoringStatusOK
-	size := s.Dao.QueueLen()
+	size, errQ := s.Dao.QueueLen()
+	if errQ != nil {
+		log.Error("Status> Unable to retrieve queue len: %v", errQ)
+	}
 	if size >= 100 {
 		status = sdk.MonitoringStatusAlert
 	} else if size >= 10 {

--- a/engine/hooks/hooks_handlers.go
+++ b/engine/hooks/hooks_handlers.go
@@ -63,7 +63,9 @@ func (s *Service) webhookHandler() service.Handler {
 		s.Dao.SaveTaskExecution(exec)
 
 		//Push the webhook execution in the queue, so it will be executed
-		s.Dao.EnqueueTaskExecution(exec)
+		if err := s.Dao.EnqueueTaskExecution(exec); err != nil {
+			return err
+		}
 
 		//Return the execution
 		return service.WriteJSON(w, exec, http.StatusOK)

--- a/engine/hooks/kafka.go
+++ b/engine/hooks/kafka.go
@@ -112,7 +112,9 @@ func (s *Service) startKafkaHook(t *sdk.Task) error {
 				Kafka:     &sdk.KafkaTaskExecution{Message: msg.Value},
 			}
 			s.Dao.SaveTaskExecution(&exec)
-			s.Dao.EnqueueTaskExecution(&exec)
+			if err := s.Dao.EnqueueTaskExecution(&exec); err != nil {
+				log.Error("startKafkaHook > error on EnqueueTaskExecution: %v", err)
+			}
 			consumer.MarkOffset(msg, "delivered")
 		}
 	}()

--- a/engine/hooks/rabbitmq.go
+++ b/engine/hooks/rabbitmq.go
@@ -82,7 +82,9 @@ func (s *Service) startRabbitMQHook(t *sdk.Task) error {
 				RabbitMQ:  &sdk.RabbitMQTaskExecution{Message: d.Body},
 			}
 			s.Dao.SaveTaskExecution(&exec)
-			s.Dao.EnqueueTaskExecution(&exec)
+			if err := s.Dao.EnqueueTaskExecution(&exec); err != nil {
+				log.Error("startRabbitMQHook > error on EnqueueTaskExecution: %v", err)
+			}
 		}
 		consumer.done <- nil
 	}()

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -239,7 +239,11 @@ func (s *Service) dequeueTaskExecutions(c context.Context) error {
 
 		// Load the task execution
 		var t = sdk.TaskExecution{}
-		if !s.Cache.Get(taskKey, &t) {
+		find, err := s.Cache.Get(taskKey, &t)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", taskKey, err)
+		}
+		if !find {
 			continue
 		}
 		t.ProcessingTimestamp = time.Now().UnixNano()

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -56,7 +56,11 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 		case <-c.Done():
 			return c.Err()
 		case <-tick.C:
-			size := s.Dao.QueueLen()
+			size, err := s.Dao.QueueLen()
+			if err != nil {
+				log.Error("Hooks> retryTaskExecutionsRoutine > Unable to get queueLen: %v", err)
+				continue
+			}
 			if size > 20 {
 				log.Warning("Hooks> too many tasks in scheduler for now, skipped this retry ticker. size:%d", size)
 				continue
@@ -209,8 +213,11 @@ func (s *Service) dequeueTaskExecutions(c context.Context) error {
 		if c.Err() != nil {
 			return c.Err()
 		}
-
-		size := s.Dao.QueueLen()
+		size, err := s.Dao.QueueLen()
+		if err != nil {
+			log.Error("Hooks> dequeueTaskExecutions > Unable to get queueLen: %v", err)
+			continue
+		}
 		log.Debug("Hooks> dequeueTaskExecutions> current queue size: %d", size)
 
 		// Dequeuing context

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -215,7 +215,10 @@ func (s *Service) dequeueTaskExecutions(c context.Context) error {
 
 		// Dequeuing context
 		var taskKey string
-		s.Cache.DequeueWithContext(c, schedulerQueueKey, &taskKey)
+		if err := s.Cache.DequeueWithContext(c, schedulerQueueKey, &taskKey); err != nil {
+			log.Error("Hooks> dequeueTaskExecutions> store.DequeueWithContext err: %v", err)
+			continue
+		}
 		log.Debug("Hooks> dequeueTaskExecutions> work on taskKey: %s", taskKey)
 
 		// Load the task execution

--- a/engine/hooks/scheduler.go
+++ b/engine/hooks/scheduler.go
@@ -84,7 +84,9 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 							continue
 						}
 						log.Warning("Hooks> retryTaskExecutionsRoutine > Enqueing very old hooks %s %d/%d type:%s status:%s timestamp:%d err:%v", e.UUID, e.NbErrors, s.Cfg.RetryError, e.Type, e.Status, e.Timestamp, e.LastError)
-						s.Dao.EnqueueTaskExecution(&e)
+						if err := s.Dao.EnqueueTaskExecution(&e); err != nil {
+							log.Error("Hooks> retryTaskExecutionsRoutine > error on EnqueueTaskExecution: %v", err)
+						}
 					}
 					if e.NbErrors < s.Cfg.RetryError && e.LastError != "" {
 						// avoid re-enqueue if the lastError is about a git branch not found
@@ -95,7 +97,9 @@ func (s *Service) retryTaskExecutionsRoutine(c context.Context) error {
 							continue
 						}
 						log.Warning("Hooks> retryTaskExecutionsRoutine > Enqueing with lastError %s %d/%d type:%s status:%s len:%d err:%s", e.UUID, e.NbErrors, s.Cfg.RetryError, e.Type, e.Status, len(e.LastError), e.LastError)
-						s.Dao.EnqueueTaskExecution(&e)
+						if err := s.Dao.EnqueueTaskExecution(&e); err != nil {
+							log.Error("Hooks> retryTaskExecutionsRoutine > error on EnqueueTaskExecution: %v", err)
+						}
 						continue
 					}
 				}
@@ -136,7 +140,9 @@ func (s *Service) enqueueScheduledTaskExecutionsRoutine(c context.Context) error
 							e.Status = ""
 							s.Dao.SaveTaskExecution(&e)
 							log.Info("Hooks> enqueueScheduledTaskExecutionsRoutine > Enqueing %s task %s:%d", e.Type, e.UUID, e.Timestamp)
-							s.Dao.EnqueueTaskExecution(&e)
+							if err := s.Dao.EnqueueTaskExecution(&e); err != nil {
+								log.Error("Hooks> enqueueScheduledTaskExecutionsRoutine > error on EnqueueTaskExecution: %v", err)
+							}
 							alreadyEnqueued = true
 						}
 

--- a/engine/hooks/tasks.go
+++ b/engine/hooks/tasks.go
@@ -107,10 +107,13 @@ func (s *Service) synchronizeTasks(ctx context.Context) error {
 		}
 		t, err := s.hookToTask(&h)
 		if err != nil {
-			log.Error("Hook> Unable to transform hoot to tast task %+v: %v", h, err)
+			log.Error("Hook> Unable to transform hook to task %+v: %v", h, err)
 			continue
 		}
-		s.Dao.SaveTask(t)
+		if err := s.Dao.SaveTask(t); err != nil {
+			log.Error("Hook> Unable to save task %+v: %v", h, err)
+			continue
+		}
 	}
 
 	// Start listening to gerrit event stream
@@ -249,7 +252,9 @@ func (s *Service) stopTasks() error {
 
 func (s *Service) startTask(ctx context.Context, t *sdk.Task) (*sdk.TaskExecution, error) {
 	t.Stopped = false
-	s.Dao.SaveTask(t)
+	if err := s.Dao.SaveTask(t); err != nil {
+		return nil, sdk.WrapError(err, "unable to save task")
+	}
 
 	switch t.Type {
 	case TypeWebHook, TypeRepoManagerWebHook, TypeWorkflowHook:
@@ -348,7 +353,9 @@ func (s *Service) prepareNextScheduledTaskExecution(t *sdk.Task) error {
 func (s *Service) stopTask(t *sdk.Task) error {
 	log.Info("Hooks> Stopping task %s", t.UUID)
 	t.Stopped = true
-	s.Dao.SaveTask(t)
+	if err := s.Dao.SaveTask(t); err != nil {
+		return sdk.WrapError(err, "unable to save task %v", t)
+	}
 
 	switch t.Type {
 	case TypeWebHook, TypeScheduler, TypeRepoManagerWebHook, TypeRepoPoller, TypeKafka, TypeWorkflowHook:

--- a/engine/hooks/tasks.go
+++ b/engine/hooks/tasks.go
@@ -90,8 +90,11 @@ func (s *Service) synchronizeTasks(ctx context.Context) error {
 			}
 		}
 		if !found && t.Type != TypeOutgoingWebHook && t.Type != TypeOutgoingWorkflow {
-			s.deleteTask(ctx, t)
-			log.Info("Hook> Task %s deleted on synchronization", t.UUID)
+			if err := s.deleteTask(ctx, t); err != nil {
+				log.Error("Hook> Error on task %s delete on synchronization: %v", t.UUID, err)
+			} else {
+				log.Info("Hook> Task %s deleted on synchronization", t.UUID)
+			}
 		}
 	}
 

--- a/engine/repositories/cleaner.go
+++ b/engine/repositories/cleaner.go
@@ -46,7 +46,7 @@ func (s *Service) vacuumStoreCleanerRun() error {
 		}
 		if time.Since(*o.Date) > 24*time.Hour*time.Duration(s.Cfg.OperationRetention) {
 			if err := s.dao.deleteOperation(o); err != nil {
-				log.Error("vacuumStoreCleanerRun> unable to delete operation %s", o.UUID)
+				log.Error("vacuumStoreCleanerRun> unable to delete operation %s: %v", o.UUID, err)
 			}
 		}
 	}

--- a/engine/repositories/cleaner.go
+++ b/engine/repositories/cleaner.go
@@ -97,7 +97,9 @@ func (s *Service) vacuumFileSystemCleanerFunc(repoUUID string) error {
 		return err
 	}
 
-	s.dao.deleteLock(repoUUID)
+	if err := s.dao.deleteLock(repoUUID); err != nil {
+		log.Error("unable to deleteLock %v: %v", repoUUID, err)
+	}
 
 	return nil
 }

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -36,7 +36,11 @@ func (d *dao) deleteOperation(o *sdk.Operation) error {
 func (d *dao) loadOperation(uuid string) *sdk.Operation {
 	key := cache.Key(rootKey, uuid)
 	o := new(sdk.Operation)
-	if d.store.Get(key, o) {
+	find, err := d.store.Get(key, o)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", key, err)
+	}
+	if find {
 		return o
 	}
 	return nil
@@ -94,7 +98,11 @@ func (d *dao) unlock(uuid string, retention time.Duration) error {
 func (d *dao) isExpired(uuid string) bool {
 	k := cache.Key(lastAccessKey, uuid)
 	var b bool
-	if d.store.Get(k, &b) {
+	find, err := d.store.Get(k, &b)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
+	if find {
 		return false
 	}
 	return true

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -29,8 +29,7 @@ func (d *dao) pushOperation(o *sdk.Operation) error {
 }
 
 func (d *dao) deleteOperation(o *sdk.Operation) error {
-	d.store.SetRemove(rootKey, o.UUID, o)
-	return nil
+	return d.store.SetRemove(rootKey, o.UUID, o)
 }
 
 func (d *dao) loadOperation(uuid string) *sdk.Operation {
@@ -80,7 +79,7 @@ func (d *dao) lock(uuid string) error {
 func (d *dao) deleteLock(uuid string) error {
 	k := cache.Key(locksKey, uuid)
 	if err := d.store.Delete(k); err != nil {
-		return sdk.WrapError(err, "unable to cache delete %v: %v", k, err)
+		log.Error("unable to cache delete %s: %v", k, err)
 	}
 	return nil
 }

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -25,8 +25,7 @@ func (d *dao) saveOperation(o *sdk.Operation) error {
 }
 
 func (d *dao) pushOperation(o *sdk.Operation) error {
-	d.store.Enqueue(processorKey, o.UUID)
-	return nil
+	return d.store.Enqueue(processorKey, o.UUID)
 }
 
 func (d *dao) deleteOperation(o *sdk.Operation) error {

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -73,8 +73,12 @@ func (d *dao) lock(uuid string) error {
 	return nil
 }
 
-func (d *dao) deleteLock(uuid string) {
-	d.store.Delete(cache.Key(locksKey, uuid))
+func (d *dao) deleteLock(uuid string) error {
+	k := cache.Key(locksKey, uuid)
+	if err := d.store.Delete(k); err != nil {
+		return sdk.WrapError(err, "unable to cache delete %v: %v", k, err)
+	}
+	return nil
 }
 
 func (d *dao) unlock(uuid string, retention time.Duration) error {

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -42,7 +42,10 @@ func (d *dao) loadOperation(uuid string) *sdk.Operation {
 }
 
 func (d *dao) loadAllOperations() ([]*sdk.Operation, error) {
-	n := d.store.SetCard(rootKey)
+	n, err := d.store.SetCard(rootKey)
+	if err != nil {
+		return nil, sdk.WrapError(err, "unable to setCard %v", rootKey)
+	}
 	opes := make([]*sdk.Operation, n)
 	for i := 0; i < n; i++ {
 		opes[i] = &sdk.Operation{}

--- a/engine/repositories/dao.go
+++ b/engine/repositories/dao.go
@@ -20,8 +20,7 @@ type dao struct {
 }
 
 func (d *dao) saveOperation(o *sdk.Operation) error {
-	d.store.SetAdd(rootKey, o.UUID, o)
-	return nil
+	return d.store.SetAdd(rootKey, o.UUID, o)
 }
 
 func (d *dao) pushOperation(o *sdk.Operation) error {

--- a/engine/repositories/processor.go
+++ b/engine/repositories/processor.go
@@ -11,7 +11,10 @@ import (
 func (s *Service) processor(ctx context.Context) error {
 	for {
 		var uuid string
-		s.dao.store.DequeueWithContext(ctx, processorKey, &uuid)
+		if err := s.dao.store.DequeueWithContext(ctx, processorKey, &uuid); err != nil {
+			log.Error("repositories > processor > store.DequeueWithContext err: %v", err)
+			continue
+		}
 		if uuid != "" {
 			op := s.dao.loadOperation(uuid)
 			if err := s.do(*op); err != nil {

--- a/engine/vcs/bitbucketcloud/client_user.go
+++ b/engine/vcs/bitbucketcloud/client_user.go
@@ -36,7 +36,11 @@ func (client *bitbucketcloudClient) CurrentUser(ctx context.Context) (User, erro
 	url := "/user"
 	cacheKey := cache.Key("vcs", "bitbucketcloud", "users", client.OAuthToken, url)
 
-	if !client.Cache.Get(cacheKey, &user) {
+	find, err := client.Cache.Get(cacheKey, &user)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", cacheKey, err)
+	}
+	if !find {
 		status, body, _, err := client.get(url)
 		if err != nil {
 			log.Warning("bitbucketcloudClient.CurrentUser> Error %s", err)
@@ -61,7 +65,11 @@ func (client *bitbucketcloudClient) Teams(ctx context.Context) (Teams, error) {
 	url := "/teams?role=member"
 	cacheKey := cache.Key("vcs", "bitbucketcloud", "users", "teams", client.OAuthToken, url)
 
-	if !client.Cache.Get(cacheKey, &teams) {
+	find, err := client.Cache.Get(cacheKey, &teams)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", cacheKey, err)
+	}
+	if !find {
 		status, body, _, err := client.get(url)
 		if err != nil {
 			log.Warning("bitbucketcloudClient.Teams> Error %s", err)

--- a/engine/vcs/bitbucketcloud/client_user.go
+++ b/engine/vcs/bitbucketcloud/client_user.go
@@ -53,7 +53,9 @@ func (client *bitbucketcloudClient) CurrentUser(ctx context.Context) (User, erro
 			return user, sdk.WithStack(err)
 		}
 		//Put the body on cache for 1 hour
-		client.Cache.SetWithTTL(cacheKey, user, 60*60)
+		if err := client.Cache.SetWithTTL(cacheKey, user, 60*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+		}
 	}
 
 	return user, nil
@@ -82,7 +84,9 @@ func (client *bitbucketcloudClient) Teams(ctx context.Context) (Teams, error) {
 			return teams, sdk.WithStack(err)
 		}
 		//Put the body on cache for 1 hour
-		client.Cache.SetWithTTL(cacheKey, teams, 60*60)
+		if err := client.Cache.SetWithTTL(cacheKey, teams, 60*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+		}
 	}
 
 	return teams, nil

--- a/engine/vcs/bitbucketserver/client_commit.go
+++ b/engine/vcs/bitbucketserver/client_commit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ovh/cds/engine/api/cache"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/log"
 )
 
 func (b *bitbucketClient) Commits(ctx context.Context, repo, branch, since, until string) ([]sdk.VCSCommit, error) {
@@ -20,7 +21,11 @@ func (b *bitbucketClient) Commits(ctx context.Context, repo, branch, since, unti
 
 	var stashCommitsKey = cache.Key("vcs", "bitbucket", b.consumer.URL, repo, "commits", "since@"+since, "until@"+until)
 
-	if !b.consumer.cache.Get(stashCommitsKey, &stashCommits) {
+	find, err := b.consumer.cache.Get(stashCommitsKey, &stashCommits)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", stashCommitsKey, err)
+	}
+	if !find {
 		response := CommitsResponse{}
 		path := fmt.Sprintf("/projects/%s/repos/%s/commits", project, slug)
 		params := url.Values{}
@@ -115,7 +120,11 @@ func (b *bitbucketClient) CommitsBetweenRefs(ctx context.Context, repo, base, he
 
 	var stashCommitsKey = cache.Key("vcs", "bitbucket", b.consumer.URL, repo, "compare/commits", "from@"+base, "to@"+head)
 
-	if !b.consumer.cache.Get(stashCommitsKey, &stashCommits) {
+	find, err := b.consumer.cache.Get(stashCommitsKey, &stashCommits)
+	if err != nil {
+		log.Error("cannot get from cache %s: %v", stashCommitsKey, err)
+	}
+	if !find {
 		response := CommitsResponse{}
 		path := fmt.Sprintf("/projects/%s/repos/%s/compare/commits", project, slug)
 		params := url.Values{}

--- a/engine/vcs/bitbucketserver/client_commit.go
+++ b/engine/vcs/bitbucketserver/client_commit.go
@@ -53,7 +53,10 @@ func (b *bitbucketClient) Commits(ctx context.Context, repo, branch, since, unti
 				break
 			}
 		}
-		b.consumer.cache.SetWithTTL(stashCommitsKey, stashCommits, 3*60*60) //3 hours
+		//3 hours
+		if err := b.consumer.cache.SetWithTTL(stashCommitsKey, stashCommits, 3*60*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", stashCommitsKey, err)
+		}
 	}
 
 	urlCommit := b.consumer.URL + "/projects/" + project + "/repos/" + slug + "/commits/"
@@ -152,7 +155,10 @@ func (b *bitbucketClient) CommitsBetweenRefs(ctx context.Context, repo, base, he
 				break
 			}
 		}
-		b.consumer.cache.SetWithTTL(stashCommitsKey, stashCommits, 3*60*60) //3 hours
+		//3 hours
+		if err := b.consumer.cache.SetWithTTL(stashCommitsKey, stashCommits, 3*60*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", stashCommitsKey, err)
+		}
 	}
 
 	urlCommit := b.consumer.URL + "/projects/" + project + "/repos/" + slug + "/compare/commits"

--- a/engine/vcs/bitbucketserver/http.go
+++ b/engine/vcs/bitbucketserver/http.go
@@ -156,7 +156,9 @@ func (c *bitbucketClient) do(ctx context.Context, method, api, path string, para
 	}
 
 	if method != "GET" {
-		c.consumer.cache.Delete(cacheKey)
+		if err := c.consumer.cache.Delete(cacheKey); err != nil {
+			log.Error("bitbucketClient.do> unable to delete cache key %v: %v", cacheKey, err)
+		}
 	}
 
 	// Unmarshall the JSON response

--- a/engine/vcs/bitbucketserver/http.go
+++ b/engine/vcs/bitbucketserver/http.go
@@ -124,7 +124,11 @@ func (c *bitbucketClient) do(ctx context.Context, method, api, path string, para
 
 	cacheKey := cache.Key("vcs", "bitbucket", "request", req.URL.String(), token.Token())
 	if v != nil && method == "GET" {
-		if c.consumer.cache.Get(cacheKey, v) {
+		find, err := c.consumer.cache.Get(cacheKey, v)
+		if err != nil {
+			log.Error("cannot get from cache %s: %v", cacheKey, err)
+		}
+		if find {
 			return nil
 		}
 	}

--- a/engine/vcs/bitbucketserver/http.go
+++ b/engine/vcs/bitbucketserver/http.go
@@ -178,7 +178,9 @@ func (c *bitbucketClient) do(ctx context.Context, method, api, path string, para
 			}
 		}
 		if method == "GET" {
-			c.consumer.cache.Set(cacheKey, v)
+			if err := c.consumer.cache.Set(cacheKey, v); err != nil {
+				log.Error("unable to cache set %v: %v", cacheKey, err)
+			}
 		}
 	}
 

--- a/engine/vcs/github/client_branch.go
+++ b/engine/vcs/github/client_branch.go
@@ -76,7 +76,10 @@ func (g *githubClient) Branches(ctx context.Context, fullname string) ([]sdk.VCS
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "branches", g.OAuthToken, "/repos/"+fullname+"/branches"), branches, 61*60)
+	k := cache.Key("vcs", "github", "branches", g.OAuthToken, "/repos/"+fullname+"/branches")
+	if err := g.Cache.SetWithTTL(k, branches, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	branchesResult := []sdk.VCSBranch{}
 	for _, b := range branches {
@@ -145,7 +148,10 @@ func (g *githubClient) Branch(ctx context.Context, fullname, theBranch string) (
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "branches", g.OAuthToken, "/repos/"+fullname+"/branch/"+theBranch), branch, 61*60)
+	k := cache.Key("vcs", "github", "branches", g.OAuthToken, "/repos/"+fullname+"/branch/"+theBranch)
+	if err := g.Cache.SetWithTTL(k, branch, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	branchResult := &sdk.VCSBranch{
 		DisplayID:    branch.Name,

--- a/engine/vcs/github/client_branch.go
+++ b/engine/vcs/github/client_branch.go
@@ -121,7 +121,6 @@ func (g *githubClient) Branch(ctx context.Context, fullname, theBranch string) (
 		if !g.Cache.Get(cacheBranchKey, &branch) {
 			log.Error("Unable to get branch (%s) from the cache", cacheBranchKey)
 		}
-
 	} else {
 		if err := json.Unmarshal(body, &branch); err != nil {
 			log.Warning("githubClient.Branch> Unable to parse github branch: %s", err)

--- a/engine/vcs/github/client_branch.go
+++ b/engine/vcs/github/client_branch.go
@@ -102,11 +102,15 @@ func (g *githubClient) Branch(ctx context.Context, fullname, theBranch string) (
 	url := "/repos/" + fullname + "/branches/" + theBranch
 	status, body, _, err := g.get(url)
 	if err != nil {
-		g.Cache.Delete(cacheBranchKey)
+		if err := g.Cache.Delete(cacheBranchKey); err != nil {
+			log.Error("githubClient.Branch> unable to delete cache key %v: %v", cacheBranchKey, err)
+		}
 		return nil, err
 	}
 	if status >= 400 {
-		g.Cache.Delete(cacheBranchKey)
+		if err := g.Cache.Delete(cacheBranchKey); err != nil {
+			log.Error("githubClient.Branch> unable to delete cache key %v: %v", cacheBranchKey, err)
+		}
 		return nil, sdk.NewError(sdk.ErrUnknownError, errorAPI(body))
 	}
 
@@ -127,7 +131,9 @@ func (g *githubClient) Branch(ctx context.Context, fullname, theBranch string) (
 
 	if branch.Name == "" {
 		log.Warning("githubClient.Branch> Cannot find branch %v: %s", branch, theBranch)
-		g.Cache.Delete(cacheBranchKey)
+		if err := g.Cache.Delete(cacheBranchKey); err != nil {
+			log.Error("githubClient.Branch> unable to delete cache key %v: %v", cacheBranchKey, err)
+		}
 		return nil, fmt.Errorf("githubClient.Branch > Cannot find branch %s", theBranch)
 	}
 

--- a/engine/vcs/github/client_commit.go
+++ b/engine/vcs/github/client_commit.go
@@ -175,7 +175,10 @@ func (g *githubClient) Commits(ctx context.Context, repo, theBranch, since, unti
 		commitsResult = append(commitsResult, commit)
 	}
 
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "commits", repo, "since="+since, "until="+until), commitsResult, 3*60*60)
+	key := cache.Key("vcs", "github", "commits", repo, "since="+since, "until="+until)
+	if err := g.Cache.SetWithTTL(key, commitsResult, 3*60*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", key, err)
+	}
 
 	return commitsResult, nil
 }
@@ -247,7 +250,10 @@ func (g *githubClient) Commit(ctx context.Context, repo, hash string) (sdk.VCSCo
 			return sdk.VCSCommit{}, err
 		}
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cache.Key("vcs", "github", "commit", g.OAuthToken, url), c, 61*60)
+		k := cache.Key("vcs", "github", "commit", g.OAuthToken, url)
+		if err := g.Cache.SetWithTTL(k, c, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 
 	commit := sdk.VCSCommit{
@@ -308,7 +314,10 @@ func (g *githubClient) CommitsBetweenRefs(ctx context.Context, repo, base, head 
 			}
 		}
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cache.Key("vcs", "github", "commitdiff", g.OAuthToken, url), &commits, 61*60)
+		k := cache.Key("vcs", "github", "commitdiff", g.OAuthToken, url)
+		if err := g.Cache.SetWithTTL(k, &commits, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 
 	return commits, nil

--- a/engine/vcs/github/client_forks.go
+++ b/engine/vcs/github/client_forks.go
@@ -67,7 +67,10 @@ func (g *githubClient) ListForks(ctx context.Context, repo string) ([]sdk.VCSRep
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "forks", g.OAuthToken, "/user/", repo, "/forks"), repos, 61*60)
+	k := cache.Key("vcs", "github", "forks", g.OAuthToken, "/user/", repo, "/forks")
+	if err := g.Cache.SetWithTTL(k, repos, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	responseRepos := []sdk.VCSRepo{}
 	for _, repo := range repos {

--- a/engine/vcs/github/client_forks.go
+++ b/engine/vcs/github/client_forks.go
@@ -41,7 +41,10 @@ func (g *githubClient) ListForks(ctx context.Context, repo string) ([]sdk.VCSRep
 			//Github may return 304 status because we are using conditional request with ETag based headers
 			if status == http.StatusNotModified {
 				//If repos aren't updated, lets get them from cache
-				g.Cache.Get(cache.Key("vcs", "github", "forks", g.OAuthToken, "/user/", repo, "/forks"), &repos)
+				k := cache.Key("vcs", "github", "forks", g.OAuthToken, "/user/", repo, "/forks")
+				if _, err := g.Cache.Get(k, &repos); err != nil {
+					log.Error("cannot get from cache %s: %v", k, err)
+				}
 				if len(repos) != 0 || attempt > 5 {
 					//We found repos, let's exit the loop
 					break

--- a/engine/vcs/github/client_hook.go
+++ b/engine/vcs/github/client_hook.go
@@ -104,7 +104,9 @@ func (g *githubClient) getHooks(ctx context.Context, fullname string) ([]Webhook
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cacheKey, webhooks, 61*60)
+	if err := g.Cache.SetWithTTL(cacheKey, webhooks, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", cacheKey, err)
+	}
 	return webhooks, nil
 }
 

--- a/engine/vcs/github/client_hook.go
+++ b/engine/vcs/github/client_hook.go
@@ -83,7 +83,11 @@ func (g *githubClient) getHooks(ctx context.Context, fullname string) ([]Webhook
 		//Github may return 304 status because we are using conditional request with ETag based headers
 		if status == http.StatusNotModified {
 			//If repos aren't updated, lets get them from cache
-			if !g.Cache.Get(cacheKey, &webhooks) {
+			find, err := g.Cache.Get(cacheKey, &webhooks)
+			if err != nil {
+				log.Error("cannot get from cache %s: %v", cacheKey, err)
+			}
+			if !find {
 				opts[0] = withoutETag
 				log.Error("Unable to get getHooks (%s) from the cache", strings.ReplaceAll(cacheKey, g.OAuthToken, ""))
 				continue

--- a/engine/vcs/github/client_pull_request.go
+++ b/engine/vcs/github/client_pull_request.go
@@ -65,7 +65,9 @@ func (g *githubClient) PullRequest(ctx context.Context, fullname string, id int)
 		}
 
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cachePullRequestKey, pr, 61*60)
+		if err := g.Cache.SetWithTTL(cachePullRequestKey, pr, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", cachePullRequestKey, err)
+		}
 		break
 	}
 
@@ -121,7 +123,10 @@ func (g *githubClient) PullRequests(ctx context.Context, fullname string) ([]sdk
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "pullrequests", g.OAuthToken, "/repos/"+fullname+"/pulls"), pullRequests, 61*60)
+	k := cache.Key("vcs", "github", "pullrequests", g.OAuthToken, "/repos/"+fullname+"/pulls")
+	if err := g.Cache.SetWithTTL(k, pullRequests, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	prResults := []sdk.VCSPullRequest{}
 	for _, pullr := range pullRequests {

--- a/engine/vcs/github/client_pull_request.go
+++ b/engine/vcs/github/client_pull_request.go
@@ -39,7 +39,11 @@ func (g *githubClient) PullRequest(ctx context.Context, fullname string, id int)
 		//Github may return 304 status because we are using conditional request with ETag based headers
 		if status == http.StatusNotModified {
 			//If repos aren't updated, lets get them from cache
-			if !g.Cache.Get(cachePullRequestKey, &pr) {
+			find, err := g.Cache.Get(cachePullRequestKey, &pr)
+			if err != nil {
+				log.Error("cannot get from cache %s: %v", cachePullRequestKey, err)
+			}
+			if !find {
 				opts = []getArgFunc{withoutETag}
 				log.Error("Unable to get pullrequest (%s) from the cache", strings.ReplaceAll(cachePullRequestKey, g.OAuthToken, ""))
 				continue
@@ -91,7 +95,11 @@ func (g *githubClient) PullRequests(ctx context.Context, fullname string) ([]sdk
 			//Github may return 304 status because we are using conditional request with ETag based headers
 			if status == http.StatusNotModified {
 				//If repos aren't updated, lets get them from cache
-				if !g.Cache.Get(cacheKey, &pullRequests) {
+				find, err := g.Cache.Get(cacheKey, &pullRequests)
+				if err != nil {
+					log.Error("cannot get from cache %s: %v", cacheKey, err)
+				}
+				if !find {
 					opts[0] = withoutETag
 					log.Error("Unable to get pullrequest (%s) from the cache", strings.ReplaceAll(cacheKey, g.OAuthToken, ""))
 					continue

--- a/engine/vcs/github/client_pull_request.go
+++ b/engine/vcs/github/client_pull_request.go
@@ -24,11 +24,15 @@ func (g *githubClient) PullRequest(ctx context.Context, fullname string, id int)
 
 		status, body, _, err := g.get(url, opts...)
 		if err != nil {
-			g.Cache.Delete(cachePullRequestKey)
+			if err := g.Cache.Delete(cachePullRequestKey); err != nil {
+				log.Error("githubclient.PullRequest > unable to delete cache key %v: %v", cachePullRequestKey, err)
+			}
 			return sdk.VCSPullRequest{}, err
 		}
 		if status >= 400 {
-			g.Cache.Delete(cachePullRequestKey)
+			if err := g.Cache.Delete(cachePullRequestKey); err != nil {
+				log.Error("githubclient.PullRequest > unable to delete cache key %v: %v", cachePullRequestKey, err)
+			}
 			return sdk.VCSPullRequest{}, sdk.NewError(sdk.ErrUnknownError, errorAPI(body))
 		}
 
@@ -50,7 +54,9 @@ func (g *githubClient) PullRequest(ctx context.Context, fullname string, id int)
 
 		if pr.Number != id {
 			log.Warning("githubClient.PullRequest> Cannot find pullrequest %d", id)
-			g.Cache.Delete(cachePullRequestKey)
+			if err := g.Cache.Delete(cachePullRequestKey); err != nil {
+				log.Error("githubclient.PullRequest > unable to delete cache key %v: %v", cachePullRequestKey, err)
+			}
 			return sdk.VCSPullRequest{}, sdk.WithStack(fmt.Errorf("cannot find pullrequest %d", id))
 		}
 

--- a/engine/vcs/github/client_repos.go
+++ b/engine/vcs/github/client_repos.go
@@ -45,7 +45,10 @@ func (g *githubClient) Repos(ctx context.Context) ([]sdk.VCSRepo, error) {
 			//Github may return 304 status because we are using conditional request with ETag based headers
 			if status == http.StatusNotModified {
 				//If repos aren't updated, lets get them from cache
-				g.Cache.Get(cache.Key("vcs", "github", "repos", g.OAuthToken, "/user/repos"), &repos)
+				k := cache.Key("vcs", "github", "repos", g.OAuthToken, "/user/repos")
+				if _, err := g.Cache.Get(k, &repos); err != nil {
+					log.Error("cannot get from cache %s: %v", k, err)
+				}
 				if len(repos) != 0 || attempt > 5 {
 					//We found repos, let's exit the loop
 					break
@@ -126,7 +129,10 @@ func (g *githubClient) repoByFullname(fullname string) (Repository, error) {
 	//Github may return 304 status because we are using conditional request with ETag based headers
 	if status == http.StatusNotModified {
 		//If repo isn't updated, lets get them from cache
-		g.Cache.Get(cache.Key("vcs", "github", "repo", g.OAuthToken, url), &repo)
+		k := cache.Key("vcs", "github", "repo", g.OAuthToken, url)
+		if _, err := g.Cache.Get(k, &repo); err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
 	} else {
 		if err := json.Unmarshal(body, &repo); err != nil {
 			log.Warning("githubClient.Repos> Unable to parse github repository: %s", err)

--- a/engine/vcs/github/client_repos.go
+++ b/engine/vcs/github/client_repos.go
@@ -71,7 +71,10 @@ func (g *githubClient) Repos(ctx context.Context) ([]sdk.VCSRepo, error) {
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "repos", g.OAuthToken, "/user/repos"), repos, 61*60)
+	k := cache.Key("vcs", "github", "repos", g.OAuthToken, "/user/repos")
+	if err := g.Cache.SetWithTTL(k, repos, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	responseRepos := []sdk.VCSRepo{}
 	for _, repo := range repos {
@@ -139,7 +142,10 @@ func (g *githubClient) repoByFullname(fullname string) (Repository, error) {
 			return Repository{}, err
 		}
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cache.Key("vcs", "github", "repo", g.OAuthToken, url), repo, 61*60)
+		k := cache.Key("vcs", "github", "repo", g.OAuthToken, url)
+		if err := g.Cache.SetWithTTL(k, repo, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 
 	return repo, nil

--- a/engine/vcs/github/client_status.go
+++ b/engine/vcs/github/client_status.go
@@ -107,7 +107,10 @@ func (g *githubClient) ListStatuses(ctx context.Context, repo string, ref string
 	//Github may return 304 status because we are using conditional request with ETag based headers
 	if status == http.StatusNotModified {
 		//If repo isn't updated, lets get them from cache
-		g.Cache.Get(cache.Key("vcs", "github", "statuses", g.OAuthToken, url), &ss)
+		k := cache.Key("vcs", "github", "statuses", g.OAuthToken, url)
+		if _, err := g.Cache.Get(k, &ss); err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
 	} else {
 		if err := json.Unmarshal(body, &ss); err != nil {
 			return []sdk.VCSCommitStatus{}, sdk.WrapError(err, "Unable to parse github commit: %s", ref)

--- a/engine/vcs/github/client_status.go
+++ b/engine/vcs/github/client_status.go
@@ -116,7 +116,10 @@ func (g *githubClient) ListStatuses(ctx context.Context, repo string, ref string
 			return []sdk.VCSCommitStatus{}, sdk.WrapError(err, "Unable to parse github commit: %s", ref)
 		}
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cache.Key("vcs", "github", "statuses", g.OAuthToken, url), ss, 61*60)
+		k := cache.Key("vcs", "github", "statuses", g.OAuthToken, url)
+		if err := g.Cache.SetWithTTL(k, ss, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 
 	vcsStatuses := []sdk.VCSCommitStatus{}

--- a/engine/vcs/github/client_tag.go
+++ b/engine/vcs/github/client_tag.go
@@ -71,7 +71,10 @@ func (g *githubClient) Tags(ctx context.Context, fullname string) ([]sdk.VCSTag,
 	}
 
 	//Put the body on cache for one hour and one minute
-	g.Cache.SetWithTTL(cache.Key("vcs", "github", "tags", g.OAuthToken, "/repos/"+fullname+"/tags"), tags, 61*60)
+	k := cache.Key("vcs", "github", "tags", g.OAuthToken, "/repos/"+fullname+"/tags")
+	if err := g.Cache.SetWithTTL(k, tags, 61*60); err != nil {
+		log.Error("cannot SetWithTTL: %s: %v", k, err)
+	}
 
 	tagsResult := make([]sdk.VCSTag, len(tags))
 	j := 0

--- a/engine/vcs/github/client_tag.go
+++ b/engine/vcs/github/client_tag.go
@@ -45,7 +45,10 @@ func (g *githubClient) Tags(ctx context.Context, fullname string) ([]sdk.VCSTag,
 			//Github may return 304 status because we are using conditional request with ETag based headers
 			if status == http.StatusNotModified {
 				//If repos aren't updated, lets get them from cache
-				g.Cache.Get(cache.Key("vcs", "github", "tags", g.OAuthToken, "/repos/"+fullname+"/tags"), &tags)
+				k := cache.Key("vcs", "github", "tags", g.OAuthToken, "/repos/"+fullname+"/tags")
+				if _, err := g.Cache.Get(k, &tags); err != nil {
+					log.Error("cannot get from cache %s:%v", k, err)
+				}
 				if len(tags) != 0 || attempt > 5 {
 					//We found tags, let's exit the loop
 					break

--- a/engine/vcs/github/client_user.go
+++ b/engine/vcs/github/client_user.go
@@ -27,7 +27,10 @@ func (g *githubClient) User(ctx context.Context, username string) (User, error) 
 	//Github may return 304 status because we are using conditional request with ETag based headers
 	if status == http.StatusNotModified {
 		//If repo isn't updated, lets get them from cache
-		g.Cache.Get(cache.Key("vcs", "github", "users", g.OAuthToken, url), &user)
+		k := cache.Key("vcs", "github", "users", g.OAuthToken, url)
+		if _, err := g.Cache.Get(k, &user); err != nil {
+			log.Error("cannot get from cache %s: %v", k, err)
+		}
 	} else {
 		if err := json.Unmarshal(body, &user); err != nil {
 			return User{}, err

--- a/engine/vcs/github/client_user.go
+++ b/engine/vcs/github/client_user.go
@@ -36,7 +36,10 @@ func (g *githubClient) User(ctx context.Context, username string) (User, error) 
 			return User{}, err
 		}
 		//Put the body on cache for one hour and one minute
-		g.Cache.SetWithTTL(cache.Key("vcs", "github", "users", g.OAuthToken, url), user, 61*60)
+		k := cache.Key("vcs", "github", "users", g.OAuthToken, url)
+		if err := g.Cache.SetWithTTL(k, user, 61*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 
 	return user, nil

--- a/engine/vcs/github/http.go
+++ b/engine/vcs/github/http.go
@@ -81,7 +81,10 @@ func (c *githubClient) setETag(path string, headers http.Header) {
 
 func (c *githubClient) getETag(path string) string {
 	var s string
-	c.Cache.Get(cache.Key("vcs", "github", "etag", c.OAuthToken, strings.Replace(path, "https://", "", -1)), &s)
+	k := cache.Key("vcs", "github", "etag", c.OAuthToken, strings.Replace(path, "https://", "", -1))
+	if _, err := c.Cache.Get(k, &s); err != nil {
+		log.Error("cannot get from cache %s: %v", k, err)
+	}
 	return s
 }
 

--- a/engine/vcs/github/http.go
+++ b/engine/vcs/github/http.go
@@ -75,7 +75,10 @@ func (c *githubClient) setETag(path string, headers http.Header) {
 
 	if etag != "" {
 		//Put etag for this path in cache for 15 minutes
-		c.Cache.SetWithTTL(cache.Key("vcs", "github", "etag", c.OAuthToken, strings.Replace(path, "https://", "", -1)), etag, 15*60)
+		k := cache.Key("vcs", "github", "etag", c.OAuthToken, strings.Replace(path, "https://", "", -1))
+		if err := c.Cache.SetWithTTL(k, etag, 15*60); err != nil {
+			log.Error("cannot SetWithTTL: %s: %v", k, err)
+		}
 	}
 }
 


### PR DESCRIPTION
close #4289

- [x] Get(key string, value interface{}) bool - 51 occ
- [x] Set(key string, value interface{})
- [x] SetWithTTL(key string, value interface{}, ttl int) - 41 occ
- [x] UpdateTTL(key string, ttl int)
- [x] Delete(key string)
- [x] DeleteAll(key string)
- [x] Enqueue(queueName string, value interface{})
- [x] ~~Dequeue(queueName string, value interface{})~~
- [x] DequeueWithContext(c context.Context, queueName string, value interface{})
- [x] QueueLen(queueName string) int
- [x] RemoveFromQueue(queueName string, memberKey string)
- [x] Publish(queueName string, value interface{})
- [x] Subscribe(queueName string) PubSub
- [x] GetMessageFromSubscription(c context.Context, pb PubSub) (string, error)
- [x] Status() sdk.MonitoringStatusLine
- [x] SetAdd(rootKey string, memberKey string, member interface{})
- [x] SetRemove(rootKey string, memberKey string, member interface{})
- [x] SetCard(key string) int
- [x] SetScan(key string, members ...interface{}) error
- [x] Lock(key string, expiration time.Duration, retryWaitDurationMillisecond int, retryCount int) bool
- [x] Unlock(key string)