### PR TITLE
fix(sdk): missing host path part on websocket request

### DIFF
--- a/sdk/cdsclient/http_websocket.go
+++ b/sdk/cdsclient/http_websocket.go
@@ -40,7 +40,7 @@ func (c *client) RequestWebsocket(ctx context.Context, path string, msgToSend <-
 	urlWebsocket := url.URL{
 		Scheme: strings.Replace(uHost.Scheme, "http", "ws", -1),
 		Host:   uHost.Host,
-		Path:   "/ws",
+		Path:   uHost.Path + "/ws",
 	}
 
 	headers := make(map[string][]string)


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
