### PR TITLE
fix(api): allow cross origin for websocket

### DIFF
--- a/engine/api/websocket.go
+++ b/engine/api/websocket.go
@@ -22,7 +22,11 @@ import (
 	"github.com/ovh/cds/sdk/log"
 )
 
-var upgrader = websocket.Upgrader{} // use default options
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
 
 type websocketClient struct {
 	UUID             string


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
