### PR TITLE
feat(venom plugin): add stop-on-failure parameter to venom plugin

### DIFF
--- a/contrib/grpcplugins/action/plugin-venom/main.go
+++ b/contrib/grpcplugins/action/plugin-venom/main.go
@@ -76,6 +76,15 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 		}, nil
 	}
 
+	stopOnFailure := false
+	if stopOnFailureStr != "" {
+		var errb error
+		stopOnFailure, errb = strconv.ParseBool(stopOnFailureStr)
+		if err != nil {
+			return actionplugin.Fail("Error parsing stopOnFailure value : %s\n", errb.Error())
+		}
+	}
+
 	v := venom.New()
 	v.RegisterExecutor(exec.Name, exec.New())
 	v.RegisterExecutor(http.Name, http.New())
@@ -154,17 +163,12 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 		}
 	}
 
-    stopOnFailure, err := strconv.ParseBool(stopOnFailureStr)
-    if err != nil {
-        return actionplugin.Fail("Error parsing stopOnFailure value : %s\n", err.Error())
-    }
-
 	v.AddVariables(data)
 	v.LogLevel = loglevel
 	v.OutputFormat = "xml"
 	v.OutputDir = output
 	v.Parallel = parallel
-    v.StopOnFailure = stopOnFailure
+	v.StopOnFailure = stopOnFailure
 
 	filepathVal := strings.Split(path, ",")
 	filepathExcluded := strings.Split(exclude, ",")

--- a/contrib/grpcplugins/action/plugin-venom/main.go
+++ b/contrib/grpcplugins/action/plugin-venom/main.go
@@ -62,6 +62,7 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 	loglevel := q.GetOptions()["loglevel"]
 	vars := q.GetOptions()["vars"]
 	varsFromFile := q.GetOptions()["vars-from-file"]
+	stopOnFailureStr := q.GetOptions()["stop-on-failure"]
 
 	if path == "" {
 		path = "."
@@ -153,11 +154,17 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 		}
 	}
 
+    stopOnFailure, err := strconv.ParseBool(stopOnFailureStr)
+    if err != nil {
+        return actionplugin.Fail("Error parsing stopOnFailure value : %s\n", err.Error())
+    }
+
 	v.AddVariables(data)
 	v.LogLevel = loglevel
 	v.OutputFormat = "xml"
 	v.OutputDir = output
 	v.Parallel = parallel
+    v.StopOnFailure = stopOnFailure
 
 	filepathVal := strings.Split(path, ",")
 	filepathExcluded := strings.Split(exclude, ",")
@@ -190,6 +197,7 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 
 	fmt.Printf("VENOM - filepath: %v\n", filepathValComputed)
 	fmt.Printf("VENOM - excluded: %v\n", filepathExcludedComputed)
+	fmt.Printf("VENOM - stop on failure: %t\n", stopOnFailure)
 	tests, err := v.Process(filepathValComputed, filepathExcludedComputed)
 	if err != nil {
 		return actionplugin.Fail("VENOM - Fail on venom: %v\n", err)

--- a/contrib/grpcplugins/action/plugin-venom/main.go
+++ b/contrib/grpcplugins/action/plugin-venom/main.go
@@ -78,10 +78,9 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 
 	stopOnFailure := false
 	if stopOnFailureStr != "" {
-		var errb error
-		stopOnFailure, errb = strconv.ParseBool(stopOnFailureStr)
+		stopOnFailure, err = strconv.ParseBool(stopOnFailureStr)
 		if err != nil {
-			return actionplugin.Fail("Error parsing stopOnFailure value : %s\n", errb.Error())
+			return actionplugin.Fail("Error parsing stopOnFailure value : %v\n", err)
 		}
 	}
 

--- a/contrib/grpcplugins/action/plugin-venom/plugin-venom.yml
+++ b/contrib/grpcplugins/action/plugin-venom/plugin-venom.yml
@@ -31,3 +31,7 @@ parameters:
   vars-from-file:
     type: string
     description: 'filename.yaml or filename.json. See https://github.com/ovh/venom#run-venom-with-file-var'
+  stop-on-failure:
+    type: boolean
+    description: 'Stop running Test Suite on first Test Case failure'
+    default: 'true'


### PR DESCRIPTION
1. Description
stop-on-failure venom option was not available in venom plugin parameters

1. Related issues
None

1. About tests
Have tested parameter behavior is OK on my CDS instance

1. Mentions

@ovh/cds
Signed-off-by: Francois Lesage francois.lesage@gmail.com