### PR TITLE
fix(plugin/marathon): avoid panic on timeout

### DIFF
--- a/contrib/grpcplugins/action/marathon/go.sum
+++ b/contrib/grpcplugins/action/marathon/go.sum
@@ -365,10 +365,12 @@ github.com/maruel/panicparse v1.3.0/go.mod h1:vszMjr5QQ4F5FSRfraldcIA/BCw5xrdLL+
 github.com/maruel/ut v1.0.0/go.mod h1:I68ffiAt5qre9obEVTy7S2/fj2dJku2NYLvzPuY0gqE=
 github.com/mattbaird/elastigo v0.0.0-20170123220020-2fe47fd29e4b h1:v29yPGHhOqw7VHEnTeQFAth3SsBrmwc8JfuhNY0G34k=
 github.com/mattbaird/elastigo v0.0.0-20170123220020-2fe47fd29e4b/go.mod h1:5MWrJXKRQyhQdUCF+vu6U5c4nQpg70vW3eHaU0/AYbU=
+github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
@@ -644,6 +646,7 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/Le
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/contrib/grpcplugins/action/marathon/main.go
+++ b/contrib/grpcplugins/action/marathon/main.go
@@ -200,13 +200,6 @@ func (actPlugin *marathonActionPlugin) Run(ctx context.Context, q *actionplugin.
 		for _, deploy := range deployments {
 			wg.Add(1)
 			go func(id string) {
-				go func() {
-					time.Sleep((time.Duration(timeout) + 1) * time.Second)
-					ticker.Stop()
-					successChan <- false
-					wg.Done()
-				}()
-
 				if err := client.WaitOnDeployment(id, time.Duration(timeout)*time.Second); err != nil {
 					fmt.Printf("Error on deployment %s: %s\n", id, err.Error())
 					ticker.Stop()


### PR DESCRIPTION
Timeout is checked by WaitOnDeployment

this will avoid a panic like that:

[INFO] Stopping plugin...Error on deployment xxxxx-xxxxx-xxxxx-xxxxx: the operation has timed out
[INFO] panic: send on closed channel
[INFO]
[INFO] goroutine 50 [running]:
[INFO] main.(*marathonActionPlugin).Run.func2(0x78, 0xc4202da050, 0xc420370230, 0xc420373a20, 0xb68620, 0xc4202f80f0, 0xc4202bcc60, 0x24)
[INFO] /go/src/github.com/ovh/cds/contrib/grpcplugins/action/marathon/main.go:213 +0x1f2
[INFO] created by main.(*marathonActionPlugin).Run
[INFO] /go/src/github.com/ovh/cds/contrib/grpcplugins/action/marathon/main.go:202 +0x1159

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
