### PR TITLE
fix(cdsctl):  verbose and insecure config from env or flags

### DIFF
--- a/cli/cdsctl/config.go
+++ b/cli/cdsctl/config.go
@@ -133,8 +133,9 @@ func recreateSessionToken(configFile string, cdsctx internal.CDSContext, context
 		"token": cdsctx.Token,
 	}
 	client := cdsclient.New(cdsclient.Config{
-		Host:    cdsctx.Host,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  cdsctx.Host,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || cdsctx.Verbose,
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || cdsctx.InsecureSkipVerifyTLS,
 	})
 	res, err := client.AuthConsumerSignin(sdk.ConsumerBuiltin, req)
 	if err != nil {

--- a/cli/cdsctl/login.go
+++ b/cli/cdsctl/login.go
@@ -75,8 +75,9 @@ func loginRun(v cli.Values) error {
 
 	// Load all drivers from given CDS instance
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 	drivers, err := client.AuthDriverList()
 	if err != nil {
@@ -194,8 +195,9 @@ func loginRunBuiltin(v cli.Values) (sdk.AuthConsumerSigninRequest, error) {
 
 func loginRunExternal(v cli.Values, consumerType sdk.AuthConsumerType, apiURL string) error {
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: v.GetBool("verbose"),
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 	config, err := client.ConfigUser()
 	if err != nil {
@@ -234,7 +236,7 @@ func doAfterLogin(client cdsclient.Interface, v cli.Values, apiURL string, drive
 		sessionToken = res.Token
 	} else {
 		var err error
-		signinToken, sessionToken, err = createOrRegenConsumer(apiURL, res.User.Username, res.Token)
+		signinToken, sessionToken, err = createOrRegenConsumer(apiURL, res.User.Username, res.Token, v)
 		if err != nil {
 			return err
 		}
@@ -331,16 +333,17 @@ func doAfterLogin(client cdsclient.Interface, v cli.Values, apiURL string, drive
 }
 
 // return signin-token, session-token
-func createOrRegenConsumer(apiURL, username, sessionToken string) (string, string, error) {
+func createOrRegenConsumer(apiURL, username, sessionToken string, v cli.Values) (string, string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", "", fmt.Errorf("cdsctl: cannot retrieve hostname: %s", err)
 	}
 
 	client := cdsclient.New(cdsclient.Config{
-		Host:         apiURL,
-		Verbose:      os.Getenv("CDS_VERBOSE") == "true",
-		SessionToken: sessionToken,
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
+		SessionToken:          sessionToken,
 	})
 
 	consumers, err := client.AuthConsumerListByUser(username)
@@ -442,8 +445,9 @@ func loginVerifyFunc(v cli.Values) error {
 
 	// Load all drivers from given CDS instance
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 	drivers, err := client.AuthDriverList()
 	if err != nil {

--- a/cli/cdsctl/reset.go
+++ b/cli/cdsctl/reset.go
@@ -39,8 +39,9 @@ func resetFunc(v cli.Values) error {
 
 	// Load all drivers from given CDS instance
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 	drivers, err := client.AuthDriverList()
 	if err != nil {
@@ -121,8 +122,9 @@ func resetConfirmFunc(v cli.Values) error {
 	}
 
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 
 	password := v.GetString("password")

--- a/cli/cdsctl/signup.go
+++ b/cli/cdsctl/signup.go
@@ -74,8 +74,9 @@ func signupFunc(v cli.Values) error {
 
 	// Load all drivers from given CDS instance
 	client := cdsclient.New(cdsclient.Config{
-		Host:    apiURL,
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
+		Host:                  apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
 	})
 	drivers, err := client.AuthDriverList()
 	if err != nil {
@@ -154,8 +155,9 @@ func signupVerifyFunc(v cli.Values) error {
 	}
 
 	client := cdsclient.New(cdsclient.Config{
-		Verbose: os.Getenv("CDS_VERBOSE") == "true",
-		Host:    apiURL,
+		Verbose:               os.Getenv("CDS_VERBOSE") == "true" || v.GetBool("verbose"),
+		InsecureSkipVerifyTLS: os.Getenv("CDS_INSECURE") == "true" || v.GetBool("insecure"),
+		Host:                  apiURL,
 	})
 
 	signupresponse, err := client.AuthConsumerLocalSignupVerify(v.GetString("token"),


### PR DESCRIPTION
Fixing cdsctl `--verbose` and `--insecure` flags not working all the time, especially during a login command

1. Description
`cdsctl --verbose --insecure login --api-url https://.....` fails when api endpoint uses TLS with an untrusted certificate. Insecure flag is not working as expected.  While fixing the use of `--insecure` flag for the login command, I also fixed it in other places, and fixed the `--verbose` flag which was not properly handled neither.

2. About tests
cdsctl commands now works on an api endpoint using a self signed certificate

3. Mentions

@ovh/cds

Signed-off-by: Pierre-Henri Symoneaux <pierre-henri.symoneaux@nokia.com>