### PR TITLE
fix: there is no api directory in the documentation's sql directory

### DIFF
--- a/docs/content/hosting/ready-to-run/from-binaries.md
+++ b/docs/content/hosting/ready-to-run/from-binaries.md
@@ -86,7 +86,7 @@ docker run --name cds-db -e POSTGRES_PASSWORD=cds -e POSTGRES_USER=cds -e POSTGR
 ```bash
 cd $HOME/cds
 ./cds-engine download sql --config conf.toml
-./cds-engine database upgrade --db-host localhost --db-user cds --db-password cds --db-name cds --db-sslmode disable --db-port 5432 --migrate-dir sql/api
+./cds-engine database upgrade --db-host localhost --db-user cds --db-password cds --db-name cds --db-sslmode disable --db-port 5432 --migrate-dir sql
 ```
 
 ## Launch CDS API


### PR DESCRIPTION
    Signed-off-by: Gregoire Salingue <gregoire.salingue@gmail.com>

1. Description
https://github.com/ovh/cds/issues/5342#issue-665829367
1. Related issues
https://github.com/ovh/cds/issues/5342#issue-665829367
1. About tests
1. Mentions

@ovh/cds
