### PR TITLE
fix(api): wrapping a multi error should not reset 'from' infos

### DIFF
--- a/sdk/error.go
+++ b/sdk/error.go
@@ -808,10 +808,20 @@ func WrapError(err error, format string, args ...interface{}) error {
 		}
 	}
 
+	httpError := ErrUnknownError
+
+	if e, ok := err.(*MultiError); ok {
+		var ss []string
+		for i := range *e {
+			ss = append(ss, ExtractHTTPError((*e)[i], "").printLight())
+		}
+		httpError.From = strings.Join(ss, ", ")
+	}
+
 	return errorWithStack{
 		root:      errors.Wrap(err, m),
 		stack:     callers(),
-		httpError: ErrUnknownError,
+		httpError: httpError,
 	}
 }
 

--- a/sdk/error_test.go
+++ b/sdk/error_test.go
@@ -162,6 +162,11 @@ func TestMultiError(t *testing.T) {
 	assert.Equal(t, "TestMultiError: internal server error (from: internal server error, wrong request: my second error, internal server error, already exists: my fourth error) (caused by: TestMultiError: internal server error (caused by: my first error), TestMultiError: wrong request (from: my second error), TestMultiError: internal server error (caused by: hidden info: my third error), TestMultiError: already exists (from: my fourth error))", stackErr.Error())
 	httpErr = ExtractHTTPError(stackErr, "fr")
 	assert.Equal(t, "erreur interne (from: internal server error, wrong request: my second error, internal server error, already exists: my fourth error)", httpErr.Error())
+
+	stackErr = WrapError(mError, "more info")
+	assert.Equal(t, "TestMultiError: internal server error (from: internal server error, wrong request: my second error, internal server error, already exists: my fourth error) (caused by: more info: TestMultiError: internal server error (caused by: my first error), TestMultiError: wrong request (from: my second error), TestMultiError: internal server error (caused by: hidden info: my third error), TestMultiError: already exists (from: my fourth error))", stackErr.Error())
+	httpErr = ExtractHTTPError(stackErr, "fr")
+	assert.Equal(t, "erreur interne (from: internal server error, wrong request: my second error, internal server error, already exists: my fourth error)", httpErr.Error())
 }
 
 func Test_cause(t *testing.T) {


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
