### PR TITLE
docs(contrib): update worker models documentation URL

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -17,7 +17,7 @@ See [User Actions Documentation](https://ovh.github.io/cds/docs/actions)
 
 ## Worker Models
 
-See [Worker Models Documentation](https://ovh.github.io/cds/docs/concepts/requirement/worker-model/)
+See [Worker Models Documentation](https://ovh.github.io/cds/docs/concepts/worker-model/)
 
 ## Workflow Templates
 


### PR DESCRIPTION
1. Description
Browsing into the **contrib** section and found a broken URL.
 
1. Related issues
None.

1. About tests
No test required.

1. Mentions

@ovh/cds

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>