### PR TITLE
feat(hatchery/kubernetes): make default ImagePullPolicy configurable

### DIFF
--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -348,11 +348,12 @@ func (h *HatcheryKubernetes) SpawnWorker(ctx context.Context, spawnArgs hatchery
 			TerminationGracePeriodSeconds: &gracePeriodSecs,
 			Containers: []apiv1.Container{
 				{
-					Name:    spawnArgs.WorkerName,
-					Image:   spawnArgs.Model.ModelDocker.Image,
-					Env:     envs,
-					Command: strings.Fields(spawnArgs.Model.ModelDocker.Shell),
-					Args:    []string{cmd},
+					Name:            spawnArgs.WorkerName,
+					Image:           spawnArgs.Model.ModelDocker.Image,
+					ImagePullPolicy: apiv1.PullPolicy(h.Config.DefaultPullPolicy),
+					Env:             envs,
+					Command:         strings.Fields(spawnArgs.Model.ModelDocker.Shell),
+					Args:            []string{cmd},
 					Resources: apiv1.ResourceRequirements{
 						Requests: apiv1.ResourceList{
 							apiv1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", memory)),

--- a/engine/hatchery/kubernetes/types.go
+++ b/engine/hatchery/kubernetes/types.go
@@ -48,6 +48,8 @@ type HatcheryConfiguration struct {
 	KubernetesClientCertData string `mapstructure:"clientCertData" toml:"clientCertData" default:"" commented:"true" comment:"Client certificate data (content, not path and not base64 encoded) for tls kubernetes (optional if no tls needed)" json:"-"`
 	// KubernetesKeyData Client certificate data for tls kubernetes (optional if no tls needed)
 	KubernetesClientKeyData string `mapstructure:"clientKeyData" toml:"clientKeyData" default:"" commented:"true" comment:"Client certificate data (content, not path and not base64 encoded) for tls kubernetes (optional if no tls needed)" json:"-"`
+	// DefaultPullPolicy describes the policy for if/when to pull a container image
+	DefaultPullPolicy string `mapstructure:"defaultPullPolicy" toml:"defaultPullPolicy" default:"Always" commented:"true" comment:"Describes the policy for if/when to pull a container image (Always, Never, IfNotPresent)" json:"defaultPullPolicy"`
 }
 
 // HatcheryKubernetes implements HatcheryMode interface for local usage


### PR DESCRIPTION
1. Description
This modifies `hatchery:kubernetes` configuration to add a `defaultPullPolicy` configuration field for hatchery config.
If defined, it sets `ImagePullPolicy` field in worker pod specs, which by default is set to `Always` by Kubernetes.
The config field is named `defaultPullPolicy` in case the pull policy become customizable per worker-model in a future release.
When no value is given, it's defaulted to `Always` in order to fallback to the current behaviour.

* `ImagePullPolicy = Never` is needed mainly for developing and testing worker images, for example in a dev environment like minikube, kind, kubernetes for windows, or more generally when uploading to a registry is undesirable.
* `ImagePullPolicy = IfNotPresent` could be usefull to not block a pipeline execution if the registry is down while the image is already present on the node.

2. About tests
When a worker pod is started (or during registration), run a `kubectl describe pod <worker pod name> -o yaml` and verify the `imagePullPolicy` value on the pod's container spec

3. Mentions

@ovh/cds

Signed-off-by: phsym <pierre-henri.symoneaux@nokia.com>