### PR TITLE
 test: use cleanup instead of defer and prevent async log when ctx canceled

### DIFF
--- a/engine/api/action/action_test.go
+++ b/engine/api/action/action_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestCRUD(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	grp2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -155,8 +154,7 @@ func TestCRUD(t *testing.T) {
 }
 
 func Test_RetrieveForGroupAndName(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	defer func() {
@@ -188,8 +186,7 @@ func Test_RetrieveForGroupAndName(t *testing.T) {
 }
 
 func Test_CheckChildrenForGroupIDsWithLoop(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	defer func() {

--- a/engine/api/action_test.go
+++ b/engine/api/action_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func Test_getActionExportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, db)
 
@@ -55,8 +54,7 @@ func Test_getActionExportHandler(t *testing.T) {
 }
 
 func Test_postActionImportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, db)
 
@@ -101,8 +99,7 @@ func Test_postActionImportHandler(t *testing.T) {
 }
 
 func Test_postActionAuditRollbackHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, db)
 
@@ -173,8 +170,7 @@ func Test_postActionAuditRollbackHandler(t *testing.T) {
 }
 
 func Test_getActions(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	_, jwtAdmin := assets.InsertAdminUser(t, api.mustDB())
 

--- a/engine/api/admin_test.go
+++ b/engine/api/admin_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_getAdminDatabaseSignatureResume(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 
@@ -31,8 +30,7 @@ func Test_getAdminDatabaseSignatureResume(t *testing.T) {
 }
 
 func Test_getAdminDatabaseSignatureTuplesByPrimaryKey(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 
@@ -73,8 +71,7 @@ func Test_getAdminDatabaseSignatureTuplesByPrimaryKey(t *testing.T) {
 }
 
 func Test_postAdminDatabaseSignatureRollEntityByPrimaryKey(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 
@@ -137,8 +134,7 @@ type TestEncryptedData struct {
 func Test_getAdminDatabaseEncryptedEntities(t *testing.T) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 
@@ -156,8 +152,7 @@ func Test_getAdminDatabaseEncryptedEntities(t *testing.T) {
 func Test_getAdminDatabaseEncryptedTuplesByEntity(t *testing.T) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 
@@ -175,8 +170,7 @@ func Test_getAdminDatabaseEncryptedTuplesByEntity(t *testing.T) {
 func Test_postAdminDatabaseRollEncryptedEntityByPrimaryKey(t *testing.T) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 

--- a/engine/api/application/dao_key_test.go
+++ b/engine/api/application/dao_key_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Test_DAOKey(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/application/dao_test.go
+++ b/engine/api/application/dao_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 func TestLoadByNameAsAdmin(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -39,8 +39,8 @@ func TestLoadByNameAsAdmin(t *testing.T) {
 }
 
 func TestLoadByNameAsUser(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 	app := sdk.Application{
@@ -60,8 +60,8 @@ func TestLoadByNameAsUser(t *testing.T) {
 }
 
 func TestLoadByIDAsAdmin(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 	app := sdk.Application{
@@ -79,8 +79,8 @@ func TestLoadByIDAsAdmin(t *testing.T) {
 }
 
 func TestLoadByIDAsUser(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -101,8 +101,8 @@ func TestLoadByIDAsUser(t *testing.T) {
 }
 
 func TestLoadAllAsAdmin(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 	app := sdk.Application{
@@ -134,8 +134,8 @@ func TestLoadAllAsAdmin(t *testing.T) {
 }
 
 func TestLoadAllAsUser(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 	app := sdk.Application{
@@ -158,8 +158,8 @@ func TestLoadAllAsUser(t *testing.T) {
 }
 
 func TestLoadByWorkflowID(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -209,9 +209,8 @@ func TestLoadByWorkflowID(t *testing.T) {
 }
 
 func TestWithRepositoryStrategy(t *testing.T) {
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
 	key := sdk.RandomString(10)
 
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/application/dao_variable_test.go
+++ b/engine/api/application/dao_variable_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Test_DAOVariable(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/application_deployment_test.go
+++ b/engine/api/application_deployment_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func Test_getApplicationDeploymentStrategiesConfigHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	pkey := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, pkey, pkey)
@@ -49,8 +49,8 @@ func Test_getApplicationDeploymentStrategiesConfigHandler(t *testing.T) {
 }
 
 func Test_postApplicationDeploymentStrategyConfigHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	pkey := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, pkey, pkey)
@@ -172,8 +172,8 @@ func Test_postApplicationDeploymentStrategyConfigHandler(t *testing.T) {
 }
 
 func Test_postApplicationDeploymentStrategyConfigHandler_InsertTwoDifferentIntegrations(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	pkey := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, pkey, pkey)
@@ -295,8 +295,7 @@ func Test_deleteApplicationDeploymentStrategyConfigHandler(t *testing.T) {
 }
 
 func Test_postApplicationDeploymentStrategyConfigHandlerAsProvider(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	u, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/application_export_test.go
+++ b/engine/api/application_export_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Test_getApplicationExportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/application_import_test.go
+++ b/engine/api/application_import_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func Test_postApplicationImportHandler_NewAppFromYAMLWithoutSecret(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -89,8 +88,7 @@ variables:
 }
 
 func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecrets(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -201,8 +199,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecrets(t *testi
 }
 
 func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImport(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -365,8 +362,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 
 func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImportWithRegen(t *testing.T) {
 	// init project and application for test
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -505,8 +501,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 }
 
 func Test_postApplicationImportHandler_NewAppFromYAMLWithEmptyKey(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -569,8 +564,7 @@ keys:
 }
 
 func Test_postApplicationImportHandler_ExistingAppFromYAMLWithoutForce(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -604,8 +598,7 @@ name: myNewApp`
 }
 
 func Test_postApplicationImportHandler_ExistingAppFromYAMLInheritPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -639,8 +632,7 @@ name: myNewApp`
 }
 
 func Test_postApplicationImportHandler_ExistingAppWithDeploymentStrategy(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -751,8 +743,7 @@ func Test_postApplicationImportHandler_ExistingAppWithDeploymentStrategy(t *test
 
 func Test_postApplicationImportHandler_DontOverrideDeploymentPasswordIfNotGiven(t *testing.T) {
 	// init test case, create a project with deployment integration then an application with deployment config
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/application_key_test.go
+++ b/engine/api/application_key_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func Test_getKeysInApplicationHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -76,8 +75,7 @@ func Test_getKeysInApplicationHandler(t *testing.T) {
 }
 
 func Test_deleteKeyInApplicationHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -129,8 +127,7 @@ func Test_deleteKeyInApplicationHandler(t *testing.T) {
 }
 
 func Test_addKeyInApplicationHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/application_test.go
+++ b/engine/api/application_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func Test_postApplicationMetadataHandler_AsProvider(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	u, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/application_variable_test.go
+++ b/engine/api/application_variable_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func Test_getVariableAuditInApplicationHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/application_vulnerability_test.go
+++ b/engine/api/application_vulnerability_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func Test_postVulnerabilityHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/artifact_test.go
+++ b/engine/api/artifact_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAPI_getStorageDriverDefault(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	cfg := objectstore.Config{
 		Kind: objectstore.Filesystem,
@@ -43,8 +42,7 @@ func TestAPI_getStorageDriverDefault(t *testing.T) {
 }
 
 func TestAPI_getArtifactsStoreHandler(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	cfg := objectstore.Config{
 		Kind: objectstore.Filesystem,

--- a/engine/api/ascode_test.go
+++ b/engine/api/ascode_test.go
@@ -56,8 +56,7 @@ func writeError(w *http.Response, err error) (*http.Response, error) {
 }
 
 func Test_postImportAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 
@@ -138,8 +137,7 @@ func Test_postImportAsCodeHandler(t *testing.T) {
 }
 
 func Test_getImportAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	p := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertAdminUser(t, db)
@@ -202,8 +200,7 @@ func Test_getImportAsCodeHandler(t *testing.T) {
 }
 
 func Test_postPerformImportAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 
@@ -347,8 +344,7 @@ version: v1.0`),
 }
 
 func Test_postResyncPRAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	repoURL := sdk.RandomString(10)
 

--- a/engine/api/auth_builtin_test.go
+++ b/engine/api/auth_builtin_test.go
@@ -46,8 +46,7 @@ func AuthentififyBuiltinConsumer(t *testing.T, api *API, jwsToken string) string
 }
 
 func Test_postAuthBuiltinSigninHandler(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	usr, _ := assets.InsertLambdaUser(t, api.mustDB(), &sdk.Group{Name: sdk.RandomString(5)})
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, usr.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/auth_consumer_test.go
+++ b/engine/api/auth_consumer_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func Test_getConsumersByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID,
@@ -61,8 +60,7 @@ func Test_getConsumersByUserHandler(t *testing.T) {
 }
 
 func Test_postConsumerByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := assets.InsertGroup(t, db)
 	u, jwtRaw := assets.InsertLambdaUser(t, db, g)
@@ -107,8 +105,7 @@ func Test_postConsumerByUserHandler(t *testing.T) {
 }
 
 func Test_deleteConsumerByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 
@@ -138,8 +135,7 @@ func Test_deleteConsumerByUserHandler(t *testing.T) {
 }
 
 func Test_postConsumerRegenByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID,
@@ -238,8 +234,7 @@ func Test_postConsumerRegenByUserHandler(t *testing.T) {
 }
 
 func Test_getSessionsByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID,
@@ -272,8 +267,7 @@ func Test_getSessionsByUserHandler(t *testing.T) {
 }
 
 func Test_deleteSessionByUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID,

--- a/engine/api/auth_test.go
+++ b/engine/api/auth_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func Test_postAuthSignoutHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwtRaw := assets.InsertLambdaUser(t, db)
 
@@ -54,8 +53,7 @@ func Test_postAuthSignoutHandler(t *testing.T) {
 }
 
 func Test_postAuthSigninHandler_ShouldSuccessWithANewUser(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	uri := api.Router.GetRoute(http.MethodPost, api.postAuthSigninHandler, map[string]string{
 		"consumerType": "futurama",
@@ -78,8 +76,7 @@ func Test_postAuthSigninHandler_ShouldSuccessWithANewUser(t *testing.T) {
 }
 
 func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUser(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	uri := api.Router.GetRoute(http.MethodPost, api.postAuthSigninHandler, map[string]string{
 		"consumerType": "futurama",
@@ -113,8 +110,7 @@ func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUser(t *testing.T) {
 }
 
 func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUserAndAnotherConsumerType(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	uri := api.Router.GetRoute(http.MethodPost, api.postAuthSigninHandler, map[string]string{
 		"consumerType": "futurama",
@@ -163,8 +159,7 @@ func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUserAndAnotherConsumerTyp
 }
 
 func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUserAnotherConsumerTypeAndAnotherUsername(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	uri := api.Router.GetRoute(http.MethodPost, api.postAuthSigninHandler, map[string]string{
 		"consumerType": "futurama",
@@ -213,8 +208,7 @@ func Test_postAuthSigninHandler_ShouldSuccessWithAKnownUserAnotherConsumerTypeAn
 }
 
 func Test_postAuthSigninHandler_ShouldSuccessWithAnExistingUserFromCurrentSessionAndAnotherConsumerType(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	// clean before test
 	u1, _ := user.LoadByUsername(context.TODO(), db, "fry")
@@ -314,8 +308,7 @@ dg/94O8U5bC2T8a9CsA/q8eGuucP
 )
 
 func Test_postAuthSigninHandler_WithCorporateSSO(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	var cfg corpsso.Config
 	cfg.Request.Keys.RequestSigningKey = AuthKey
@@ -436,8 +429,7 @@ func generateToken(t *testing.T, username string) string {
 }
 
 func Test_getAuthMe(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwtRaw := assets.InsertLambdaUser(t, db)
 

--- a/engine/api/authentication/authentication_test.go
+++ b/engine/api/authentication/authentication_test.go
@@ -19,8 +19,7 @@ type myPayload struct {
 }
 
 func TestSignJWS(t *testing.T) {
-	_, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	_, _ = test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	p := myPayload{
 		RandomID: sdk.UUID(),

--- a/engine/api/authentication/consumer_test.go
+++ b/engine/api/authentication/consumer_test.go
@@ -18,8 +18,7 @@ import (
 
 // Given a consumer with two groups, if we invalidate one it should be invalidated and one warning should be set.
 func TestConsumerInvalidateGroupForUser_InvalidateOneConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -58,8 +57,7 @@ func TestConsumerInvalidateGroupForUser_InvalidateOneConsumerGroup(t *testing.T)
 
 // Given a consumer with two groups, if we invalidate one it should not be invalidated if the user is an admin.
 func TestConsumerInvalidateGroupForUser_InvalidateOneConsumerGroupForAdmin(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -96,8 +94,7 @@ func TestConsumerInvalidateGroupForUser_InvalidateOneConsumerGroupForAdmin(t *te
 
 // Given a consumer with one group, if we invalidate the group it should disable the consumer and add two warnings.
 func TestConsumerInvalidateGroupForUser_InvalidateLastConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -136,8 +133,7 @@ func TestConsumerInvalidateGroupForUser_InvalidateLastConsumerGroup(t *testing.T
 
 // Given a consumer with two groups, if we remove one a warning should be set.
 func TestConsumerRemoveGroup_RemoveOneConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -175,8 +171,7 @@ func TestConsumerRemoveGroup_RemoveOneConsumerGroup(t *testing.T) {
 
 // Given a consumer with a valid and an invalid group, if we remove the invalid one a warning should be set to replace previous warning.
 func TestConsumerRemoveGroup_RemoveOneInvalidConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -220,8 +215,7 @@ func TestConsumerRemoveGroup_RemoveOneInvalidConsumerGroup(t *testing.T) {
 
 // Given a consumer with one group, if we remove the group it should disable the consumer and add two warnings.
 func TestConsumerRemoveGroup_RemoveLastConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -259,8 +253,7 @@ func TestConsumerRemoveGroup_RemoveLastConsumerGroup(t *testing.T) {
 
 // Given a consumer with one invalid group, if we remove the group it should disable the consumer and add two warnings.
 func TestConsumerRemoveGroup_RemoveLastInvalidConsumerGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -309,8 +302,7 @@ func TestConsumerRemoveGroup_RemoveLastInvalidConsumerGroup(t *testing.T) {
 
 // Given a consumer with a valid and an invalid group, restoring the invalid one should remove warning.
 func TestConsumerRestoreInvalidatedGroupForUser_RestoreInvalidatedGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -355,8 +347,7 @@ func TestConsumerRestoreInvalidatedGroupForUser_RestoreInvalidatedGroup(t *testi
 
 // Given a disabled consumer with an invalid group, restoring the group remove warning and re-enable the consumer.
 func TestConsumerLifecycle_RestoreInvalidatedLastGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -401,8 +392,7 @@ func TestConsumerLifecycle_RestoreInvalidatedLastGroup(t *testing.T) {
 }
 
 func TestConsumerInvalidateGroupsForUser_InvalidateLastGroups(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -453,8 +443,7 @@ func TestConsumerInvalidateGroupsForUser_InvalidateLastGroups(t *testing.T) {
 }
 
 func TestConsumerRestoreInvalidatedGroupsForUser(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 

--- a/engine/api/authentication/dao_consumer_test.go
+++ b/engine/api/authentication/dao_consumer_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestLoadConsumer(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	assets.DeleteConsumers(t, db)
 
@@ -89,8 +88,7 @@ func TestLoadConsumer(t *testing.T) {
 }
 
 func TestInsertConsumer(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -111,8 +109,7 @@ func TestInsertConsumer(t *testing.T) {
 }
 
 func TestUpdateConsumer(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -135,8 +132,7 @@ func TestUpdateConsumer(t *testing.T) {
 }
 
 func TestDeleteConsumer(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),

--- a/engine/api/authentication/dao_session_test.go
+++ b/engine/api/authentication/dao_session_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestLoadSession(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{Username: sdk.RandomString(10)}
 	require.NoError(t, user.Insert(context.TODO(), db, &u))
@@ -59,8 +58,7 @@ func TestLoadSession(t *testing.T) {
 }
 
 func TestInsertSession(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -80,8 +78,7 @@ func TestInsertSession(t *testing.T) {
 }
 
 func TestUpdateSession(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -103,8 +100,7 @@ func TestUpdateSession(t *testing.T) {
 }
 
 func TestDeleteSession(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -128,8 +124,8 @@ func TestDeleteSession(t *testing.T) {
 }
 
 func Test_GetAndDeleteCorruptedSessions(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	sessions, err := authentication.UnsafeLoadCorruptedSessions(context.TODO(), db)
 	require.NoError(t, err)
 	for _, s := range sessions {

--- a/engine/api/authentication/loader_consumer_test.go
+++ b/engine/api/authentication/loader_consumer_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestWithAuthentifiedUser(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertGroup(t, db)
 	u, _ := assets.InsertLambdaUser(t, db, g)
@@ -34,8 +33,7 @@ func TestWithAuthentifiedUser(t *testing.T) {
 }
 
 func TestWithConsumerGroups(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertGroup(t, db)
 	g2 := assets.InsertGroup(t, db)

--- a/engine/api/authentication/local/dao_registration_test.go
+++ b/engine/api/authentication/local/dao_registration_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestInsertRegistration(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	r1 := sdk.UserRegistration{
 		Username: sdk.RandomString(10),

--- a/engine/api/authentication/local/reset_test.go
+++ b/engine/api/authentication/local/reset_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestResetConsumerToken(t *testing.T) {
-	_, store, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	_, store := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	consumerUUID := sdk.UUID()
 	token, err := local.NewResetConsumerToken(store, consumerUUID)

--- a/engine/api/authentication/session_test.go
+++ b/engine/api/authentication/session_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_CheckSessionJWT(t *testing.T) {
-	_, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	_, _ = test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	now := time.Now()
 
@@ -46,7 +45,7 @@ func Test_CheckSessionJWT(t *testing.T) {
 func Test_SessionCleaner(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
 	defer cancel()
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	authentication.SessionCleaner(ctx, func() *gorp.DbMap { return db })
 }

--- a/engine/api/bookmark_test.go
+++ b/engine/api/bookmark_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_postUserFavoriteHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	wkf := assets.InsertTestWorkflow(t, db, api.Cache, proj, sdk.RandomString(10))

--- a/engine/api/broadcast_test.go
+++ b/engine/api/broadcast_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_addBroadcastHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, db)
 
@@ -41,8 +40,7 @@ func Test_addBroadcastHandler(t *testing.T) {
 }
 
 func Test_postMarkAsReadBroadcastHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	uLambda, passLambda := assets.InsertLambdaUser(t, db)

--- a/engine/api/database/gorpmapping/benchmark_test.go
+++ b/engine/api/database/gorpmapping/benchmark_test.go
@@ -32,7 +32,7 @@ BenchmarkCheckSignature: 5283 ns/op 1344 B/op 21 allocs/op
 func BenchmarkGetWithoutDecryption(b *testing.B) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(b)
+	db, _, end := test.SetupPGToCancel(b)
 	defer end()
 
 	var d = TestEncryptedData{
@@ -54,7 +54,7 @@ func BenchmarkGetWithoutDecryption(b *testing.B) {
 func BenchmarkGetWithDecryption(b *testing.B) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(b)
+	db, _, end := test.SetupPGToCancel(b)
 	defer end()
 
 	var d = TestEncryptedData{
@@ -76,7 +76,7 @@ func BenchmarkGetWithDecryption(b *testing.B) {
 func BenchmarkInsertWithoutSignature(b *testing.B) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(b)
+	db, _, end := test.SetupPGToCancel(b)
 	defer end()
 
 	for n := 0; n < b.N; n++ {
@@ -93,7 +93,7 @@ func BenchmarkInsertWithoutSignature(b *testing.B) {
 func BenchmarkInsertWithSignature(b *testing.B) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(b)
+	db, _, end := test.SetupPGToCancel(b)
 	defer end()
 
 	for n := 0; n < b.N; n++ {
@@ -110,7 +110,7 @@ func BenchmarkInsertWithSignature(b *testing.B) {
 func BenchmarkCheckSignature(b *testing.B) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(b)
+	db, _, end := test.SetupPGToCancel(b)
 	defer end()
 
 	var d = TestEncryptedData{
@@ -124,5 +124,4 @@ func BenchmarkCheckSignature(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_, _ = gorpmapping.CheckSignature(d, d.GetSignature())
 	}
-
 }

--- a/engine/api/database/gorpmapping/encryption_test.go
+++ b/engine/api/database/gorpmapping/encryption_test.go
@@ -29,8 +29,7 @@ func (e TestEncryptedData) Canonical() gorpmapping.CanonicalForms {
 func TestEncryption(t *testing.T) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	var d = TestEncryptedData{
 		Data:                 "data",
@@ -100,8 +99,7 @@ func TestEncryption(t *testing.T) {
 func TestEncryption_Multiple(t *testing.T) {
 	gorpmapping.Register(gorpmapping.New(TestEncryptedData{}, "test_encrypted_data", true, "id"))
 
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	var d = TestEncryptedData{
 		Data:                 "data",

--- a/engine/api/database/gorpmapping/signature_utils_test.go
+++ b/engine/api/database/gorpmapping/signature_utils_test.go
@@ -19,16 +19,15 @@ func Test_GetSignedEntities(t *testing.T) {
 }
 
 func Test_ListCanonicalFormsByEntity(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	res, err := gorpmapping.ListCanonicalFormsByEntity(db, "user.authentifiedUser")
 	require.NoError(t, err)
 	t.Logf("%+v", res)
 }
 
 func Test_ListTupleByCanonicalForm(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	res, err := gorpmapping.ListCanonicalFormsByEntity(db, "user.authentifiedUser")
 	require.NoError(t, err)
@@ -45,8 +44,7 @@ func Test_ListTupleByCanonicalForm(t *testing.T) {
 }
 
 func Test_LoadTupleByPrimaryKey(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	res, err := gorpmapping.ListCanonicalFormsByEntity(db, "user.authentifiedUser")
 	require.NoError(t, err)
@@ -65,8 +63,7 @@ func Test_LoadTupleByPrimaryKey(t *testing.T) {
 }
 
 func Test_RollSignedTupleByPrimaryKey(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	res, err := gorpmapping.ListCanonicalFormsByEntity(db, "user.authentifiedUser")
 	require.NoError(t, err)

--- a/engine/api/environment/dao_variable_test.go
+++ b/engine/api/environment/dao_variable_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_DAOVariable(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/environment/environment_importer_test.go
+++ b/engine/api/environment/environment_importer_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestImportInto_Variable(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	u := &sdk.AuthentifiedUser{
 		Username: "foo",
@@ -137,8 +136,7 @@ func TestImportInto_Variable(t *testing.T) {
 }
 
 func TestImportInto_Group(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	u := &sdk.AuthentifiedUser{
 		Username: "foo",

--- a/engine/api/environment_export_test.go
+++ b/engine/api/environment_export_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_getEnvironmentExportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/environment_import_test.go
+++ b/engine/api/environment_import_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithoutSecret(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -85,8 +84,7 @@ variables:
 }
 
 func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecrets(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -206,8 +204,7 @@ func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecrets(t *testi
 }
 
 func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecretsAndReImport(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -384,8 +381,7 @@ func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecretsAndReImpo
 }
 
 func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithEmptyKey(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -450,8 +446,7 @@ keys:
 }
 
 func Test_postEnvironmentImportHandler_ExistingAppFromYAMLWithoutForce(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -486,8 +481,7 @@ name: myNewEnv`
 }
 
 func Test_postEnvironmentImportHandler_ExistingAppFromYAMLInheritPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/environment_key_test.go
+++ b/engine/api/environment_key_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_getKeysInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -77,8 +76,7 @@ func Test_getKeysInEnvironmentHandler(t *testing.T) {
 }
 
 func Test_deleteKeyInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -131,8 +129,7 @@ func Test_deleteKeyInEnvironmentHandler(t *testing.T) {
 }
 
 func Test_addKeyInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/environment_test.go
+++ b/engine/api/environment_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestAddEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -64,8 +63,7 @@ func TestAddEnvironmentHandler(t *testing.T) {
 }
 
 func TestUpdateEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -122,8 +120,7 @@ func TestUpdateEnvironmentHandler(t *testing.T) {
 }
 
 func TestDeleteEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -172,8 +169,7 @@ func TestDeleteEnvironmentHandler(t *testing.T) {
 }
 
 func TestGetEnvironmentsHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -214,8 +210,7 @@ func TestGetEnvironmentsHandler(t *testing.T) {
 }
 
 func TestGetEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -257,8 +252,7 @@ func TestGetEnvironmentHandler(t *testing.T) {
 }
 
 func Test_cloneEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/environment_variable_test.go
+++ b/engine/api/environment_variable_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestAddVariableInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -79,8 +78,7 @@ func TestAddVariableInEnvironmentHandler(t *testing.T) {
 }
 
 func TestUpdateVariableInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -149,8 +147,7 @@ func TestUpdateVariableInEnvironmentHandler(t *testing.T) {
 }
 
 func TestDeleteVariableFromEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -208,8 +205,7 @@ func TestDeleteVariableFromEnvironmentHandler(t *testing.T) {
 }
 
 func TestGetVariablesInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -264,8 +260,7 @@ func TestGetVariablesInEnvironmentHandler(t *testing.T) {
 }
 
 func Test_getVariableAuditInEnvironmentHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/events.go
+++ b/engine/api/events.go
@@ -78,11 +78,11 @@ func (b *eventsBroker) cacheSubscribe(c context.Context, cacheMsgChan chan<- sdk
 	for {
 		select {
 		case <-c.Done():
-			if c.Err() != nil {
-				log.Error(c, "events.cacheSubscribe> Exiting: %v", c.Err())
-				return
-			}
+			return
 		case <-tick.C:
+			if c.Err() != nil {
+				continue
+			}
 			msg, err := store.GetMessageFromSubscription(c, pubSub)
 			if err != nil {
 				log.Warning(c, "events.cacheSubscribe> Cannot get message: %v", err)
@@ -120,10 +120,7 @@ func (b *eventsBroker) Start(ctx context.Context, panicCallback func(s string) (
 				}
 				observability.Record(b.router.Background, SSEClients, 0)
 			}
-			if ctx.Err() != nil {
-				log.Error(ctx, "eventsBroker.Start> Exiting: %v", ctx.Err())
-				return
-			}
+			return
 
 		case receivedEvent := <-b.messages:
 			for i := range b.clients {

--- a/engine/api/group/crud_test.go
+++ b/engine/api/group/crud_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_Create_LoadByName_Delete(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u, _ := assets.InsertLambdaUser(t, db)
 

--- a/engine/api/group/dao_project_link_test.go
+++ b/engine/api/group/dao_project_link_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_DAO_Project_Link(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	pkey := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, pkey, pkey)

--- a/engine/api/group/dao_test.go
+++ b/engine/api/group/dao_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestLoadAll(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u, _ := assets.InsertLambdaUser(t, db)
 	groupName := sdk.RandomString(10)

--- a/engine/api/group/dao_user_link_test.go
+++ b/engine/api/group/dao_user_link_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestDAO_LinkGroupUser(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	u1, _ := assets.InsertLambdaUser(t, db)
 	u2, _ := assets.InsertLambdaUser(t, db)

--- a/engine/api/group_test.go
+++ b/engine/api/group_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_getGroupHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := sdk.Group{Name: sdk.RandomString(10)}
 	u, jwtRaw := assets.InsertLambdaUser(t, db, &g)
@@ -40,8 +39,7 @@ func Test_getGroupHandler(t *testing.T) {
 }
 
 func Test_getGroupsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g1 := &sdk.Group{Name: sdk.RandomString(10)}
 	g2 := &sdk.Group{Name: sdk.RandomString(10)}
@@ -71,8 +69,7 @@ func Test_getGroupsHandler(t *testing.T) {
 }
 
 func Test_postGroupHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 
@@ -96,8 +93,7 @@ func Test_postGroupHandler(t *testing.T) {
 }
 
 func Test_putGroupHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g1Name, g2Name := sdk.RandomString(10), sdk.RandomString(10)
 	g1, g2 := &sdk.Group{Name: g1Name}, &sdk.Group{Name: g2Name}
@@ -129,8 +125,7 @@ func Test_putGroupHandler(t *testing.T) {
 }
 
 func Test_deleteGroupHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := sdk.Group{Name: sdk.RandomString(10)}
 	_, jwtRaw := assets.InsertLambdaUser(t, db, &g)
@@ -149,8 +144,7 @@ func Test_deleteGroupHandler(t *testing.T) {
 }
 
 func Test_postGroupUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := &sdk.Group{Name: sdk.RandomString(10)}
 	_, jwtRaw1 := assets.InsertLambdaUser(t, db, g)
@@ -192,8 +186,7 @@ func Test_postGroupUserHandler(t *testing.T) {
 }
 
 func Test_putGroupUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := &sdk.Group{Name: sdk.RandomString(10)}
 	_, jwtRaw1 := assets.InsertLambdaUser(t, db, g)
@@ -234,8 +227,7 @@ func Test_putGroupUserHandler(t *testing.T) {
 }
 
 func Test_deleteGroupUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := &sdk.Group{Name: sdk.RandomString(10)}
 	u1, jwtRaw1 := assets.InsertLambdaUser(t, db, g)

--- a/engine/api/integration/dao_model_test.go
+++ b/engine/api/integration/dao_model_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestCRUDModel(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	var p = &sdk.KafkaIntegration
 

--- a/engine/api/integration/dao_project_integration_test.go
+++ b/engine/api/integration/dao_project_integration_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestCRUDIntegration(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	project.Delete(db, "key")
 
 	proj := sdk.Project{

--- a/engine/api/integration_test.go
+++ b/engine/api/integration_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func Test_getIntegrationModelsHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 
 	vars := map[string]string{}
@@ -29,8 +29,8 @@ func Test_getIntegrationModelsHandler(t *testing.T) {
 }
 
 func Test_postIntegrationModelHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 
 	vars := map[string]string{}
@@ -51,8 +51,8 @@ func Test_postIntegrationModelHandler(t *testing.T) {
 }
 
 func Test_putIntegrationModelHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 
 	model := sdk.IntegrationModel{
@@ -77,8 +77,8 @@ func Test_putIntegrationModelHandler(t *testing.T) {
 }
 
 func Test_deleteIntegrationModelHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 
 	model := sdk.IntegrationModel{

--- a/engine/api/migrate/dao_test.go
+++ b/engine/api/migrate/dao_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	mig1 := sdk.Migration{
 		Name:      "firstOne",

--- a/engine/api/migrate/refactor_group_test.go
+++ b/engine/api/migrate/refactor_group_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestRefactorGroupMembership(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	require.NoError(t, migrate.RefactorGroupMembership(context.TODO(), db))
 }
- 

--- a/engine/api/migration_test.go
+++ b/engine/api/migration_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestPostAdminMigrationCancelHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/notification/permission_test.go
+++ b/engine/api/notification/permission_test.go
@@ -16,8 +16,7 @@ import (
 
 // Test_projectPermissionUserIDs test the usernames selected to send notifications
 func Test_projectPermissionUserIDs(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))

--- a/engine/api/pipeline/pipeline_importer_test.go
+++ b/engine/api/pipeline/pipeline_importer_test.go
@@ -75,8 +75,8 @@ func testImportUpdate(t *testing.T, db gorp.SqlExecutor, store cache.Store, tt t
 }
 
 func TestImportUpdate(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	if db == nil {

--- a/engine/api/pipeline/pipeline_test.go
+++ b/engine/api/pipeline/pipeline_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestInsertPipeline(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	pk := sdk.RandomString(8)
 
 	p := sdk.Project{
@@ -74,8 +74,8 @@ func TestInsertPipeline(t *testing.T) {
 }
 
 func TestInsertPipelineWithParemeters(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	pk := sdk.RandomString(8)
 
 	p := sdk.Project{
@@ -112,8 +112,8 @@ func TestInsertPipelineWithParemeters(t *testing.T) {
 }
 
 func TestInsertPipelineWithWithWrongParemeters(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	pk := sdk.RandomString(8)
 
 	p := sdk.Project{
@@ -143,8 +143,8 @@ func TestInsertPipelineWithWithWrongParemeters(t *testing.T) {
 }
 
 func TestLoadByWorkflowID(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -192,8 +192,7 @@ func TestLoadByWorkflowID(t *testing.T) {
 }
 
 func TestLoadByWorkerModel(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := group.SharedInfraGroup
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))

--- a/engine/api/pipeline_export_test.go
+++ b/engine/api/pipeline_export_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func Test_getPipelineExportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/pipeline_import_test.go
+++ b/engine/api/pipeline_import_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func Test_postPipelinePreviewHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -63,8 +62,7 @@ jobs:
 }
 
 func Test_putPipelineImportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -100,8 +98,7 @@ jobs:
 }
 
 func Test_putPipelineImportJSONWithoutVersionHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -127,8 +124,7 @@ func Test_putPipelineImportJSONWithoutVersionHandler(t *testing.T) {
 }
 
 func Test_putPipelineImportDifferentStageHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/pipeline_job_test.go
+++ b/engine/api/pipeline_job_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestAddJobHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -84,8 +83,7 @@ func TestAddJobHandler(t *testing.T) {
 }
 
 func TestUpdateJobHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -165,8 +163,7 @@ func TestUpdateJobHandler(t *testing.T) {
 }
 
 func TestUpdateInvalidJobHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -247,8 +244,7 @@ func TestUpdateInvalidJobHandler(t *testing.T) {
 }
 
 func TestDeleteJobHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//1. Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/pipeline_stage_test.go
+++ b/engine/api/pipeline_stage_test.go
@@ -66,8 +66,8 @@ func deleteAll(t *testing.T, api *API, key string) error {
 }
 
 func TestInsertAndLoadPipelineWith1StageAnd0ActionWithoutCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 
 	//Insert Project
@@ -118,8 +118,7 @@ func TestInsertAndLoadPipelineWith1StageAnd0ActionWithoutCondition(t *testing.T)
 }
 
 func TestInsertAndLoadPipelineWith1StageAnd1ActionWithoutCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 
@@ -188,8 +187,7 @@ func TestInsertAndLoadPipelineWith1StageAnd1ActionWithoutCondition(t *testing.T)
 }
 
 func TestInsertAndLoadPipelineWith2StagesWithAnEmptyStageAtFirstFollowedBy2ActionsStageWithoutCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 
@@ -294,8 +292,7 @@ func TestInsertAndLoadPipelineWith2StagesWithAnEmptyStageAtFirstFollowedBy2Actio
 }
 
 func TestInsertAndLoadPipelineWith1StageWithoutConditionAnd1StageWith2Conditions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 
@@ -430,8 +427,7 @@ func TestInsertAndLoadPipelineWith1StageWithoutConditionAnd1StageWith2Conditions
 }
 
 func TestDeleteStageByIDShouldDeleteStageConditions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 
@@ -491,8 +487,7 @@ func TestDeleteStageByIDShouldDeleteStageConditions(t *testing.T) {
 }
 
 func TestUpdateStageShouldUpdateStageConditions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	deleteAll(t, api, "TESTPIPELINESTAGES")
 

--- a/engine/api/pipeline_test.go
+++ b/engine/api/pipeline_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestUpdateAsCodePipelineHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 

--- a/engine/api/plugin/dao_test.go
+++ b/engine/api/plugin/dao_test.go
@@ -29,8 +29,7 @@ func TestInsertUpdateLoadDelete(t *testing.T) {
 		},
 	}
 
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	require.NoError(t, Insert(db, &p))
 	assert.NotEqual(t, 0, p.ID)

--- a/engine/api/project/dao_test.go
+++ b/engine/api/project/dao_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestInsertProject(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	project.Delete(db, "key")
 
 	proj := sdk.Project{
@@ -30,8 +30,8 @@ func TestInsertProject(t *testing.T) {
 }
 
 func TestInsertProject_withWrongKey(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	proj := sdk.Project{
 		Name: "test proj",
 		Key:  "error key",
@@ -53,8 +53,8 @@ func TestExist(t *testing.T) {
 }
 
 func TestLoadAllByRepo(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	app, _ := application.LoadByName(db, "TestLoadAllByRepo", "TestLoadAllByRepo")
@@ -102,8 +102,7 @@ func TestLoadAllByRepo(t *testing.T) {
 }
 
 func TestLoadAll(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	project.Delete(db, "test_TestLoadAll1")
 	project.Delete(db, "test_TestLoadAll2")

--- a/engine/api/project/dao_variable_test.go
+++ b/engine/api/project/dao_variable_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Test_DAOVariable(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/project/key_test.go
+++ b/engine/api/project/key_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestEncryptWithBuiltinKey(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 

--- a/engine/api/project_group_test.go
+++ b/engine/api/project_group_test.go
@@ -15,8 +15,8 @@ import (
 
 // Test_ProjectPerms Useful to test permission on project
 func Test_ProjectPerms(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertLambdaUser(t, api.mustDB(), &proj.ProjectGroups[0].Group)
 

--- a/engine/api/project_integration_test.go
+++ b/engine/api/project_integration_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAddUpdateAndDeleteProjectIntegration(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 

--- a/engine/api/project_key_test.go
+++ b/engine/api/project_key_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_getKeysInProjectHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -66,8 +65,7 @@ func Test_getKeysInProjectHandler(t *testing.T) {
 }
 
 func Test_deleteKeyInProjectHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -109,8 +107,7 @@ func Test_deleteKeyInProjectHandler(t *testing.T) {
 }
 
 func Test_addKeyInProjectHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/project_test.go
+++ b/engine/api/project_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestVariableInProject(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	// 1. Create project
 	project1 := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -75,8 +74,8 @@ func TestVariableInProject(t *testing.T) {
 }
 
 func Test_getProjectsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	repofullname := sdk.RandomString(10) + "/" + sdk.RandomString(10)
 	app := &sdk.Application{
@@ -104,8 +103,8 @@ func Test_getProjectsHandler(t *testing.T) {
 }
 
 func Test_addProjectHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertLambdaUser(t, db)
 
 	proj := sdk.Project{
@@ -137,8 +136,7 @@ func Test_addProjectHandler(t *testing.T) {
 }
 
 func Test_addProjectHandlerWithGroup(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	g := sdk.Group{Name: sdk.RandomString(10)}
@@ -174,8 +172,8 @@ func Test_addProjectHandlerWithGroup(t *testing.T) {
 }
 
 func Test_getProjectsHandler_WithWPermissionShouldReturnNoProjects(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())
@@ -198,8 +196,8 @@ func Test_getProjectsHandler_WithWPermissionShouldReturnNoProjects(t *testing.T)
 }
 
 func Test_getProjectHandler_CheckPermission(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	require.NoError(t, group.InsertLinkGroupUser(context.TODO(), api.mustDB(), &group.LinkGroupUser{
@@ -260,8 +258,8 @@ func Test_getProjectHandler_CheckPermission(t *testing.T) {
 }
 
 func Test_getProjectsHandler_WithWPermissionShouldReturnOneProject(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	require.NoError(t, group.InsertLinkGroupUser(context.TODO(), api.mustDB(), &group.LinkGroupUser{
@@ -288,8 +286,7 @@ func Test_getProjectsHandler_WithWPermissionShouldReturnOneProject(t *testing.T)
 }
 
 func Test_getProjectsHandler_AsProvider(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -319,8 +316,7 @@ func Test_getProjectsHandler_AsProvider(t *testing.T) {
 }
 
 func Test_getprojectsHandler_AsProviderWithRequestedUsername(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -374,8 +370,8 @@ func Test_getprojectsHandler_AsProviderWithRequestedUsername(t *testing.T) {
 }
 
 func Test_putProjectLabelsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, db)
 
 	pkey := sdk.RandomString(10)
@@ -432,8 +428,7 @@ func Test_putProjectLabelsHandler(t *testing.T) {
 }
 
 func Test_getProjectsHandler_FilterByRepo(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/project_variable_test.go
+++ b/engine/api/project_variable_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func Test_getVariableAuditInProjectHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -58,8 +57,7 @@ func Test_getVariableAuditInProjectHandler(t *testing.T) {
 }
 
 func Test_postEncryptVariableHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	//Create admin user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/purge/purge_test.go
+++ b/engine/api/purge/purge_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func Test_deleteWorkflowRunsHistory(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	// Init store
 	cfg := objectstore.Config{

--- a/engine/api/repositories_manager_test.go
+++ b/engine/api/repositories_manager_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestAPI_detachRepositoriesManagerHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	srvs, err := services.LoadAll(context.TODO(), db)
 	require.NoError(t, err)

--- a/engine/api/repositoriesmanager/dao_test.go
+++ b/engine/api/repositoriesmanager/dao_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func Test_CRUDProjectVCSServerLink(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	pk := sdk.RandomString(8)
 
 	proj := sdk.Project{

--- a/engine/api/router_middleware_auth_permission_test.go
+++ b/engine/api/router_middleware_auth_permission_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func Test_checkWorkflowPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	wctx := testRunWorkflow(t, api, api.Router)
 	user := wctx.user
@@ -78,8 +77,7 @@ func Test_checkWorkflowPermissions(t *testing.T) {
 }
 
 func Test_checkProjectPermissions(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	g := assets.InsertGroup(t, api.mustDB())
 	authUser, _ := assets.InsertLambdaUser(t, api.mustDB(), g)
@@ -131,8 +129,7 @@ func Test_checkProjectPermissions(t *testing.T) {
 }
 
 func Test_checkUserPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	authUser, _ := assets.InsertLambdaUser(t, db)
 	authUserMaintainer, _ := assets.InsertMaintainerUser(t, db)
@@ -214,8 +211,7 @@ func Test_checkUserPermissions(t *testing.T) {
 }
 
 func Test_checkUserPublicPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	authUser, _ := assets.InsertLambdaUser(t, db)
 	authUserMaintainer, _ := assets.InsertMaintainerUser(t, db)
@@ -297,8 +293,7 @@ func Test_checkUserPublicPermissions(t *testing.T) {
 }
 
 func Test_checkConsumerPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	authUser, _ := assets.InsertLambdaUser(t, db)
 	authUserConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, authUser.ID)
@@ -384,8 +379,7 @@ func Test_checkConsumerPermissions(t *testing.T) {
 }
 
 func Test_checkSessionPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	authUser, _ := assets.InsertLambdaUser(t, db)
 	authUserConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, authUser.ID)
@@ -475,8 +469,7 @@ func Test_checkSessionPermissions(t *testing.T) {
 }
 
 func Test_checkWorkerModelPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	defer func() {
@@ -508,8 +501,7 @@ func Test_checkWorkerModelPermissions(t *testing.T) {
 }
 
 func Test_checkWorkflowPermissionsByUser(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	type setup struct {
 		UserAdmin                bool
@@ -705,8 +697,7 @@ func Test_checkJobIDPermissions(t *testing.T) {
 }
 
 func Test_checkGroupPermissions(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	type setup struct {
 		currentUser           string
@@ -947,8 +938,7 @@ func Test_checkGroupPermissions(t *testing.T) {
 }
 
 func Test_checkTemplateSlugPermissions(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	type setup struct {
 		groupName    string
@@ -1051,8 +1041,7 @@ func Test_checkTemplateSlugPermissions(t *testing.T) {
 }
 
 func Test_checkActionPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	defer func() {
@@ -1081,8 +1070,7 @@ func Test_checkActionPermissions(t *testing.T) {
 }
 
 func Test_checkActionBuiltinPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	scriptAction := assets.GetBuiltinOrPluginActionByName(t, db, "Script")
 

--- a/engine/api/router_middleware_auth_test.go
+++ b/engine/api/router_middleware_auth_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func Test_authMiddleware_WithAuth(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwt := assets.InsertLambdaUser(t, db)
 
@@ -45,8 +44,7 @@ func Test_authMiddleware_WithAuth(t *testing.T) {
 }
 
 func Test_authMiddleware_WithAuthConsumerDisabled(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := assets.InsertGroup(t, db)
 	u, _ := assets.InsertLambdaUser(t, db, g)
@@ -78,8 +76,7 @@ func Test_authMiddleware_WithAuthConsumerDisabled(t *testing.T) {
 }
 
 func Test_authMiddleware_WithoutAuth(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwt := assets.InsertLambdaUser(t, db)
 
@@ -107,8 +104,7 @@ func Test_authMiddleware_WithoutAuth(t *testing.T) {
 }
 
 func Test_authMiddleware_NeedAdmin(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwtLambda := assets.InsertLambdaUser(t, db)
 	admin, jwtAdmin := assets.InsertAdminUser(t, db)
@@ -135,8 +131,7 @@ func Test_authMiddleware_NeedAdmin(t *testing.T) {
 }
 
 func Test_authMiddleware_WithAuthConsumerScoped(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g := assets.InsertGroup(t, db)
 	u, _ := assets.InsertLambdaUser(t, db, g)

--- a/engine/api/services/dao_test.go
+++ b/engine/api/services/dao_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestDAO(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	allSrv, err := services.LoadAll(context.TODO(), db)
 	for _, s := range allSrv {

--- a/engine/api/services_test.go
+++ b/engine/api/services_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestServicesHandlers(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	admin, jwtRaw := assets.InsertAdminUser(t, api.mustDB())
 	_, jwtLambda := assets.InsertLambdaUser(t, api.mustDB())

--- a/engine/api/templates_test.go
+++ b/engine/api/templates_test.go
@@ -50,8 +50,7 @@ jobs:
 }
 
 func Test_postTemplateApplyHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 
@@ -135,8 +134,7 @@ func Test_postTemplateApplyHandler(t *testing.T) {
 }
 
 func Test_postTemplateBulkHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, jwt := assets.InsertAdminUser(t, api.mustDB())
 	g, err := group.LoadByName(context.TODO(), api.mustDB(), "shared.infra")
@@ -210,8 +208,7 @@ jobs:
 }
 
 func Test_getTemplateInstancesHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	projectOne := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	projectTwo := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/test/test.go
+++ b/engine/api/test/test.go
@@ -84,7 +84,14 @@ XeJEyyEjosSa3qWACDYorGMnzRXdeJa5H7J0W+G3x4tH2LMW8VHS
 -----END RSA PRIVATE KEY-----`)
 
 // SetupPG setup PG DB for test
-func SetupPG(t log.Logger, bootstrapFunc ...Bootstrapf) (*gorp.DbMap, cache.Store, context.CancelFunc) {
+func SetupPG(t *testing.T, bootstrapFunc ...Bootstrapf) (*gorp.DbMap, cache.Store) {
+	db, cache, cancel := SetupPGToCancel(t, bootstrapFunc...)
+	t.Cleanup(cancel)
+	return db, cache
+}
+
+// SetupPGToCancel setup PG DB for test
+func SetupPGToCancel(t log.Logger, bootstrapFunc ...Bootstrapf) (*gorp.DbMap, cache.Store, func()) {
 	log.SetLogger(t)
 	cfg := LoadTestingConf(t)
 	DBDriver = cfg["dbDriver"]

--- a/engine/api/timeline_test.go
+++ b/engine/api/timeline_test.go
@@ -27,8 +27,7 @@ type testTimelineEvent struct {
 func (e testTimelineEvent) String() string { return e.ProjectKey + "/" + e.WorkflowName }
 
 func Test_getTimelineHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	// Create two projects with workflows
 	proj1 := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/ui_test.go
+++ b/engine/api/ui_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_getNavbarHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 

--- a/engine/api/user/dao_test.go
+++ b/engine/api/user/dao_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAuthenticatedUserDAO(t *testing.T) {
-	db, _, _ := test.SetupPG(t)
+	db, _ := test.SetupPG(t)
 
 	u := sdk.AuthentifiedUser{
 		Username: sdk.RandomString(10),
@@ -45,7 +45,8 @@ func TestAuthenticatedUserDAO(t *testing.T) {
 }
 
 func TestLoadAll(t *testing.T) {
-	db, _, _ := test.SetupPG(t)
+	db, _ := test.SetupPG(t)
+
 	for i := 0; i < 10; i++ {
 		var u = sdk.AuthentifiedUser{
 			Username: sdk.RandomString(10),
@@ -64,7 +65,7 @@ func TestLoadAll(t *testing.T) {
 }
 
 func TestLoadAllByIDs(t *testing.T) {
-	db, _, _ := test.SetupPG(t)
+	db, _ := test.SetupPG(t)
 
 	ids := make([]string, 3)
 	for i := 0; i < 2; i++ {

--- a/engine/api/user/loader_test.go
+++ b/engine/api/user/loader_test.go
@@ -18,7 +18,7 @@ func TestLoadContacts(t *testing.T) {
 		Ring:     sdk.UserRingAdmin,
 	}
 
-	db, _, _ := test.SetupPG(t)
+	db, _ := test.SetupPG(t)
 	assert.NoError(t, user.Insert(context.TODO(), db, &u))
 
 	c := sdk.UserContact{

--- a/engine/api/user_contacts_test.go
+++ b/engine/api/user_contacts_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func Test_getUserContactsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, jwtRaw := assets.InsertLambdaUser(t, db)
 

--- a/engine/api/user_groups_test.go
+++ b/engine/api/user_groups_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func Test_getUserGroupsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	g1 := assets.InsertGroup(t, db)
 	g2 := assets.InsertGroup(t, db)

--- a/engine/api/user_test.go
+++ b/engine/api/user_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_getUsersHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	expected, jwtRaw := assets.InsertLambdaUser(t, db)
 
@@ -42,8 +41,7 @@ func Test_getUsersHandler(t *testing.T) {
 }
 
 func Test_getUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	expected, jwtRaw := assets.InsertLambdaUser(t, db)
 
@@ -62,8 +60,7 @@ func Test_getUserHandler(t *testing.T) {
 }
 
 func Test_putUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	assets.DeleteAdmins(t, db)
 
@@ -195,8 +192,7 @@ func Test_putUserHandler(t *testing.T) {
 }
 
 func Test_deleteUserHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	assets.DeleteAdmins(t, db)
 

--- a/engine/api/version/version_test.go
+++ b/engine/api/version/version_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestMaxInstall(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	sdk.VERSION = "0.37.0"
 	test.NoError(t, version.Upsert(db))

--- a/engine/api/websocket.go
+++ b/engine/api/websocket.go
@@ -76,11 +76,7 @@ func (b *websocketBroker) Start(ctx context.Context, panicCallback func(s string
 				}
 				observability.Record(b.router.Background, WebSocketClients, 0)
 			}
-			if ctx.Err() != nil {
-				log.Error(ctx, "websocketBroker.Start> Exiting: %v", ctx.Err())
-				return
-			}
-
+			return
 		case receivedEvent := <-b.messages:
 			for i := range b.clients {
 				c := b.clients[i]
@@ -131,11 +127,12 @@ func (b *websocketBroker) cacheSubscribe(ctx context.Context, cacheMsgChan chan<
 	for {
 		select {
 		case <-ctx.Done():
-			if ctx.Err() != nil {
-				log.Error(ctx, "websocketBroker.cacheSubscribe> Exiting: %v", ctx.Err())
-				return
-			}
+			return
 		case <-tick.C:
+			if ctx.Err() != nil {
+				continue
+			}
+
 			msg, err := store.GetMessageFromSubscription(ctx, pubSub)
 			if err != nil {
 				log.Warning(ctx, "websocketBroker.cacheSubscribe> Cannot get message %s: %s", msg, err)

--- a/engine/api/websocket_test.go
+++ b/engine/api/websocket_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func Test_websocketWrongFilters(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	u, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -129,8 +128,7 @@ func Test_websocketWrongFilters(t *testing.T) {
 }
 
 func Test_websocketGetWorkflowEvent(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	u, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -186,8 +184,7 @@ func Test_websocketGetWorkflowEvent(t *testing.T) {
 }
 
 func Test_websocketDeconnection(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	u, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/worker/worker_test.go
+++ b/engine/api/worker/worker_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestDAO(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	workers, err := worker.LoadAll(context.TODO(), db)
 	test.NoError(t, err)
@@ -62,15 +61,14 @@ func TestDAO(t *testing.T) {
 }
 
 func TestDeadWorkers(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
+
 	test.NoError(t, worker.DisableDeadWorkers(context.TODO(), db))
 	test.NoError(t, worker.DeleteDeadWorkers(context.TODO(), db))
 }
 
 func TestRegister(t *testing.T) {
-	db, store, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, store := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertGroup(t, db)
 	h, _, c, _ := assets.InsertHatchery(t, db, *g)

--- a/engine/api/worker_model_hatchery_test.go
+++ b/engine/api/worker_model_hatchery_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func Test_getWorkerModelSecretHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	g := assets.InsertTestGroup(t, api.mustDB(), sdk.RandomString(10))
 

--- a/engine/api/worker_model_test.go
+++ b/engine/api/worker_model_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func Test_DeleteAllWorkerModels(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	// Load and delete all worker
 	workers, err := worker.LoadAll(context.Background(), api.mustDB())
@@ -53,8 +52,7 @@ func Test_DeleteAllWorkerModels(t *testing.T) {
 func Test_postWorkerModelAsAdmin(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	_, jwtRaw := assets.InsertAdminUser(t, api.mustDB())
 
@@ -92,8 +90,7 @@ func Test_postWorkerModelAsAdmin(t *testing.T) {
 }
 
 func Test_addWorkerModelWithPrivateRegistryAsAdmin(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	//Loading all models
 	models, errlw := workermodel.LoadAll(context.Background(), api.mustDB(), nil)
@@ -171,8 +168,7 @@ func Test_addWorkerModelWithPrivateRegistryAsAdmin(t *testing.T) {
 func Test_WorkerModelUsage(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	u, jwt := assets.InsertAdminUser(t, db)
 	assert.NotZero(t, u)
@@ -295,8 +291,7 @@ func Test_WorkerModelUsage(t *testing.T) {
 func Test_postWorkerModelWithWrongRequest(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create admin user
 	u, jwt := assets.InsertAdminUser(t, api.mustDB())
@@ -403,8 +398,7 @@ func Test_postWorkerModelWithWrongRequest(t *testing.T) {
 func Test_postWorkerModelAsAGroupMember(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -445,8 +439,7 @@ func Test_postWorkerModelAsAGroupMember(t *testing.T) {
 func Test_postWorkerModelAsAGroupAdmin(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -486,8 +479,7 @@ func Test_postWorkerModelAsAGroupAdmin(t *testing.T) {
 func Test_postWorkerModelAsAGroupAdminWithRestrict(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -531,8 +523,7 @@ func Test_postWorkerModelAsAGroupAdminWithRestrict(t *testing.T) {
 func Test_postWorkerModelAsAGroupAdminWithoutRestrictWithPattern(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -590,8 +581,7 @@ func Test_postWorkerModelAsAGroupAdminWithoutRestrictWithPattern(t *testing.T) {
 func Test_postWorkerModelAsAWrongGroupMember(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -638,8 +628,7 @@ func Test_postWorkerModelAsAWrongGroupMember(t *testing.T) {
 func Test_putWorkerModel(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -712,8 +701,7 @@ func Test_putWorkerModel(t *testing.T) {
 func Test_putWorkerModelWithPassword(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -818,8 +806,7 @@ func Test_putWorkerModelWithPassword(t *testing.T) {
 func Test_deleteWorkerModel(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create group
 	g := &sdk.Group{
@@ -880,8 +867,7 @@ func Test_deleteWorkerModel(t *testing.T) {
 func Test_getWorkerModel(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
 
 	//Create admin user
 	u, jwt := assets.InsertAdminUser(t, api.mustDB())
@@ -936,8 +922,7 @@ func Test_getWorkerModel(t *testing.T) {
 func Test_getWorkerModels(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	_, jwtAdmin := assets.InsertAdminUser(t, api.mustDB())
 
@@ -1011,8 +996,7 @@ func Test_getWorkerModels(t *testing.T) {
 func Test_renameWorkerModel(t *testing.T) {
 	Test_DeleteAllWorkerModels(t)
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// create new group
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))

--- a/engine/api/worker_test.go
+++ b/engine/api/worker_test.go
@@ -107,8 +107,7 @@ func LoadOrCreateWorkerModel(t *testing.T, api *API, groupID int64, workermodelN
 }
 
 func TestPostRegisterWorkerHandler(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	g := LoadSharedInfraGroup(t, api)
 
@@ -137,8 +136,7 @@ func TestPostRegisterWorkerHandler(t *testing.T) {
 
 // TestPostInvalidRegister tests to register a worker for a job, without a JobID
 func TestPostInvalidRegister(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
 
 	g := LoadSharedInfraGroup(t, api)
 

--- a/engine/api/workermodel/crud_test.go
+++ b/engine/api/workermodel/crud_test.go
@@ -19,8 +19,7 @@ import (
 
 // create handler tests
 func TestCreateModel(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	u, _ := assets.InsertLambdaUser(t, db)
@@ -51,8 +50,7 @@ func TestCreateModel(t *testing.T) {
 }
 
 func TestUpdateModel(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -138,8 +136,7 @@ func TestUpdateModel(t *testing.T) {
 // rename worker model to aaa-bar
 // the pipeline should keep the name aaa-foo
 func TestUpdateModelInPipeline(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	u, _ := assets.InsertLambdaUser(t, db)
@@ -242,8 +239,7 @@ func TestUpdateModelInPipeline(t *testing.T) {
 }
 
 func TestUpdateModelInPipelineSimple(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	u, _ := assets.InsertLambdaUser(t, db)
@@ -364,8 +360,7 @@ func TestCopyModelTypeData_OldRestricted(t *testing.T) {
 }
 
 func TestUpdateModel_NeedRegister(t *testing.T) {
-	db, store, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, store := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 

--- a/engine/api/workermodel/dao_test.go
+++ b/engine/api/workermodel/dao_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestInsertAndUpdate_WithRegistryPassword(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertGroup(t, db)
 
@@ -115,8 +114,7 @@ func insertWorkerModel(t *testing.T, db gorp.SqlExecutor, name string, groupID i
 }
 
 func TestInsert(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertGroup(t, db)
 
@@ -138,8 +136,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestLoadByNameAndGroupID(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertGroup(t, db)
 
@@ -154,8 +151,7 @@ func TestLoadByNameAndGroupID(t *testing.T) {
 }
 
 func TestLoadWorkerModelsByNameAndGroupIDs(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -182,8 +178,7 @@ func TestLoadWorkerModelsByNameAndGroupIDs(t *testing.T) {
 }
 
 func TestLoadAll(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	// delete all workers
 	wks, err := worker.LoadAll(context.TODO(), db)
@@ -260,8 +255,7 @@ func TestLoadAll(t *testing.T) {
 }
 
 func TestLoadAllByGroupIDs(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -329,8 +323,7 @@ func TestLoadAllByGroupIDs(t *testing.T) {
 }
 
 func TestLoadCapabilities(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 
@@ -348,8 +341,7 @@ func TestLoadCapabilities(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	src := insertWorkerModel(t, db, sdk.RandomString(10), g.ID)
@@ -370,8 +362,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestLoadWorkerModelsForGroupIDs(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	g1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	g2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))

--- a/engine/api/workflow/audit_test.go
+++ b/engine/api/workflow/audit_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func Test_PurgeAudits(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	err := PurgeAudits(context.TODO(), db)
 	test.NoError(t, err)

--- a/engine/api/workflow/dao_run_test.go
+++ b/engine/api/workflow/dao_run_test.go
@@ -78,8 +78,8 @@ func TestCanBeRun(t *testing.T) {
 }
 
 func TestPurgeWorkflowRun(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	mockVCSSservice, _ := assets.InsertService(t, db, "TestManualRunBuildParameterMultiApplication", services.TypeVCS)
@@ -254,8 +254,8 @@ vcs_ssh_key: proj-blabla
 }
 
 func TestPurgeWorkflowRunWithRunningStatus(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	u, _ := assets.InsertAdminUser(t, db)
@@ -352,8 +352,8 @@ func TestPurgeWorkflowRunWithRunningStatus(t *testing.T) {
 }
 
 func TestPurgeWorkflowRunWithOneSuccessWorkflowRun(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	mockVCSSservice, _ := assets.InsertService(t, db, "TestManualRunBuildParameterMultiApplication", services.TypeVCS)
@@ -554,8 +554,8 @@ vcs_ssh_key: proj-blabla
 }
 
 func TestPurgeWorkflowRunWithNoSuccessWorkflowRun(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	mockVCSSservice, _ := assets.InsertService(t, db, "TestManualRunBuildParameterMultiApplication", services.TypeVCS)
@@ -723,8 +723,8 @@ vcs_ssh_key: proj-blabla
 }
 
 func TestPurgeWorkflowRunWithoutTags(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	u, _ := assets.InsertAdminUser(t, db)
@@ -809,8 +809,8 @@ func TestPurgeWorkflowRunWithoutTags(t *testing.T) {
 }
 
 func TestPurgeWorkflowRunWithoutTagsBiggerHistoryLength(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	u, _ := assets.InsertAdminUser(t, db)

--- a/engine/api/workflow/dao_staticfiles_test.go
+++ b/engine/api/workflow/dao_staticfiles_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestInsertStaticFiles(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	_ = event.Initialize(context.Background(), db, cache)
 
 	u, _ := assets.InsertAdminUser(t, db)

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -34,8 +34,8 @@ import (
 )
 
 func TestLoadAllShouldNotReturnAnyWorkflows(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 
@@ -47,8 +47,7 @@ func TestLoadAllShouldNotReturnAnyWorkflows(t *testing.T) {
 }
 
 func TestInsertSimpleWorkflowAndExport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -109,8 +108,7 @@ func TestInsertSimpleWorkflowAndExport(t *testing.T) {
 }
 
 func TestInsertSimpleWorkflowWithWrongName(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -145,8 +143,7 @@ func TestInsertSimpleWorkflowWithWrongName(t *testing.T) {
 }
 
 func TestInsertSimpleWorkflowWithApplicationAndEnv(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -210,8 +207,7 @@ func TestInsertSimpleWorkflowWithApplicationAndEnv(t *testing.T) {
 }
 
 func TestInsertComplexeWorkflowAndExport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -351,8 +347,7 @@ func TestInsertComplexeWorkflowAndExport(t *testing.T) {
 }
 
 func TestInsertComplexeWorkflowWithBadOperator(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -485,8 +480,7 @@ func assertEqualNode(t *testing.T, n1, n2 *sdk.Node) {
 	}
 }
 func TestUpdateSimpleWorkflowWithApplicationEnvPipelineParametersAndPayload(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -626,8 +620,7 @@ func TestUpdateSimpleWorkflowWithApplicationEnvPipelineParametersAndPayload(t *t
 }
 
 func TestInsertComplexeWorkflowWithJoinsAndExport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -844,8 +837,7 @@ func TestInsertComplexeWorkflowWithJoinsAndExport(t *testing.T) {
 }
 
 func TestInsertComplexeWorkflowWithComplexeJoins(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -1114,8 +1106,7 @@ func TestInsertComplexeWorkflowWithComplexeJoins(t *testing.T) {
 }
 
 func TestUpdateWorkflowWithJoins(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -1241,8 +1232,8 @@ func TestUpdateWorkflowWithJoins(t *testing.T) {
 }
 
 func TestInsertSimpleWorkflowWithHookAndExport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(db))
 	test.NoError(t, workflow.CreateBuiltinWorkflowOutgoingHookModels(db))
 
@@ -1499,8 +1490,8 @@ func TestInsertSimpleWorkflowWithHookAndExport(t *testing.T) {
 }
 
 func TestInsertAndDeleteMultiHook(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(db))
 

--- a/engine/api/workflow/factory_dao_test.go
+++ b/engine/api/workflow/factory_dao_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestLoadAllWorkflows(t *testing.T) {
-	db, _, end := test.SetupPG(t)
-	defer end()
+	db, _ := test.SetupPG(t)
 
 	var opts = []workflow.WorkflowDAO{
 		{},

--- a/engine/api/workflow/process_node_test.go
+++ b/engine/api/workflow/process_node_test.go
@@ -35,8 +35,8 @@ type mockServiceClient struct {
 
 // Payload: nothing
 func TestHookRunWithoutPayloadProcessNodeBuildParameter(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	webHookModel, err := workflow.LoadHookModelByName(db, sdk.WebHookModelName)
@@ -227,8 +227,8 @@ func TestHookRunWithoutPayloadProcessNodeBuildParameter(t *testing.T) {
 
 // Payload: commit only
 func TestHookRunWithHashOnlyProcessNodeBuildParameter(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	webHookModel, err := workflow.LoadHookModelByName(db, sdk.WebHookModelName)
@@ -411,8 +411,8 @@ func TestHookRunWithHashOnlyProcessNodeBuildParameter(t *testing.T) {
 
 // Payload: branch only
 func TestManualRunWithPayloadProcessNodeBuildParameter(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -564,8 +564,8 @@ func TestManualRunWithPayloadProcessNodeBuildParameter(t *testing.T) {
 
 // Payload: branch and commit
 func TestManualRunBranchAndCommitInPayloadProcessNodeBuildParameter(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -710,8 +710,8 @@ func TestManualRunBranchAndCommitInPayloadProcessNodeBuildParameter(t *testing.T
 
 // Payload: branch and repository (we want to build a fork)
 func TestManualRunBranchAndRepositoryInPayloadProcessNodeBuildParameter(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -942,8 +942,8 @@ func TestManualRunBranchAndRepositoryInPayloadProcessNodeBuildParameter(t *testi
 
 // Payload: multi application, multi repo
 func TestManualRunBuildParameterMultiApplication(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -1188,8 +1188,7 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 }
 
 func TestManualRunBuildParameterNoApplicationOnRoot(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -1433,8 +1432,8 @@ func TestManualRunBuildParameterNoApplicationOnRoot(t *testing.T) {
 
 // Payload: branch only
 func TestGitParamOnPipelineWithoutApplication(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -1620,8 +1619,8 @@ func TestGitParamOnPipelineWithoutApplication(t *testing.T) {
 
 // Payload: branch only
 func TestGitParamOnApplicationWithoutRepo(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -1801,8 +1800,8 @@ func TestGitParamOnApplicationWithoutRepo(t *testing.T) {
 
 // Payload: branch only
 func TestGitParamOn2ApplicationSameRepo(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -2002,8 +2001,8 @@ func TestGitParamOn2ApplicationSameRepo(t *testing.T) {
 
 // Payload: branch only
 func TestGitParamWithJoin(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -2221,8 +2220,8 @@ func TestGitParamWithJoin(t *testing.T) {
 
 // Payload: branch only
 func TestGitParamOn2ApplicationSameRepoWithFork(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project
@@ -2438,8 +2437,8 @@ func TestGitParamOn2ApplicationSameRepoWithFork(t *testing.T) {
 
 // Payload: branch only  + run condition on git.branch
 func TestManualRunWithPayloadAndRunCondition(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	// Create project

--- a/engine/api/workflow/process_start_test.go
+++ b/engine/api/workflow/process_start_test.go
@@ -2,6 +2,8 @@ package workflow_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ovh/cds/engine/api/authentication"
 	"github.com/ovh/cds/engine/api/bootstrap"
 	"github.com/ovh/cds/engine/api/test"
@@ -9,12 +11,11 @@ import (
 	"github.com/ovh/cds/engine/api/workflow"
 	"github.com/ovh/cds/sdk"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestProcessJoinDefaultCondition(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -72,8 +73,8 @@ func TestProcessJoinDefaultCondition(t *testing.T) {
 }
 
 func TestProcessJoinCustomCondition(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 

--- a/engine/api/workflow/run_workflow_test.go
+++ b/engine/api/workflow/run_workflow_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func TestManualRun1(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -182,8 +182,8 @@ func TestManualRun1(t *testing.T) {
 }
 
 func TestManualRun2(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -301,8 +301,8 @@ func TestManualRun2(t *testing.T) {
 }
 
 func TestManualRun3(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -827,8 +827,8 @@ queueRun:
 }
 
 func TestNoStage(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
@@ -897,8 +897,8 @@ func TestNoStage(t *testing.T) {
 }
 
 func TestNoJob(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 

--- a/engine/api/workflow/workflow_exporter_test.go
+++ b/engine/api/workflow/workflow_exporter_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestPull(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)
 

--- a/engine/api/workflow/workflow_importer_test.go
+++ b/engine/api/workflow/workflow_importer_test.go
@@ -30,8 +30,8 @@ func (h *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
 }
 
 func TestImport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, cache, key, key)

--- a/engine/api/workflow/workflow_parser_test.go
+++ b/engine/api/workflow/workflow_parser_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestParseAndImport(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	u, _ := assets.InsertAdminUser(t, db)
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 	require.NoError(t, err)
@@ -116,8 +116,8 @@ func TestParseAndImport(t *testing.T) {
 
 // TestParseAndImportFromRepository tests to import a workflow with FromRepository
 func TestParseAndImportFromRepository(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
+
 	u, _ := assets.InsertAdminUser(t, db)
 
 	pkey := sdk.RandomString(10)

--- a/engine/api/workflow/workflow_run_event_test.go
+++ b/engine/api/workflow/workflow_run_event_test.go
@@ -24,8 +24,7 @@ import (
 // Test ResyncCommitStatus with a notification where all is disabled.
 // Must: no error returned, only list status is called
 func TestResyncCommitStatusNotifDisabled(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	ctx := context.TODO()
 
@@ -122,8 +121,7 @@ func TestResyncCommitStatusNotifDisabled(t *testing.T) {
 // Test TestResyncCommitStatusSetStatus with a notification where all is disabled.
 // Must: no error returned, setStatus must be called
 func TestResyncCommitStatusSetStatus(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	ctx := context.TODO()
 
@@ -226,8 +224,7 @@ func TestResyncCommitStatusSetStatus(t *testing.T) {
 // Test TestResyncCommitStatusCommentPR with a notification where all is disabled.
 // Must: no error returned, postComment must be called
 func TestResyncCommitStatusCommentPR(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	ctx := context.TODO()
 
@@ -344,8 +341,7 @@ func TestResyncCommitStatusCommentPR(t *testing.T) {
 // Test TestResyncCommitStatusCommentPRNotTerminated with a notification where all is disabled.
 // Must: no error returned, postComment must be called
 func TestResyncCommitStatusCommentPRNotTerminated(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	ctx := context.TODO()
 
@@ -453,8 +449,7 @@ func TestResyncCommitStatusCommentPRNotTerminated(t *testing.T) {
 // Test TestResyncCommitStatus with a notification where all is disabled.
 // Must: no error returned, postComment must be called
 func TestResyncCommitStatusCommitCache(t *testing.T) {
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	ctx := context.TODO()
 

--- a/engine/api/workflow_ascode_rename_test.go
+++ b/engine/api/workflow_ascode_rename_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func Test_WorkflowAsCodeRename(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)

--- a/engine/api/workflow_ascode_test.go
+++ b/engine/api/workflow_ascode_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestPostUpdateWorkflowAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)
@@ -235,8 +234,7 @@ func TestPostUpdateWorkflowAsCodeHandler(t *testing.T) {
 }
 
 func TestPostMigrateWorkflowAsCodeHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 
@@ -502,8 +500,7 @@ func initWorkflow(t *testing.T, db gorp.SqlExecutor, proj *sdk.Project, app *sdk
 }
 
 func Test_WorkflowAsCodeWithNotifications(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)

--- a/engine/api/workflow_ascode_with_hooks_test.go
+++ b/engine/api/workflow_ascode_with_hooks_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func Test_WorkflowAsCodeWithNoHook_ShouldGive_AnAutomaticRepoWebHook(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)
@@ -235,8 +234,7 @@ func Test_WorkflowAsCodeWithDefaultHook_ShouldGive_TheSameRepoWebHook(t *testing
 	// Then we trigger the workflow, this aims to run another "as-code operation"
 	// This should not change the hooks
 
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)
@@ -517,8 +515,7 @@ func Test_WorkflowAsCodeWithDefaultHookAndAScheduler_ShouldGive_TheSameRepoWebHo
 	// Then we trigger the workflow, this aims to run another "as-code operation"
 	// This should not change the hooks
 
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)
@@ -883,8 +880,7 @@ func Test_WorkflowAsCodeWithJustAcheduler_ShouldGive_ARepoWebHookAndTheScheduler
 	// This last time, the scheduler should be deleted
 	// This should not change the repowebhook
 
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 	_, _ = assets.InsertService(t, db, t.Name()+"_VCS", services.TypeVCS)

--- a/engine/api/workflow_export_test.go
+++ b/engine/api/workflow_export_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func Test_getWorkflowExportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, api.mustDB(), api.Cache, key, key)
@@ -150,8 +150,8 @@ workflow:
 }
 
 func Test_getWorkflowExportHandlerWithPermissions(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, api.mustDB(), api.Cache, key, key)
@@ -284,8 +284,8 @@ history_length: 25
 }
 
 func Test_getWorkflowPullHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, api.mustDB(), api.Cache, key, key)

--- a/engine/api/workflow_group_test.go
+++ b/engine/api/workflow_group_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 func Test_postWorkflowGroupHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -91,8 +91,8 @@ func Test_postWorkflowGroupHandler(t *testing.T) {
 }
 
 func Test_postWorkflowGroupWithLessThanRWXProjectHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -157,8 +157,8 @@ func Test_postWorkflowGroupWithLessThanRWXProjectHandler(t *testing.T) {
 }
 
 func Test_putWorkflowGroupHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -261,8 +261,8 @@ func Test_putWorkflowGroupHandler(t *testing.T) {
 }
 
 func Test_deleteWorkflowGroupHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -344,8 +344,8 @@ func Test_deleteWorkflowGroupHandler(t *testing.T) {
 
 // Test_UpdateProjectPermsWithWorkflow Useful to test permission propagation on project
 func Test_UpdateProjectPermsWithWorkflow(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertLambdaUser(t, api.mustDB(), &proj.ProjectGroups[0].Group)
 
@@ -425,8 +425,7 @@ func Test_UpdateProjectPermsWithWorkflow(t *testing.T) {
 
 // Test_PermissionOnWorkflowInferiorOfProject Useful to test when permission on wf is superior than permission on project
 func Test_PermissionOnWorkflowInferiorOfProject(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertLambdaUser(t, api.mustDB(), &proj.ProjectGroups[0].Group)
@@ -594,8 +593,8 @@ func Test_PermissionOnWorkflowInferiorOfProject(t *testing.T) {
 
 // Test_PermissionOnWorkflowWithRestrictionOnNode Useful to test when we add permission on a workflow node
 func Test_PermissionOnWorkflowWithRestrictionOnNode(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	u, pass := assets.InsertLambdaUser(t, api.mustDB(), &proj.ProjectGroups[0].Group)
 

--- a/engine/api/workflow_hook_test.go
+++ b/engine/api/workflow_hook_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func Test_getWorkflowHookModelsHandlerAsLambdaUser(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
+
 	db := api.mustDB()
 	cache := api.Cache
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(api.mustDB()))
@@ -89,8 +89,8 @@ func Test_getWorkflowHookModelsHandlerAsLambdaUser(t *testing.T) {
 }
 
 func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
+
 	db := api.mustDB()
 	cache := api.Cache
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(api.mustDB()))
@@ -157,8 +157,8 @@ func Test_getWorkflowHookModelsHandlerAsAdminUser(t *testing.T) {
 }
 
 func Test_getWorkflowHookModelHandler(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
+
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(api.mustDB()))
 	admin, passAdmin := assets.InsertAdminUser(t, api.mustDB())
 
@@ -185,8 +185,8 @@ func Test_getWorkflowHookModelHandler(t *testing.T) {
 }
 
 func Test_putWorkflowHookModelHandlerAsAdminUser(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
+
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(api.mustDB()))
 	admin, passAdmin := assets.InsertAdminUser(t, api.mustDB())
 
@@ -227,8 +227,8 @@ func Test_putWorkflowHookModelHandlerAsAdminUser(t *testing.T) {
 }
 
 func Test_putWorkflowHookModelHandlerAsLambdaUser(t *testing.T) {
-	api, _, _, end := newTestAPI(t)
-	defer end()
+	api, _, _ := newTestAPI(t)
+
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(api.mustDB()))
 
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())

--- a/engine/api/workflow_import_test.go
+++ b/engine/api/workflow_import_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func Test_postWorkflowImportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -88,8 +87,7 @@ metadata:
 }
 
 func Test_postWorkflowImportHandlerWithExistingIcon(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -160,8 +158,7 @@ metadata:
 }
 
 func Test_putWorkflowImportHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -224,8 +221,7 @@ workflow:
 }
 
 func Test_putWorkflowImportHandlerWithJoinAndCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -351,8 +347,7 @@ metadata:
 }
 
 func Test_putWorkflowImportHandlerWithJoinWithOrWithoutCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -484,8 +479,7 @@ metadata:
 }
 
 func Test_putWorkflowImportHandlerWithJoinWithoutCondition(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
@@ -623,8 +617,8 @@ metadata:
 }
 
 func Test_getWorkflowPushHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, api.mustDB(), api.Cache, key, key)
@@ -790,8 +784,7 @@ func Test_getWorkflowPushHandler(t *testing.T) {
 }
 
 func Test_putWorkflowImportHandlerMustNotHave2Joins(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
 
 	u, pass := assets.InsertAdminUser(t, db)
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -354,8 +354,7 @@ func testRegisterHatchery(t *testing.T, api *API, router *Router, ctx *testRunWo
 }
 
 func TestGetWorkflowJobQueueHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// delete all existing workers
 	workers, err := worker.LoadAll(context.TODO(), db)
@@ -430,8 +429,8 @@ func TestGetWorkflowJobQueueHandler(t *testing.T) {
 }
 
 func Test_postTakeWorkflowJobHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	require.NotNil(t, ctx.job)
@@ -502,8 +501,8 @@ func Test_postTakeWorkflowJobHandler(t *testing.T) {
 }
 
 func Test_postTakeWorkflowJobHandlerDefautlRegion(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	require.NotNil(t, ctx.job)
@@ -559,8 +558,8 @@ func Test_postTakeWorkflowJobHandlerDefautlRegion(t *testing.T) {
 }
 
 func Test_postTakeWorkflowInvalidJobHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	require.NotNil(t, ctx.job)
@@ -599,8 +598,8 @@ func Test_postTakeWorkflowInvalidJobHandler(t *testing.T) {
 }
 
 func Test_postBookWorkflowJobHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsHatchery(t, api, router, &ctx)
 	assert.NotNil(t, ctx.job)
@@ -621,8 +620,8 @@ func Test_postBookWorkflowJobHandler(t *testing.T) {
 }
 
 func Test_postWorkflowJobResultHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	assert.NotNil(t, ctx.job)
@@ -712,8 +711,8 @@ func Test_postWorkflowJobResultHandler(t *testing.T) {
 }
 
 func Test_postWorkflowJobTestsResultsHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	assert.NotNil(t, ctx.job)
@@ -816,8 +815,8 @@ func Test_postWorkflowJobTestsResultsHandler(t *testing.T) {
 }
 
 func Test_postWorkflowJobArtifactHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 
@@ -962,8 +961,8 @@ func fileExists(filename string) bool {
 }
 
 func Test_postWorkflowJobStaticFilesHandler(t *testing.T) {
-	api, _, router, end := newTestAPI(t)
-	defer end()
+	api, _, router := newTestAPI(t)
+
 	ctx := testRunWorkflow(t, api, router)
 	testGetWorkflowJobAsWorker(t, api, router, &ctx)
 	require.NotNil(t, ctx.job)
@@ -1030,8 +1029,7 @@ func Test_postWorkflowJobStaticFilesHandler(t *testing.T) {
 }
 
 func TestWorkerPrivateKey(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Create user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1147,8 +1145,7 @@ func TestWorkerPrivateKey(t *testing.T) {
 }
 
 func TestPostVulnerabilityReportHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Create user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1288,8 +1285,7 @@ func TestPostVulnerabilityReportHandler(t *testing.T) {
 }
 
 func TestInsertNewCodeCoverageReport(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Create user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())

--- a/engine/api/workflow_run_test.go
+++ b/engine/api/workflow_run_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 func Test_getWorkflowNodeRunHistoryHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -160,8 +160,8 @@ func Test_getWorkflowNodeRunHistoryHandler(t *testing.T) {
 }
 
 func Test_getWorkflowRunsHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 	key := sdk.RandomString(10)
@@ -314,8 +314,8 @@ func Test_getWorkflowRunsHandler(t *testing.T) {
 }
 
 func Test_getWorkflowRunsHandlerWithFilter(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -430,8 +430,8 @@ func Test_getWorkflowRunsHandlerWithFilter(t *testing.T) {
 }
 
 func Test_getLatestWorkflowRunHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -564,8 +564,8 @@ func Test_getLatestWorkflowRunHandler(t *testing.T) {
 }
 
 func Test_getWorkflowRunHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -681,8 +681,8 @@ func Test_getWorkflowRunHandler(t *testing.T) {
 }
 
 func Test_getWorkflowNodeRunHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 
@@ -832,8 +832,8 @@ func Test_getWorkflowNodeRunHandler(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -990,8 +990,8 @@ func waitCraftinWorkflow(t *testing.T, db gorp.SqlExecutor, id int64) error {
  * 3. Run workflow :  Must fail on getting PR.id = 1
  */
 func Test_postWorkflowRunAsyncFailedHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1230,8 +1230,8 @@ func Test_postWorkflowRunAsyncFailedHandler(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerWithoutRightOnEnvironment(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
 
@@ -1342,8 +1342,8 @@ func Test_postWorkflowRunHandlerWithoutRightOnEnvironment(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerWithoutRightConditionsOnHook(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1501,8 +1501,8 @@ func Test_postWorkflowRunHandlerWithoutRightConditionsOnHook(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerHookWithMutex(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1663,8 +1663,8 @@ func Test_postWorkflowRunHandlerHookWithMutex(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerHook(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1832,8 +1832,8 @@ func Test_postWorkflowRunHandlerHook(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandler_Forbidden(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1905,8 +1905,8 @@ func Test_postWorkflowRunHandler_Forbidden(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandler_ConditionNotOK(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -1989,8 +1989,8 @@ func Test_postWorkflowRunHandler_ConditionNotOK(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandler_BadPayload(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -2200,8 +2200,7 @@ func initGetWorkflowNodeRunJobTest(t *testing.T, api *API, db *gorp.DbMap) (*sdk
 }
 
 func Test_getWorkflowNodeRunJobStepHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	u, pass, proj, w1, lastRun, jobRun := initGetWorkflowNodeRunJobTest(t, api, db)
 
@@ -2230,8 +2229,7 @@ func Test_getWorkflowNodeRunJobStepHandler(t *testing.T) {
 }
 
 func Test_getWorkflowNodeRunJobServiceLogsHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	u, pass, proj, w1, lastRun, jobRun := initGetWorkflowNodeRunJobTest(t, api, db)
 
@@ -2258,8 +2256,8 @@ func Test_getWorkflowNodeRunJobServiceLogsHandler(t *testing.T) {
 }
 
 func Test_deleteWorkflowRunsBranchHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -2404,8 +2402,8 @@ func Test_deleteWorkflowRunsBranchHandler(t *testing.T) {
 }
 
 func Test_deleteWorkflowRunHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -2520,8 +2518,7 @@ func Test_deleteWorkflowRunHandler(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerBadResyncOptions(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -2551,8 +2548,8 @@ func Test_postWorkflowRunHandlerBadResyncOptions(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerRestartOnlyFailed(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
@@ -2695,8 +2692,8 @@ func Test_postWorkflowRunHandlerRestartOnlyFailed(t *testing.T) {
 }
 
 func Test_postWorkflowRunHandlerRestartResync(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
 	key := sdk.RandomString(10)
 	proj := assets.InsertTestProject(t, db, api.Cache, key, key)

--- a/engine/api/workflow_test.go
+++ b/engine/api/workflow_test.go
@@ -37,8 +37,8 @@ import (
 )
 
 func Test_getWorkflowsHandler(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	require.NoError(t, group.InsertLinkGroupUser(context.TODO(), api.mustDB(), &group.LinkGroupUser{
@@ -134,8 +134,8 @@ func Test_getWorkflowsHandler(t *testing.T) {
 }
 
 func Test_getWorkflowNotificationsConditionsHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	u, pass := assets.InsertAdminUser(t, db)
 	consumer, _ := authentication.LoadConsumerByTypeAndUserID(context.TODO(), db, sdk.ConsumerLocal, u.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
 	key := sdk.RandomString(10)
@@ -260,8 +260,7 @@ func Test_getWorkflowNotificationsConditionsHandler(t *testing.T) {
 }
 
 func Test_getWorkflowHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -284,8 +283,8 @@ func Test_getWorkflowHandler(t *testing.T) {
 }
 
 func Test_getWorkflowHandler_CheckPermission(t *testing.T) {
-	api, db, _, end := newTestAPI(t)
-	defer end()
+	api, db, _ := newTestAPI(t)
+
 	u, pass := assets.InsertLambdaUser(t, api.mustDB())
 	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
 	require.NoError(t, group.InsertLinkGroupUser(context.TODO(), api.mustDB(), &group.LinkGroupUser{
@@ -376,8 +375,7 @@ func Test_getWorkflowHandler_CheckPermission(t *testing.T) {
 }
 
 func Test_getWorkflowHandler_AsProvider(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -440,8 +438,7 @@ func Test_getWorkflowHandler_AsProvider(t *testing.T) {
 }
 
 func Test_getWorkflowHandler_withUsage(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -503,8 +500,7 @@ func Test_getWorkflowHandler_withUsage(t *testing.T) {
 }
 
 func Test_postWorkflowHandlerWithoutRootShouldFail(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -528,8 +524,7 @@ func Test_postWorkflowHandlerWithoutRootShouldFail(t *testing.T) {
 
 func Test_postWorkflowHandlerWithRootShouldSuccess(t *testing.T) {
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -591,8 +586,7 @@ func Test_postWorkflowHandlerWithRootShouldSuccess(t *testing.T) {
 }
 func Test_postWorkflowHandlerWithBadPayloadShouldFail(t *testing.T) {
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -645,8 +639,7 @@ func Test_postWorkflowHandlerWithBadPayloadShouldFail(t *testing.T) {
 
 func Test_putWorkflowHandler(t *testing.T) {
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -884,8 +877,7 @@ func Test_putWorkflowHandler(t *testing.T) {
 }
 
 func Test_deleteWorkflowEventIntegrationHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1017,8 +1009,7 @@ func Test_postWorkflowHandlerWithError(t *testing.T) {
 	// because default payload on non-root node should be illegal
 	// issue #4593
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1074,8 +1065,7 @@ func Test_postWorkflowHandlerWithError(t *testing.T) {
 
 func Test_postWorkflowRollbackHandler(t *testing.T) {
 
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1227,8 +1217,7 @@ func Test_postWorkflowRollbackHandler(t *testing.T) {
 }
 
 func Test_postAndDeleteWorkflowLabelHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init user
 	u, pass := assets.InsertAdminUser(t, api.mustDB())
@@ -1366,8 +1355,8 @@ func Test_postAndDeleteWorkflowLabelHandler(t *testing.T) {
 }
 
 func Test_deleteWorkflowHandler(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
+
 	test.NoError(t, workflow.CreateBuiltinWorkflowHookModels(db))
 
 	// Init user
@@ -1449,8 +1438,7 @@ loop:
 func TestBenchmarkGetWorkflowsWithoutAPIAsAdmin(t *testing.T) {
 	t.SkipNow()
 
-	db, cache, end := test.SetupPG(t)
-	defer end()
+	db, cache := test.SetupPG(t)
 
 	// Init project
 	key := sdk.RandomString(10)
@@ -1514,8 +1502,7 @@ func TestBenchmarkGetWorkflowsWithoutAPIAsAdmin(t *testing.T) {
 
 func TestBenchmarkGetWorkflowsWithAPI(t *testing.T) {
 	t.SkipNow()
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	// Init project
 	key := sdk.RandomString(10)
@@ -1596,8 +1583,7 @@ func TestBenchmarkGetWorkflowsWithAPI(t *testing.T) {
 }
 
 func Test_putWorkflowShouldNotCallHOOKSIfHookDoesNotChange(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 
@@ -1706,8 +1692,7 @@ func Test_putWorkflowShouldNotCallHOOKSIfHookDoesNotChange(t *testing.T) {
 }
 
 func Test_putWorkflowWithDuplicateHooksShouldRaiseAnError(t *testing.T) {
-	api, db, router, end := newTestAPI(t)
-	defer end()
+	api, db, router := newTestAPI(t)
 
 	_, _ = assets.InsertService(t, db, t.Name()+"_HOOKS", services.TypeHooks)
 
@@ -1828,8 +1813,7 @@ func Test_putWorkflowWithDuplicateHooksShouldRaiseAnError(t *testing.T) {
 }
 
 func Test_getWorkflowsHandler_FilterByRepo(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)
@@ -1910,8 +1894,7 @@ func Test_getWorkflowsHandler_FilterByRepo(t *testing.T) {
 }
 
 func Test_getSearchWorkflowHandler(t *testing.T) {
-	api, tsURL, tsClose := newTestServer(t)
-	defer tsClose()
+	api, tsURL := newTestServer(t)
 
 	admin, _ := assets.InsertAdminUser(t, api.mustDB())
 	localConsumer, err := authentication.LoadConsumerByTypeAndUserID(context.TODO(), api.mustDB(), sdk.ConsumerLocal, admin.ID, authentication.LoadConsumerOptions.WithAuthentifiedUser)

--- a/engine/api/workflowtemplate/dao_instance_test.go
+++ b/engine/api/workflowtemplate/dao_instance_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestCRUD_Instance(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	proj := assets.InsertTestProject(t, db, cache, sdk.RandomString(10), sdk.RandomString(10))
 	grp := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -46,8 +45,7 @@ func TestCRUD_Instance(t *testing.T) {
 }
 
 func TestLoad_Instance(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	proj1 := assets.InsertTestProject(t, db, cache, sdk.RandomString(10), sdk.RandomString(10))
 	proj2 := assets.InsertTestProject(t, db, cache, sdk.RandomString(10), sdk.RandomString(10))

--- a/engine/api/workflowtemplate/dao_test.go
+++ b/engine/api/workflowtemplate/dao_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestCRUD(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	grp2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
@@ -101,8 +100,7 @@ func TestCRUD(t *testing.T) {
 }
 
 func TestCRUD_Audit(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	defer assets.DeleteTestGroup(t, db, grp)

--- a/engine/api/workflowtemplate/instance_test.go
+++ b/engine/api/workflowtemplate/instance_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestCheckAndExecuteTemplate(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	proj := assets.InsertTestProject(t, db, cache, sdk.RandomString(10), sdk.RandomString(10))
 	grp := proj.ProjectGroups[0].Group
@@ -172,8 +171,7 @@ version: v2.0`)),
 }
 
 func TestUpdateTemplateInstanceWithWorkflow(t *testing.T) {
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	proj := assets.InsertTestProject(t, db, cache, sdk.RandomString(10), sdk.RandomString(10))
 	grp := proj.ProjectGroups[0].Group

--- a/engine/api/workflowtemplate/loader_test.go
+++ b/engine/api/workflowtemplate/loader_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestLoadGroup(t *testing.T) {
-	db, _, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	grp1 := assets.InsertTestGroup(t, db, sdk.RandomString(10))
 	grp2 := assets.InsertTestGroup(t, db, sdk.RandomString(10))

--- a/engine/cdn/cdn_log_test.go
+++ b/engine/cdn/cdn_log_test.go
@@ -3,13 +3,14 @@ package cdn
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/ovh/cds/engine/api/bootstrap"
 	"github.com/ovh/cds/engine/api/test"
 	"github.com/ovh/cds/engine/api/workflow"
 	"github.com/ovh/cds/sdk"
 	gocache "github.com/patrickmn/go-cache"
-	"testing"
-	"time"
 
 	"github.com/ovh/cds/sdk/jws"
 	"github.com/ovh/cds/sdk/log"
@@ -17,9 +18,7 @@ import (
 )
 
 func TestWorkerLog(t *testing.T) {
-	// Init DB
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	// Create worker private key
 	key, err := jws.NewRandomSymmetricKey(32)
@@ -61,7 +60,7 @@ func TestWorkerLog(t *testing.T) {
 	signatureField, err := jws.Sign(sign, signature)
 	require.NoError(t, err)
 
-	message := `{"level": 1, "version": "1", "short": "this", "_facility": "fa", "_file": "file", 
+	message := `{"level": 1, "version": "1", "short": "this", "_facility": "fa", "_file": "file",
 	"host": "host", "_line":1, "_pid": 1, "_prefix": "prefix", "full_message": "this is my message", "_Signature": "%s"}`
 	message = fmt.Sprintf(message, signatureField)
 
@@ -74,9 +73,7 @@ func TestWorkerLog(t *testing.T) {
 }
 
 func TestServiceLog(t *testing.T) {
-	// Init DB
-	db, cache, end := test.SetupPG(t, bootstrap.InitiliazeDB)
-	defer end()
+	db, cache := test.SetupPG(t, bootstrap.InitiliazeDB)
 
 	// Create hatchery private key
 	key, err := jws.NewRandomRSAKey()
@@ -120,7 +117,7 @@ func TestServiceLog(t *testing.T) {
 	signatureField, err := jws.Sign(sign, signature)
 	require.NoError(t, err)
 
-	message := `{"level": 1, "version": "1", "short": "this", "_facility": "fa", "_file": "file", 
+	message := `{"level": 1, "version": "1", "short": "this", "_facility": "fa", "_file": "file",
 	"host": "host", "_line":1, "_pid": 1, "_prefix": "prefix", "full_message": "this is my service message", "_Signature": "%s"}`
 	message = fmt.Sprintf(message, signatureField)
 


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
