### PR TITLE
Fix "cdsctl verify" cmd: Do not use advertised API URL

### DIFF
--- a/cli/cdsctl/signup.go
+++ b/cli/cdsctl/signup.go
@@ -166,5 +166,8 @@ func signupVerifyFunc(v cli.Values) error {
 		return err
 	}
 
-	return doAfterLogin(client, v, signupresponse.APIURL, sdk.ConsumerLocal, signupresponse)
+	if apiURL != signupresponse.APIURL {
+		fmt.Println("WARNING: The advertised API URL differs from the provided URL")
+	}
+	return doAfterLogin(client, v, apiURL, sdk.ConsumerLocal, signupresponse)
 }


### PR DESCRIPTION
1. Description
cdsctl verify now uses the api url provided in arguments instead of url advertised by CDS verify response. It will display a warning when provided and advertised URLs differ from each other.
This is useful when cdsctl verify is used where the advertised user facing URL is not reachable.
It also makes verify command consistent with login command behavior

1. Related issues
1. About tests
1. Mentions

@ovh/cds

Signed-off-by: phsym <pierre-henri.symoneaux@nokia.com>
