### PR TITLE
refactor(api): generalize ldap

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -85,17 +85,20 @@ type Configuration struct {
 		DefaultGroup  string `toml:"defaultGroup" default:"" comment:"The default group is the group in which every new user will be granted at signup" json:"defaultGroup"`
 		RSAPrivateKey string `toml:"rsaPrivateKey" default:"" comment:"The RSA Private Key used to sign and verify the JWT Tokens issued by the API \nThis is mandatory." json:"-"`
 		LDAP          struct {
-			Enabled         bool   `toml:"enabled" default:"false" json:"enabled"`
-			SignupDisabled  bool   `toml:"signupDisabled" default:"false" json:"signupDisabled"`
-			Host            string `toml:"host" json:"host"`
-			Port            int    `toml:"port" default:"636" json:"port"`
-			SSL             bool   `toml:"ssl" default:"true" json:"ssl"`
-			RootDN          string `toml:"rootDN" default:"dc=myorganization,dc=com" json:"rootDN"`
-			UserSearchBase  string `toml:"userSearchBase" default:"ou=people" json:"userSearchBase"`
-			UserSearch      string `toml:"userSearch" default:"uid={0}" json:"userSearch"`
-			UserFullname    string `toml:"userFullname" default:"{{.givenName}} {{.sn}}" json:"userFullname"`
-			ManagerDN       string `toml:"managerDN" default:"cn=admin,dc=myorganization,dc=com" comment:"Define it if ldapsearch need to be authenticated" json:"managerDN"`
-			ManagerPassword string `toml:"managerPassword" default:"SECRET_PASSWORD_MANAGER" comment:"Define it if ldapsearch need to be authenticated" json:"-"`
+			Enabled        bool   `toml:"enabled" default:"false" json:"enabled"`
+			SignupDisabled bool   `toml:"signupDisabled" default:"false" json:"signupDisabled"`
+			Host           string `toml:"host" json:"host"`
+			Port           int    `toml:"port" default:"636" json:"port"`
+			SSL            bool   `toml:"ssl" default:"true" json:"ssl"`
+			UserSearchBase string `toml:"userSearchBase" default:"ou=people,dc=myorganization,dc=com" json:"userSearchBase"`
+			UserSearch     string `toml:"userSearch" default:"uid={0}" json:"userSearch"`
+			UserDN         string `toml:"userDN" default:"cn={0},ou=people,dc=ejnserver,dc=fr" json:"userDN"`
+			UserFullname   string `toml:"userFullname" default:"{{.givenName}} {{.sn}}" json:"userFullname"`
+			UserEmail      string `toml:"userEmail" default:"{{.mail}}" json:"userEmail"`
+			UserExternalID string `toml:"userExternalID" default:"{{.uid}}" json:"userExternalID"`
+			Attributes     string `toml:"attributes" default:"uid,dn,cn,ou,givenName,sn,displayName,mail,memberOf" json:"attributes"`
+			BindDN         string `toml:"bindDN" default:"cn=admin,dc=myorganization,dc=com" comment:"Define it if ldapsearch need to be authenticated" json:"bindDn"`
+			BindPW         string `toml:"bindPW" default:"BIND_PASSWORD" comment:"Define it if ldapsearch need to be authenticated" json:"-"`
 		} `toml:"ldap" json:"ldap"`
 		Local struct {
 			Enabled              bool   `toml:"enabled" default:"true" json:"enabled"`
@@ -564,15 +567,17 @@ func (a *API) Serve(ctx context.Context) error {
 			ctx,
 			a.Config.Auth.LDAP.SignupDisabled,
 			ldap.Config{
-				Host:            a.Config.Auth.LDAP.Host,
-				Port:            a.Config.Auth.LDAP.Port,
-				SSL:             a.Config.Auth.LDAP.SSL,
-				RootDN:          a.Config.Auth.LDAP.RootDN,
-				UserSearchBase:  a.Config.Auth.LDAP.UserSearchBase,
-				UserSearch:      a.Config.Auth.LDAP.UserSearch,
-				UserFullname:    a.Config.Auth.LDAP.UserFullname,
-				ManagerDN:       a.Config.Auth.LDAP.ManagerDN,
-				ManagerPassword: a.Config.Auth.LDAP.ManagerPassword,
+				Host:           a.Config.Auth.LDAP.Host,
+				Port:           a.Config.Auth.LDAP.Port,
+				SSL:            a.Config.Auth.LDAP.SSL,
+				UserSearchBase: a.Config.Auth.LDAP.UserSearchBase,
+				UserSearch:     a.Config.Auth.LDAP.UserSearch,
+				UserFullname:   a.Config.Auth.LDAP.UserFullname,
+				UserEmail:      a.Config.Auth.LDAP.UserEmail,
+				UserExternalID: a.Config.Auth.LDAP.UserExternalID,
+				Attributes:     a.Config.Auth.LDAP.Attributes,
+				BindDN:         a.Config.Auth.LDAP.BindDN,
+				BindPW:         a.Config.Auth.LDAP.BindPW,
 			},
 		)
 		if err != nil {

--- a/engine/api/authentication/ldap/ldap_test.go
+++ b/engine/api/authentication/ldap/ldap_test.go
@@ -34,13 +34,16 @@ func TestGetUserInfo(t *testing.T) {
 	log.SetLogger(t)
 	cfg := test.LoadTestingConf(t)
 	ldapConfig := Config{
-		RootDN:          cfg["ldapRootDN"],
-		UserSearchBase:  cfg["ldapUserSearchBase"],
-		UserSearch:      cfg["ldapUserSearch"],
-		UserFullname:    cfg["ldapFullname"],
-		Host:            cfg["ldapHost"],
-		ManagerDN:       cfg["ldapManagerDN"],
-		ManagerPassword: cfg["ldapManagerPassword"],
+		UserSearchBase: cfg["ldapUserSearchBase"],
+		UserSearch:     cfg["ldapUserSearch"],
+		UserDN:         cfg["ldapUserDN"],
+		UserFullname:   cfg["ldapFullname"],
+		UserEmail:      cfg["ldapEmail"],
+		UserExternalID: cfg["ldapExternalID"],
+		Host:           cfg["ldapHost"],
+		BindDN:         cfg["ldapManagerDN"],
+		BindPW:         cfg["ldapManagerPassword"],
+		Attributes:     cfg["ldapAttributes"],
 	}
 
 	if ldapConfig.Host == "" {
@@ -53,7 +56,7 @@ func TestGetUserInfo(t *testing.T) {
 	driver, err := NewDriver(context.TODO(), false, ldapConfig)
 	require.NoError(t, err)
 	info, err := driver.GetUserInfo(context.TODO(), sdk.AuthConsumerSigninRequest{
-		"bind":     cfg["ldapTestUsername"],
+		"user":     cfg["ldapTestUsername"],
 		"password": cfg["ldapTestPassword"],
 	})
 

--- a/ui/src/app/service/authentication/authentication.service.ts
+++ b/ui/src/app/service/authentication/authentication.service.ts
@@ -75,9 +75,9 @@ export class AuthenticationService {
         });
     }
 
-    ldapSignin(bind: string, password: string, init_token?: string): Observable<AuthConsumerSigninResponse> {
+    ldapSignin(user: string, password: string, init_token?: string): Observable<AuthConsumerSigninResponse> {
         return this._http.post<AuthConsumerSigninResponse>('/auth/consumer/ldap/signin', {
-            bind,
+            user,
             password,
             init_token
         });

--- a/ui/src/app/views/auth/signin/signin.html
+++ b/ui/src/app/views/auth/signin/signin.html
@@ -77,8 +77,8 @@
                     <div *ngIf="ldapDriver" class="ui bottom attached tab segment" [class.active]="ldapSigninActive">
                         <form class="ui form" (ngSubmit)="ldapSignin(signinForm)" #signinForm="ngForm">
                             <div class="field">
-                                <label>LDAP Bind*</label>
-                                <input type="text" name="bind" ngModel required>
+                                <label>{{ 'user_label_user_ldap' | translate }}*</label>
+                                <input type="text" name="user" ngModel required>
                             </div>
                             <div class="field">
                                 <label>{{ 'user_label_password' | translate }}*</label>

--- a/ui/src/app/views/auth/signin/signin.ts
+++ b/ui/src/app/views/auth/signin/signin.ts
@@ -129,7 +129,7 @@ export class SigninComponent implements OnInit {
     }
 
     ldapSignin(f: NgForm) {
-        this._authenticationService.ldapSignin(f.value.bind, f.value.password, f.value.init_token).subscribe(() => {
+        this._authenticationService.ldapSignin(f.value.user, f.value.password, f.value.init_token).subscribe(() => {
             if (this.redirect) {
                 this._router.navigateByUrl(decodeURIComponent(this.redirect));
             } else {

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -641,6 +641,7 @@
   "ui_updated": "UI has just been updated. Please click here to refresh your page.",
   "user_label_fullname": "Fullname",
   "user_label_username": "Username",
+  "user_label_user_ldap": "LDAP Login",
   "user_label_new_password": "New password",
   "user_label_password": "Password",
   "user_label_email": "Mail address",


### PR DESCRIPTION
1. Description
Make LDAP Auth login more generic. If config has a supplied `bindDN` value, it will use that to search the ldap server with the user search filter `userSearch`, grab the DN from the result and then try to bind using that DN and the user supplied password.

If no `bindDN` value was given, it will use the supplied login user value with the `UserDN` value and attempt to bind to the ldap server with the resulting DN and user supplied password.

Added configuration values to be able to change email, external id and full name values as well as what attributes the ldap search should request.

Added template string to modify ldap login username field.

1. Related issues
1. About tests
1. Mentions

@ovh/cds
