### PR TITLE
feat(api): basic support for openid-connect authentication provider

### DIFF
--- a/docs/content/docs/integrations/openid-connect.md
+++ b/docs/content/docs/integrations/openid-connect.md
@@ -1,0 +1,37 @@
+---
+title: OpenID-Connect Authentication
+main_menu: true
+card: 
+  name: authentication
+---
+
+The OpenID-Connect Integration have to be configured on your CDS by a CDS Administrator.
+
+This integration allows you to delegate users authetication to an OpenID-Connect third party like [Keycloak](https://www.keycloak.org/getting-started) or [Hydra](https://github.com/ory/hydra)
+
+## How to configure OpenID-Connect Authentication integration
+
+Edit the toml file:
+
+- section `[api.auth.oidc]`
+  - enable the signin with `enabled = true`
+  - if you want to disable signup, set `signupDisabled = true`
+
+```toml
+[api.auth.oidc]
+      clientId = "YOUR CLIENT ID"
+      clientSecret = "YOUR CLIENT SECRET"
+      enabled = true
+      signupDisabled = false
+      url = "http[s]://<OIDC HOST>:<PORT>/auth/realms/<YOUR REALM>"
+```
+
+For example :
+```toml
+[api.auth.oidc]
+      clientId = "cds_client"
+      clientSecret = "6ebf3c3f-6f0b-4326-bebd-05fd472a90ec"
+      enabled = true
+      signupDisabled = false
+      url = "http://openid-connect.myorg.com:8080/auth/realms/cds"
+```

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -143,8 +143,8 @@ type Configuration struct {
 			URL            string `toml:"url" json:"url" default:"" comment:"Open ID connect config URL"`
 			ClientID       string `toml:"clientId" json:"-" comment:"OIDC Client ID"`
 			ClientSecret   string `toml:"clientSecret" json:"-" comment:"OIDC Client Secret"`
-		} `toml:"oidc" json:"oidc" comment:"#######\n CDS <-> Open ID Connect Auth \n######"`
-	} `toml:"auth" comment:"##############################\n CDS Authentication Settings. Documentation on https://ovh.github.io/cds/docs/integrations/openid-connect/ \n#############################" json:"auth"`
+		} `toml:"oidc" json:"oidc" comment:"#######\n CDS <-> Open ID Connect Auth. Documentation on https://ovh.github.io/cds/docs/integrations/openid-connect/ \n######"`
+	} `toml:"auth" comment:"##############################\n CDS Authentication Settings# \n#############################" json:"auth"`
 	SMTP struct {
 		Disable  bool   `toml:"disable" default:"true" json:"disable" comment:"Set to false to enable the internal SMTP client"`
 		Host     string `toml:"host" json:"host" comment:"smtp host"`

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ovh/cds/engine/api/authentication/gitlab"
 	"github.com/ovh/cds/engine/api/authentication/ldap"
 	"github.com/ovh/cds/engine/api/authentication/local"
+	"github.com/ovh/cds/engine/api/authentication/oidc"
 	"github.com/ovh/cds/engine/api/bootstrap"
 	"github.com/ovh/cds/engine/api/broadcast"
 	"github.com/ovh/cds/engine/api/database/gorpmapping"
@@ -136,7 +137,14 @@ type Configuration struct {
 			ApplicationID  string `toml:"applicationID" json:"-" comment:"GitLab OAuth Application ID"`
 			Secret         string `toml:"secret" json:"-" comment:"GitLab OAuth Application Secret"`
 		} `toml:"gitlab" json:"gitlab" comment:"#######\n CDS <-> GitLab Auth. Documentation on https://ovh.github.io/cds/docs/integrations/gitlab/gitlab_authentication/ \n######"`
-	} `toml:"auth" comment:"##############################\n CDS Authentication Settings#\n#############################" json:"auth"`
+		OIDC struct {
+			Enabled        bool   `toml:"enabled" default:"false" json:"enabled"`
+			SignupDisabled bool   `toml:"signupDisabled" default:"false" json:"signupDisabled"`
+			URL            string `toml:"url" json:"url" default:"" comment:"Open ID connect config URL"`
+			ClientID       string `toml:"clientId" json:"-" comment:"OIDC Client ID"`
+			ClientSecret   string `toml:"clientSecret" json:"-" comment:"OIDC Client Secret"`
+		} `toml:"oidc" json:"oidc" comment:"#######\n CDS <-> Open ID Connect Auth \n######"`
+	} `toml:"auth" comment:"##############################\n CDS Authentication Settings. Documentation on https://ovh.github.io/cds/docs/integrations/openid-connect/ \n#############################" json:"auth"`
 	SMTP struct {
 		Disable  bool   `toml:"disable" default:"true" json:"disable" comment:"Set to false to enable the internal SMTP client"`
 		Host     string `toml:"host" json:"host" comment:"smtp host"`
@@ -581,6 +589,18 @@ func (a *API) Serve(ctx context.Context) error {
 			a.Config.Auth.Gitlab.ApplicationID,
 			a.Config.Auth.Gitlab.Secret,
 		)
+	}
+	if a.Config.Auth.OIDC.Enabled {
+		a.AuthenticationDrivers[sdk.ConsumerOIDC], err = oidc.NewDriver(
+			a.Config.Auth.OIDC.SignupDisabled,
+			a.Config.URL.UI,
+			a.Config.Auth.OIDC.URL,
+			a.Config.Auth.OIDC.ClientID,
+			a.Config.Auth.OIDC.ClientSecret,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	if a.Config.Auth.CorporateSSO.Enabled {

--- a/engine/api/authentication/oidc/openid.go
+++ b/engine/api/authentication/oidc/openid.go
@@ -21,7 +21,7 @@ var _ sdk.AuthDriverWithSigninStateToken = (*authDriver)(nil)
 func NewDriver(signupDisabled bool, cdsURL, url, clientID, clientSecret string) (sdk.AuthDriver, error) {
 	provider, err := oidc.NewProvider(context.Background(), url)
 	if err != nil {
-		return nil, sdk.WrapError(err, "Failed to initialize OIDC driver")
+		return nil, sdk.WrapError(err, "failed to initialize OIDC driver")
 	}
 	// Configure an OpenID Connect aware OAuth2 client.
 	oauth2Config := oauth2.Config{
@@ -103,7 +103,7 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 	ctx2 := context.WithValue(context.Background(), oauth2.HTTPClient, http.DefaultClient)
 	oauth2Token, err := d.OAuth2Config.Exchange(ctx2, req["code"])
 	if err != nil {
-		return info, sdk.WrapError(err, "Failed to exchange token")
+		return info, sdk.WrapError(err, "failed to exchange token")
 	}
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
@@ -111,11 +111,11 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 	}
 	idToken, err := d.Verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return info, sdk.WrapError(err, "Failed to verify ID Token")
+		return info, sdk.WrapError(err, "failed to verify ID Token")
 	}
 	tokenClaim := make(map[string]interface{})
 	if err := idToken.Claims(&tokenClaim); err != nil {
-		return info, sdk.WrapError(err, "Cannot unmarshal OIDC claim")
+		return info, sdk.WrapError(err, "cannot unmarshal OIDC claim")
 	}
 
 	// Check if email is verified.
@@ -128,12 +128,12 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 	}
 
 	if info.Username, ok = tokenClaim["preferred_username"].(string); !ok {
-		return info, sdk.WithStack(errors.New("Missing username in OIDC token claim"))
+		return info, sdk.WithStack(errors.New("missing username in OIDC token claim"))
 	}
 
 	info.Fullname, _ = tokenClaim["name"].(string)
 	if info.Email, ok = tokenClaim["email"].(string); !ok {
-		return info, sdk.WithStack(errors.New("Missing user's email in OIDC token claim"))
+		return info, sdk.WithStack(errors.New("missing user's email in OIDC token claim"))
 	}
 
 	return info, nil

--- a/engine/api/authentication/oidc/openid.go
+++ b/engine/api/authentication/oidc/openid.go
@@ -1,0 +1,134 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ovh/cds/engine/api/authentication"
+
+	oidc "github.com/coreos/go-oidc"
+	"github.com/ovh/cds/sdk"
+	"golang.org/x/oauth2"
+)
+
+var _ sdk.AuthDriverWithRedirect = (*authDriver)(nil)
+var _ sdk.AuthDriverWithSigninStateToken = (*authDriver)(nil)
+
+// NewDriver returns a new OIDC auth driver for given config.
+func NewDriver(signupDisabled bool, cdsURL, url, clientID, clientSecret string) (sdk.AuthDriver, error) {
+	provider, err := oidc.NewProvider(context.Background(), url)
+	if err != nil {
+		return nil, sdk.WrapError(err, "Failed to initialize OIDC driver")
+	}
+	// Configure an OpenID Connect aware OAuth2 client.
+	oauth2Config := oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  fmt.Sprintf("%s/auth/callback/%s", cdsURL, sdk.ConsumerOIDC),
+		// Discovery returns the OAuth2 endpoints.
+		Endpoint: provider.Endpoint(),
+		// "openid" is a required scope for OpenID Connect flows.
+		Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+	}
+	oidcConfig := &oidc.Config{
+		ClientID: clientID,
+	}
+	verifier := provider.Verifier(oidcConfig)
+
+	return &authDriver{
+		signupDisabled: signupDisabled,
+		cdsURL:         cdsURL,
+		OAuth2Config:   oauth2Config,
+		Verifier:       verifier,
+	}, nil
+}
+
+type authDriver struct {
+	signupDisabled bool
+	cdsURL         string
+	OAuth2Config   oauth2.Config
+	Verifier       *oidc.IDTokenVerifier
+}
+
+func (d authDriver) GetManifest() sdk.AuthDriverManifest {
+	return sdk.AuthDriverManifest{
+		Type:           sdk.ConsumerOIDC,
+		SignupDisabled: d.signupDisabled,
+	}
+}
+
+func (d authDriver) GetSigninURI(signinState sdk.AuthSigninConsumerToken) (sdk.AuthDriverSigningRedirect, error) {
+	// Generate a new state value for the auth signin request
+	jws, err := authentication.NewDefaultSigninStateToken(signinState.Origin,
+		signinState.RedirectURI, signinState.IsFirstConnection)
+	if err != nil {
+		return sdk.AuthDriverSigningRedirect{}, err
+	}
+
+	var result = sdk.AuthDriverSigningRedirect{
+		Method: http.MethodGet,
+		URL:    d.OAuth2Config.AuthCodeURL(jws),
+	}
+
+	return result, nil
+}
+
+func (d authDriver) GetSessionDuration() time.Duration {
+	return time.Hour * 24 * 30 // 1 month session
+}
+
+func (d authDriver) CheckSigninRequest(req sdk.AuthConsumerSigninRequest) error {
+	if code, ok := req["code"]; !ok || code == "" {
+		return sdk.NewErrorFrom(sdk.ErrWrongRequest, "missing or invalid code")
+	}
+	return nil
+}
+
+func (d authDriver) CheckSigninStateToken(req sdk.AuthConsumerSigninRequest) error {
+	// Check if state is given and if its valid
+	state, okState := req["state"]
+	if !okState {
+		return sdk.NewErrorFrom(sdk.ErrWrongRequest, "missing state value")
+	}
+
+	return authentication.CheckDefaultSigninStateToken(state)
+}
+
+func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninRequest) (sdk.AuthDriverUserInfo, error) {
+	var info sdk.AuthDriverUserInfo
+
+	ctx2 := context.WithValue(context.Background(), oauth2.HTTPClient, http.DefaultClient)
+	oauth2Token, err := d.OAuth2Config.Exchange(ctx2, req["code"])
+	if err != nil {
+		return info, sdk.WrapError(err, "Failed to exchange token")
+	}
+	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return info, sdk.WrapError(err, "No id_token field in oauth2 token")
+	}
+	idToken, err := d.Verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return info, sdk.WrapError(err, "Failed to verify ID Token")
+	}
+	tokenClaim := make(map[string]interface{})
+	if err := idToken.Claims(&tokenClaim); err != nil {
+		return info, sdk.WrapError(err, "Cannot unmarshal OIDC claim")
+	}
+
+	if info.ExternalID, ok = tokenClaim["sub"].(string); !ok {
+		return info, sdk.WrapError(sdk.ErrInvalidUser, "Missing OIDC user ID in token claim")
+	}
+
+	if info.Username, ok = tokenClaim["preferred_username"].(string); !ok {
+		return info, sdk.WrapError(sdk.ErrInvalidUser, "Missing username in OIDC token claim")
+	}
+
+	info.Fullname, _ = tokenClaim["name"].(string)
+	if info.Email, ok = tokenClaim["email"].(string); !ok {
+		return info, sdk.WrapError(sdk.ErrInvalidUser, "Missing user's email in OIDC token claim")
+	}
+
+	return info, nil
+}

--- a/engine/api/authentication/oidc/openid.go
+++ b/engine/api/authentication/oidc/openid.go
@@ -117,6 +117,11 @@ func (d authDriver) GetUserInfo(ctx context.Context, req sdk.AuthConsumerSigninR
 		return info, sdk.WrapError(err, "Cannot unmarshal OIDC claim")
 	}
 
+	// Check if email is verified.
+	// See standard claims at https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+	if verified, ok := tokenClaim["email_verified"].(bool); !ok || !verified {
+		return info, sdk.WrapError(sdk.ErrInvalidUser, "OIDC user's email not verified")
+	}
 	if info.ExternalID, ok = tokenClaim["sub"].(string); !ok {
 		return info, sdk.WrapError(sdk.ErrInvalidUser, "Missing OIDC user ID in token claim")
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/distribution v2.7.0-rc.0+incompatible // indirect
 	github.com/docker/docker v1.13.1
@@ -106,6 +107,7 @@ require (
 	github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
 	github.com/pkg/errors v0.8.1
 	github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 // indirect
+	github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f // indirect
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
+github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
@@ -397,6 +399,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
+github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f h1:JDEmUDtyiLMyMlFwiaDOv2hxUp35497fkwePcLeV7j4=
+github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f/go.mod h1:hoLfEwdY11HjRfKFH6KqnPsfxlo3BP6bJehpDv8t6sQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/sdk/token.go
+++ b/sdk/token.go
@@ -274,6 +274,7 @@ const (
 	ConsumerCorporateSSO AuthConsumerType = "corporate-sso"
 	ConsumerGithub       AuthConsumerType = "github"
 	ConsumerGitlab       AuthConsumerType = "gitlab"
+	ConsumerOIDC         AuthConsumerType = "openid-connect"
 	ConsumerTest         AuthConsumerType = "futurama"
 	ConsumerTest2        AuthConsumerType = "planet-express"
 )
@@ -290,7 +291,7 @@ func (t AuthConsumerType) IsValid() bool {
 // IsValidExternal returns validity of given auth consumer type.
 func (t AuthConsumerType) IsValidExternal() bool {
 	switch t {
-	case ConsumerLDAP, ConsumerCorporateSSO, ConsumerGithub, ConsumerGitlab, ConsumerTest, ConsumerTest2:
+	case ConsumerLDAP, ConsumerCorporateSSO, ConsumerGithub, ConsumerGitlab, ConsumerOIDC, ConsumerTest, ConsumerTest2:
 		return true
 	}
 	return false

--- a/ui/src/app/views/auth/signin/signin.ts
+++ b/ui/src/app/views/auth/signin/signin.ts
@@ -56,7 +56,20 @@ export class SigninComponent implements OnInit {
                     .filter(d => d.type !== 'local' && d.type !== 'ldap' && d.type !== 'builtin')
                     .sort((a, b) => a.type < b.type ? -1 : 1)
                     .map(d => {
-                        d.icon = d.type === 'corporate-sso' ? 'shield alternate' : d.type;
+                        switch (d.type) {
+                            case 'corporate-sso': {
+                                d.icon = 'shield alternate';
+                                break;
+                            }
+                            case 'openid-connect': {
+                                d.icon = 'openid';
+                                break;
+                            }
+                            default: {
+                                d.icon = d.type;
+                                break;
+                            }
+                        }
                         return d;
                     });
 

--- a/ui/src/app/views/settings/user/edit/user.edit.component.ts
+++ b/ui/src/app/views/settings/user/edit/user.edit.component.ts
@@ -263,6 +263,9 @@ export class UserEditComponent implements OnInit {
                             case 'corporate-sso':
                                 icon['class'] = ['shield', 'alternate', 'icon'];
                                 break;
+                            case 'openid-connect':
+                                icon['class'] = ['openid', 'icon'];
+                                break;
                             default:
                                 icon['class'] = [consumer.type, 'icon'];
                                 break;

--- a/ui/src/app/views/settings/user/edit/user.edit.html
+++ b/ui/src/app/views/settings/user/edit/user.edit.html
@@ -115,6 +115,14 @@
                                             Corporate SSO
                                         </div>
                                     </ng-container>
+                                    <ng-container *ngSwitchCase="'openid-connect'">
+                                        <div class="center aligned header">
+                                            <i class="ui openid icon huge"></i>
+                                        </div>
+                                        <div class="center aligned description">
+                                            OpenID Connect
+                                        </div>
+                                    </ng-container>
                                     <ng-container *ngSwitchDefault>
                                         <div class="center aligned header">
                                             <i class="ui {{d.type}} icon huge"></i>


### PR DESCRIPTION
1. Description
This enables basic integration with openid-connect authentication providers like Keycloak or Hydra

2. About tests
Not sure yet how to automate the tests here, but for manual testing :
* Setup Keycloak ([more here](https://www.keycloak.org/getting-started/getting-started-docker))
  * Start a keycloak server in Docker with `docker run -p 4040:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:11.0.1`
  > Map internal port 8080 to 4040 to avoid conflict with CDS UI, in case you run everything locally
  * Login to keycoak web UI as admin
  * Create a realm named "cds"
  * Create a user in this realm, add a password to it
  * Create an openid-connect client named "cds_client", set the CDS urls, and change it from public to confidential. Save, and copy the client secrets
  * Edit cds API config to add open id settings as following
  ```toml
  [api.auth.oidc]
        clientId = "cds_client"
        clientSecret = "<CDS CLIENT SECRET>"
        enabled = true
        signupDisabled = false
        url = "http://<KEYCLOAK ADDRESS>:4040/auth/realms/cds"
  ```
  > `<KEYCLOAK ADDRESS>` can be localhost if you run everything locally
  * Login on CDS UI using the openid-connect button. You'll e redirected to keycloak login screen. After succesfull login, you'll be redirected to CDS screen.

3. Mentions

@ovh/cds

Signed-off-by: phsym <pierre-henri.symoneaux@nokia.com>