### PR TITLE
fix(cdsctl): cdsctl version

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,7 +38,6 @@ minio_reset_bucket:
 
 test-docker-compose:
 	@export HOSTNAME=`hostname` && \
-	export CDS_DOCKER_IMAGE=ovhcom/cds-engine:$(VERSION) && \
 	docker-compose up --no-recreate -d cds-db cds-cache elasticsearch smtpmocksrv && \
 	sleep 5	&& \
 	docker-compose up --no-recreate cds-migrate && \


### PR DESCRIPTION
display
{"version":"snapshot","architecture":"amd64","os":"darwin","git_hash":"","build_time":"","db_migrate":"","keychain":true}

instead of:
{"keychain":true,"version":"CDS  version:snapshot os:darwin architecture:amd64 git.hash: build.time: db.migrate:"}

 - do not display version of api in cdsctl version
 - fix Makefile docker-compose, to let user specifiy the docker image

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
