### PR TITLE
fix(api): avoid panic if app does not exist

### DIFF
--- a/engine/api/ascode.go
+++ b/engine/api/ascode.go
@@ -206,7 +206,7 @@ func (api *API) postResyncPRAsCodeHandler() service.Handler {
 			if err != nil {
 				return err
 			}
-			if app == nil{
+			if app == nil {
 				return sdk.WrapError(sdk.ErrApplicationNotFound, "unable to load application ", appName)
 			}
 		}

--- a/engine/api/ascode.go
+++ b/engine/api/ascode.go
@@ -196,12 +196,18 @@ func (api *API) postResyncPRAsCodeHandler() service.Handler {
 			if err != nil {
 				return err
 			}
+			if len(apps) == 0 {
+				return sdk.WrapError(sdk.ErrApplicationNotFound, "unable to load application as code key:%s fromRepo:%s", key, fromRepo)
+			}
 			app = &apps[0]
 		} else {
 			var err error
 			app, err = application.LoadByName(api.mustDB(), api.Cache, key, appName)
 			if err != nil {
 				return err
+			}
+			if app == nil{
+				return sdk.WrapError(sdk.ErrApplicationNotFound, "unable to load application ", appName)
 			}
 		}
 

--- a/engine/api/ascode.go
+++ b/engine/api/ascode.go
@@ -207,7 +207,7 @@ func (api *API) postResyncPRAsCodeHandler() service.Handler {
 				return err
 			}
 			if app == nil {
-				return sdk.WrapError(sdk.ErrApplicationNotFound, "unable to load application ", appName)
+				return sdk.WrapError(sdk.ErrApplicationNotFound, "unable to load application %s", appName)
 			}
 		}
 

--- a/sdk/workflow_run.go
+++ b/sdk/workflow_run.go
@@ -131,7 +131,7 @@ func (r *WorkflowRun) Tag(tag, value string) bool {
 	return false
 }
 
-// TagExists return true if tag already exits
+// TagExists returns true if tag already exists
 func (r *WorkflowRun) TagExists(tag string) bool {
 	for i := range r.Tags {
 		if r.Tags[i].Tag == tag {

--- a/ui/src/app/service/ascode/ascode.service.ts
+++ b/ui/src/app/service/ascode/ascode.service.ts
@@ -23,7 +23,9 @@ export class AscodeService {
         if (repo) {
             params = params.append('repo', repo);
         }
-        params = params.append('appName', appName);
+        if (appName) {
+            params = params.append('appName', appName);
+        }
 
         return this._http.post<boolean>(`/project/${projectKey}/ascode/events/resync`, null, {params})
             .map(() => {


### PR DESCRIPTION
/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/ovh/cds/engine/api.(*API).postResyncPRAsCodeHandler.func1(0x3110ce0, 0xc002caa1e0, 0x31055a0, 0xc002362440, 0xc001eece00, 0xc001358d90, 0x3110ce0)
	/tmp/QnVpbGQgYW5kIFBhY2thZ2UgQWxs/run/engine/api/ascode.go:199 +0x5eb

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>
