### PR TITLE
fix(ui): remove extra pointing class from the banner element

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -3,7 +3,7 @@
         <div id="navbar" *ngIf="isConnected && !hideNavBar" [class.connected]="isConnected">
             <app-navbar></app-navbar>
         </div>
-        <div class="maintenance banner pointing" [class.mt50]="isConnected" *ngIf="maintenance && (!isConnected || user?.ring == 'ADMIN')">
+        <div class="maintenance banner" [class.mt50]="isConnected" *ngIf="maintenance && (!isConnected || user?.ring == 'ADMIN')">
             <span>{{ 'maintenance_title' | translate }}</span>
             <img src="assets/images/maintenance.svg"/>
         </div>


### PR DESCRIPTION
Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>

1. Description
A banner is displayed with a the following helper class `pointing` but
the element isn't clickable.

That's why I suggest to remove this extra helper class.
1. Related issues
None.
1. About tests
None.
1. Mentions
// @marie-j 

@ovh/cds
