### PR TITLE
fix(hooks): revert use DisplayName as bitbucket cloud (#5064)

### DIFF
--- a/engine/api/workflow/process_node_test.go
+++ b/engine/api/workflow/process_node_test.go
@@ -1012,6 +1012,18 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 				}
 			case "/vcs/stash/repos/ovh/cds/branches/?branch=feat%2Fbranch":
 				return writeError(w, sdk.ErrNotFound)
+			case "/vcs/github/repos/sguiheux/demo/branches":
+				bs := []sdk.VCSBranch{
+					{
+						LatestCommit: "defaultCommit",
+						DisplayID:    "defaultBranch",
+						Default:      true,
+						ID:           "1",
+					},
+				}
+				if err := enc.Encode(bs); err != nil {
+					return writeError(w, err)
+				}
 			case "/vcs/stash/repos/ovh/cds/commits/defaultCommit":
 				c := sdk.VCSCommit{
 					Author: sdk.VCSAuthor{
@@ -1037,18 +1049,6 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 					SSHCloneURL:  "git://github.com/sguiheux/demo.git",
 				}
 				if err := enc.Encode(repo); err != nil {
-					return writeError(w, err)
-				}
-			case "/vcs/github/repos/sguiheux/demo/branches":
-				bs := []sdk.VCSBranch{
-					{
-						LatestCommit: "defaultCommit",
-						DisplayID:    "defaultBranch",
-						Default:      true,
-						ID:           "1",
-					},
-				}
-				if err := enc.Encode(bs); err != nil {
 					return writeError(w, err)
 				}
 				// NEED GET BRANCH TO GET LATEST COMMIT
@@ -1084,8 +1084,8 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 	)
 
 	pip := createEmptyPipeline(t, db, cache, proj, u)
-	app1 := createApplication1(t, db, cache, proj, u) // github - sguiheux/demo
-	app2 := createApplication2(t, db, cache, proj, u) // stash - ovh/cds
+	app1 := createApplication1(t, db, cache, proj, u)
+	app2 := createApplication2(t, db, cache, proj, u)
 
 	// RELOAD PROJECT WITH DEPENDENCIES
 	proj.Applications = append(proj.Applications, *app1, *app2)
@@ -1102,7 +1102,7 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 				Type: sdk.NodeTypePipeline,
 				Context: &sdk.NodeContext{
 					PipelineID:    proj.Pipelines[0].ID,
-					ApplicationID: app1.ID, // github - sguiheux/demo
+					ApplicationID: proj.Applications[0].ID,
 				},
 				Triggers: []sdk.NodeTrigger{
 					{
@@ -1111,7 +1111,7 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 							Type: sdk.NodeTypePipeline,
 							Context: &sdk.NodeContext{
 								PipelineID:    proj.Pipelines[0].ID,
-								ApplicationID: app2.ID, // stash - ovh/cds
+								ApplicationID: proj.Applications[1].ID,
 							},
 							Triggers: []sdk.NodeTrigger{
 								{
@@ -1120,7 +1120,7 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 										Type: sdk.NodeTypePipeline,
 										Context: &sdk.NodeContext{
 											PipelineID:    proj.Pipelines[0].ID,
-											ApplicationID: app1.ID, // github - sguiheux/demo
+											ApplicationID: proj.Applications[0].ID,
 										},
 									},
 								},
@@ -1131,8 +1131,8 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 			},
 		},
 		Applications: map[int64]sdk.Application{
-			app1.ID: proj.Applications[0],
-			app2.ID: proj.Applications[1],
+			proj.Applications[0].ID: proj.Applications[0],
+			proj.Applications[1].ID: proj.Applications[1],
 		},
 		Pipelines: map[int64]sdk.Pipeline{
 			proj.Pipelines[0].ID: proj.Pipelines[0],

--- a/engine/hooks/bitbucket_server.go
+++ b/engine/hooks/bitbucket_server.go
@@ -105,7 +105,7 @@ func getVariableFromBitbucketServerAuthor(payload map[string]interface{}, actor 
 	if actor == nil {
 		return
 	}
-	payload[GIT_AUTHOR] = actor.DisplayName
+	payload[GIT_AUTHOR] = actor.Name
 	payload[GIT_AUTHOR_EMAIL] = actor.EmailAddress
 	payload[CDS_TRIGGERED_BY_USERNAME] = actor.Name
 	payload[CDS_TRIGGERED_BY_FULLNAME] = actor.DisplayName

--- a/engine/hooks/tasks_bitbucket_test.go
+++ b/engine/hooks/tasks_bitbucket_test.go
@@ -31,7 +31,7 @@ func Test_doWebHookExecutionBitbucket(t *testing.T) {
 	assert.Equal(t, 1, len(hs))
 	assert.Equal(t, "repo:refs_changed", hs[0].Payload["git.hook"])
 	assert.Equal(t, "name-of-branch", hs[0].Payload["git.branch"])
-	assert.Equal(t, "Steven Guiheux", hs[0].Payload["git.author"])
+	assert.Equal(t, "steven.guiheux", hs[0].Payload["git.author"])
 	assert.Equal(t, "9f4fac7ec5642099982a86f584f2c4a362adb670", hs[0].Payload["git.hash"])
 }
 
@@ -61,7 +61,7 @@ func Test_doWebHookExecutionBitbucketPRReviewerUpdated(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -104,7 +104,7 @@ func Test_doWebHookExecutionBitbucketPRReviewerApproved(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -153,7 +153,7 @@ func Test_doWebHookExecutionBitbucketPRReviewerUnapproved(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -202,7 +202,7 @@ func Test_doWebHookExecutionBitbucketPRReviewerNeedsWork(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -251,7 +251,7 @@ func Test_doWebHookExecutionBitbucketPRCommentAdded(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -299,7 +299,7 @@ func Test_doWebHookExecutionBitbucketPRCommentDeleted(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -347,7 +347,7 @@ func Test_doWebHookExecutionBitbucketPRCommentModified(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -397,7 +397,7 @@ func Test_doWebHookExecutionBitbucketPROpened(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -441,7 +441,7 @@ func Test_doWebHookExecutionBitbucketPRModified(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -488,7 +488,7 @@ func Test_doWebHookExecutionBitbucketPRMerged(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -532,7 +532,7 @@ func Test_doWebHookExecutionBitbucketPRDeleted(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -575,7 +575,7 @@ func Test_doWebHookExecutionBitbucketPRDeclined(t *testing.T) {
 	test.Equal(t, "john.doe", hs[0].Payload[CDS_TRIGGERED_BY_USERNAME])
 	test.Equal(t, "john doe", hs[0].Payload[CDS_TRIGGERED_BY_FULLNAME])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[CDS_TRIGGERED_BY_EMAIL])
-	test.Equal(t, "john doe", hs[0].Payload[GIT_AUTHOR])
+	test.Equal(t, "john.doe", hs[0].Payload[GIT_AUTHOR])
 	test.Equal(t, "john.doe@targate.fr", hs[0].Payload[GIT_AUTHOR_EMAIL])
 
 	test.Equal(t, "dest_branch", hs[0].Payload[GIT_BRANCH])
@@ -612,10 +612,10 @@ func Test_doWebHookExecutionBitbucketMultiple(t *testing.T) {
 
 	assert.Equal(t, 2, len(hs))
 	assert.Equal(t, "name-of-branch", hs[0].Payload["git.branch"])
-	assert.Equal(t, "Steven Guiheux", hs[0].Payload["git.author"])
+	assert.Equal(t, "steven.guiheux", hs[0].Payload["git.author"])
 	assert.Equal(t, "9f4fac7ec5642099982a86f584f2c4a362adb670", hs[0].Payload["git.hash"])
 	assert.Equal(t, "name-of-branch-bis", hs[1].Payload["git.branch"])
-	assert.Equal(t, "Steven Guiheux", hs[1].Payload["git.author"])
+	assert.Equal(t, "steven.guiheux", hs[1].Payload["git.author"])
 	assert.Equal(t, "9f4fac7ec5642099982a86f584f2c4a362adb670", hs[0].Payload["git.hash"])
 }
 


### PR DESCRIPTION
This reverts commit 1db9d660e0ebf0e32d5607be3effc4fad8db3c42.

The fix should remove the set of git.author from the actor.name of bitbucket, which is not the git user.name of commit.
