### PR TITLE
chore(husky): upgrade to new format + add commitlint

### DIFF
--- a/ui/commitlint.config.js
+++ b/ui/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/ui/package.json
+++ b/ui/package.json
@@ -98,6 +98,8 @@
     "@angular-devkit/build-angular": "0.802.0",
     "@angular/cli": "8.2.0",
     "@angular/compiler-cli": "8.2.0",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
     "@compodoc/compodoc": "1.1.7",
     "@sentry/cli": "1.37.4",
     "@types/d3": "5.7.0",
@@ -127,6 +129,7 @@
   },
   "husky": {
     "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "lint-staged"
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,6 @@
     "build:prod": "ng build --prod",
     "build:stats": "ng build --prod --stats-json",
     "build:analyse": "webpack-bundle-analyzer dist/stats.json",
-    "precommit": "lint-staged",
     "sentry:release": "sentry-cli releases -o ${SENTRY_ORG} -p ${SENTRY_PROJECT} new ${CDS_VERSION}",
     "sentry:sourcemaps": "sentry-cli releases -o ${SENTRY_ORG} -p ${SENTRY_PROJECT} files ${CDS_VERSION} upload-sourcemaps --url-prefix=${SENTRY_CDS_PREFIX_URL}"
   },
@@ -109,7 +108,7 @@
     "@types/node": "10.12.18",
     "codelyzer": "5.1.0",
     "copy-webpack-plugin": "4.6.0",
-    "husky": "1.3.1",
+    "husky": "^3.0.5",
     "jasmine-core": "3.4.0",
     "jasmine-spec-reporter": "4.2.1",
     "karma": "4.1.0",
@@ -125,5 +124,10 @@
     "webdriver-manager": "12.1.1",
     "webpack-bundle-analyzer": "3.3.2",
     "wrench-sui": "0.0.3"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   }
 }


### PR DESCRIPTION
Hello 👋 

As requested by @bnjjj , this PR does 2 things : 
- Upgrade Husky to new format, instead of using npm precommit
- Add Commitlint, to lint commit messages (based on conventional format type(scope): body)