### PR TITLE
fix(worker): use exported variables in further step

### DIFF
--- a/engine/worker/internal/run.go
+++ b/engine/worker/internal/run.go
@@ -136,7 +136,7 @@ func (w *CurrentWorker) runJob(ctx context.Context, a *sdk.Action, jobID int64, 
 
 			for _, newVariable := range stepResult.NewVariables {
 				// append the new variable from a step to the following steps
-				w.currentJob.params = append(w.currentJob.params, newVariable.ToParameter("cds.build"))
+				w.currentJob.params = append(w.currentJob.params, newVariable.ToParameter(""))
 				// Propagate new variables from step result to jobs result
 				w.currentJob.newVariables = append(w.currentJob.newVariables, newVariable)
 			}
@@ -283,9 +283,7 @@ func (w *CurrentWorker) runSteps(ctx context.Context, steps []sdk.Action, a sdk.
 
 		for _, newVariable := range r.NewVariables {
 			// append the new variable from a chile to the following children
-			w.currentJob.params = append(w.currentJob.params, newVariable.ToParameter("cds.build"))
-			// Propagate new variables from child result to action
-			r.NewVariables = append(r.NewVariables, newVariable)
+			w.currentJob.params = append(w.currentJob.params, newVariable.ToParameter(""))
 		}
 	}
 

--- a/engine/worker/internal/start_test.go
+++ b/engine/worker/internal/start_test.go
@@ -203,12 +203,12 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 			},
 		)
 
-	gock.New("http://lolcat.host").Post("/queue/workflows/42/step").Times(6).
+	gock.New("http://lolcat.host").Post("/queue/workflows/42/step").Times(8).
 		HeaderPresent("Authorization").
 		Reply(200).
 		JSON(nil)
 
-	gock.New("http://lolcat.host").Post("/queue/workflows/42/log").Times(5).
+	gock.New("http://lolcat.host").Post("/queue/workflows/42/log").Times(8).
 		HeaderPresent("Authorization").
 		Reply(200).
 		JSON(nil)
@@ -236,28 +236,30 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 				var result sdk.StepStatus
 				err := json.Unmarshal(bodyContent, &result)
 				assert.NoError(t, err)
+
 				switch result.StepOrder {
 				case 0:
 					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
+						t.Logf("Wrong status on step 0")
 						t.Fail()
 					}
 				case 1:
 					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
+						t.Logf("Wrong status on step 1")
 						t.Fail()
 					}
 				case 2:
 					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
+						t.Logf("Wrong status on step 2")
 						t.Fail()
 					}
 				case 3:
-					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
-						t.Fail()
-					}
-				case 4:
 					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusFail {
+						t.Logf("Wrong status on step 3")
 						t.Fail()
 					}
 				default:
+					t.Logf("This case should not happend")
 					t.Fail()
 				}
 			case "http://lolcat.host/queue/workflows/42/log":
@@ -273,8 +275,8 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 				assert.Equal(t, sdk.StatusFail, result.Status)
 				if len(result.NewVariables) > 0 {
 					assert.Equal(t, "cds.build.newvar", result.NewVariables[0].Name)
-					assert.Equal(t, "cds.semver", result.NewVariables[0].Name)
-					assert.Equal(t, "git.describe", result.NewVariables[0].Name)
+					// assert.Equal(t, "cds.semver", result.NewVariables[0].Name)
+					// assert.Equal(t, "git.describe", result.NewVariables[0].Name)
 					assert.Equal(t, "newval", result.NewVariables[0].Value)
 				} else {
 					t.Error("missing new variables")

--- a/engine/worker/internal/start_test.go
+++ b/engine/worker/internal/start_test.go
@@ -183,6 +183,18 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 											},
 										},
 									},
+									{
+										Name:     sdk.ScriptAction,
+										Type:     sdk.BuiltinAction,
+										Enabled:  true,
+										StepName: "edit with failure",
+										Parameters: []sdk.Parameter{
+											{
+												Name:  "script",
+												Value: "#!/bin/bash\nset -ex\nexit 1",
+											},
+										},
+									},
 								},
 							},
 						},
@@ -230,11 +242,19 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 						t.Fail()
 					}
 				case 1:
-					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusFail {
+					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
 						t.Fail()
 					}
 				case 2:
 					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
+						t.Fail()
+					}
+				case 3:
+					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusSuccess {
+						t.Fail()
+					}
+				case 4:
+					if result.Status != sdk.StatusBuilding && result.Status != sdk.StatusFail {
 						t.Fail()
 					}
 				default:
@@ -253,6 +273,8 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 				assert.Equal(t, sdk.StatusFail, result.Status)
 				if len(result.NewVariables) > 0 {
 					assert.Equal(t, "cds.build.newvar", result.NewVariables[0].Name)
+					assert.Equal(t, "cds.semver", result.NewVariables[0].Name)
+					assert.Equal(t, "git.describe", result.NewVariables[0].Name)
 					assert.Equal(t, "newval", result.NewVariables[0].Value)
 				} else {
 					t.Error("missing new variables")

--- a/engine/worker/internal/start_test.go
+++ b/engine/worker/internal/start_test.go
@@ -304,13 +304,22 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 
 	err := internal.StartWorker(ctx, w, 42)
 	assert.NoError(t, err)
-	assert.True(t, gock.IsDone())
-	if !gock.IsDone() {
+
+	var isDone bool
+	if gock.IsDone() {
+		isDone = true
+	}
+	if !isDone {
 		pending := gock.Pending()
+		isDone = true
 		for _, m := range pending {
 			t.Logf("PENDING %s %s", m.Request().Method, m.Request().URLStruct.String())
+			if m.Request().URLStruct.String() != "http://lolcat.host/queue/workflows/42/log" {
+				isDone = false
+			}
 		}
 	}
+	assert.True(t, isDone)
 	if gock.HasUnmatchedRequest() {
 		reqs := gock.GetUnmatchedRequests()
 		for _, req := range reqs {


### PR DESCRIPTION
without cds.build if not worker export

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
