### PR TITLE
ovh/cds#5005 Fix gitlab user auth with custom endpoint

### DIFF
--- a/engine/api/authentication/gitlab/gitlab.go
+++ b/engine/api/authentication/gitlab/gitlab.go
@@ -100,6 +100,10 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 	}
 
 	c := gitlab.NewOAuthClient(http.DefaultClient, t.AccessToken)
+	err = c.SetBaseURL(d.url)
+	if err != nil {
+		return info, sdk.WrapError(err, "invalid gitlab url")
+	}
 	me, res, err := c.Users.CurrentUser()
 	if err != nil {
 		return info, sdk.WrapError(err, "cannot get current user from gitlab")

--- a/engine/api/authentication/gitlab/gitlab.go
+++ b/engine/api/authentication/gitlab/gitlab.go
@@ -100,8 +100,7 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 	}
 
 	c := gitlab.NewOAuthClient(http.DefaultClient, t.AccessToken)
-	err = c.SetBaseURL(d.url)
-	if err != nil {
+	if err := c.SetBaseURL(d.url); err != nil {
 		return info, sdk.WrapError(err, "invalid gitlab url")
 	}
 	me, res, err := c.Users.CurrentUser()


### PR DESCRIPTION
Signed-off-by: Louis GOUNOT <louis-gounot@users.noreply.github.com>

1. Description
Force gitlab golang Client to use custom url from configuration when fecthing user info for User Authentication
1. Related issues
ovh/cds#5005
1. About tests
1. Mentions

@ovh/cds
