### PR TITLE
fix(api): send node run event on filter workflow run

### DIFF
--- a/engine/api/websocket.go
+++ b/engine/api/websocket.go
@@ -382,6 +382,14 @@ func (b *websocketBroker) computeEventKeys(event sdk.Event) []string {
 			WorkflowRunNumber: event.WorkflowRunNum,
 		}.Key())
 	}
+	if event.EventType == fmt.Sprintf("%T", sdk.EventRunWorkflowNode{}) {
+		keys = append(keys, sdk.WebsocketFilter{
+			Type:              sdk.WebsocketFilterTypeWorkflowRun,
+			ProjectKey:        event.ProjectKey,
+			WorkflowName:      event.WorkflowName,
+			WorkflowRunNumber: event.WorkflowRunNum,
+		}.Key())
+	}
 	// Event that match workflow node run filter
 	if event.EventType == fmt.Sprintf("%T", sdk.EventRunWorkflowNode{}) {
 		keys = append(keys, sdk.WebsocketFilter{


### PR DESCRIPTION
1. Description
When looking at a workflow run, we need node run event to be able to refresh pipeline status on UI
1. Related issues
1. About tests
1. Mentions

@ovh/cds
