### PR TITLE
feat(engine, api): metrics through REST API

### DIFF
--- a/engine/api/api_routes.go
+++ b/engine/api/api_routes.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/ovh/cds/engine/api/observability"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/log"
@@ -136,6 +137,7 @@ func (api *API) InitRouter() {
 	r.Handle("/mon/db/migrate", ScopeNone(), r.GET(api.getMonDBStatusMigrateHandler, NeedAdmin(true)))
 	r.Handle("/mon/metrics", ScopeNone(), r.GET(service.GetPrometheustMetricsHandler(api), Auth(false)))
 	r.Handle("/mon/metrics/all", ScopeNone(), r.GET(service.GetMetricsHandler, Auth(false)))
+	r.HandlePrefix("/mon/metrics/detail/", ScopeNone(), r.GET(service.GetMetricHandler(observability.StatsHTTPExporter(), "/mon/metrics/detail/"), Auth(false)))
 	r.Handle("/mon/errors/{uuid}", ScopeNone(), r.GET(api.getErrorHandler, NeedAdmin(true)))
 	r.Handle("/mon/panic/{uuid}", ScopeNone(), r.GET(api.getPanicDumpHandler, Auth(false)))
 

--- a/engine/api/observability/http_exporter.go
+++ b/engine/api/observability/http_exporter.go
@@ -1,0 +1,65 @@
+package observability
+
+import (
+	"reflect"
+	"time"
+
+	"go.opencensus.io/stats/view"
+)
+
+type HTTPExporter struct {
+	Views []HTTPExporterView `json:"views"`
+}
+
+type HTTPExporterView struct {
+	Name  string            `json:"name"`
+	Tags  map[string]string `json:"tags"`
+	Value float64           `json:"value"`
+	Date  time.Time         `json:"date"`
+}
+
+func (e *HTTPExporter) GetView(name string, tags map[string]string) *HTTPExporterView {
+	for i := range e.Views {
+		if e.Views[i].Name == name && reflect.DeepEqual(e.Views[i].Tags, tags) {
+			return &e.Views[i]
+		}
+	}
+	return nil
+}
+
+func (e *HTTPExporter) NewView(name string, tags map[string]string) *HTTPExporterView {
+	v := HTTPExporterView{
+		Name: name,
+		Tags: tags,
+	}
+	e.Views = append(e.Views, v)
+	return &v
+}
+
+func (e *HTTPExporter) ExportView(vd *view.Data) {
+	for _, row := range vd.Rows {
+		tags := make(map[string]string)
+		for _, t := range row.Tags {
+			tags[t.Key.Name()] = t.Value
+		}
+		view := e.GetView(vd.View.Name, tags)
+		if view == nil {
+			view = e.NewView(vd.View.Name, tags)
+		}
+		view.Record(row.Data)
+	}
+}
+
+func (v *HTTPExporterView) Record(data view.AggregationData) {
+	v.Date = time.Now()
+	switch x := data.(type) {
+	case *view.DistributionData:
+		v.Value = x.Mean
+	case *view.CountData:
+		v.Value = float64(x.Value)
+	case *view.SumData:
+		v.Value = x.Value
+	case *view.LastValueData:
+		v.Value = x.Value
+	}
+}

--- a/engine/api/observability/init.go
+++ b/engine/api/observability/init.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	traceExporter trace.Exporter
-	statsExporter *prometheus.Exporter
+	traceExporter     trace.Exporter
+	statsExporter     *prometheus.Exporter
+	statsHTTPExporter *HTTPExporter
 )
 
 type service interface {
@@ -29,6 +30,10 @@ func serviceName(s service) string {
 
 func StatsExporter() *prometheus.Exporter {
 	return statsExporter
+}
+
+func StatsHTTPExporter() *HTTPExporter {
+	return statsHTTPExporter
 }
 
 // Init the opencensus exporter
@@ -70,6 +75,10 @@ func Init(ctx context.Context, cfg Configuration, s service) (context.Context, e
 		}
 		view.RegisterExporter(e)
 		statsExporter = e
+
+		he := new(HTTPExporter)
+		view.RegisterExporter(he)
+		statsHTTPExporter = he
 	}
 
 	return ctx, nil

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
+github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
usage:
```
curl  http://localhost:8081/mon/metrics/detail/
```
returns the list of all metrics as a JSON array

```
curl -vv http://localhost:8081/mon/metrics/detail/cds/nb_users
```
Returns the detail of a metric.
Here the metric is named `cds/nb_users`

```
curl "http://localhost:8081/mon/metrics/detail/cds/queue?range=all&status=building"
```
Returns the detail of a tagged metric

You can add the query parameter `threshold=x`
to raised a 509 HTTP Error if the threshold is reached of exceeded

Signed-off-by: francois  samin <francois.samin@corp.ovh.com>
