### PR TITLE
Documents the configuration as code attribute for mutex

### DIFF
--- a/docs/content/development/contribute/documentation.md
+++ b/docs/content/development/contribute/documentation.md
@@ -21,4 +21,4 @@ GEN_PATH=${CDS_SOURCES}/docs/content/docs/components make doc
 cd ${CDS_SOURCES}/docs
 hugo server
 ```
-* go to http://localhost:1313/cds/
+* go to http://localhost:1313/

--- a/docs/content/docs/concepts/files/workflow-syntax.md
+++ b/docs/content/docs/concepts/files/workflow-syntax.md
@@ -23,6 +23,7 @@ workflow:
     pipeline: deploy
     application: my-application
     environment: my-production
+    one_at_a_time: true
 hooks:
   build:
   - type: RepositoryWebHook
@@ -125,4 +126,20 @@ Example of vcs notification. Note that `pipelines` list is optional on every not
         [[- end]]
       disable_comment: false
       disable_status: false
+```
+
+## Mutex
+
+[Mutex documentation]({{<relref "/docs/concepts/workflow/mutex.md">}})
+
+Example of a pipeline limited to one execution at a time: deployments to production cannot be executed concurently.
+
+```yml
+name: my-workflow
+workflow:
+  # ...
+  deploy:
+    pipeline: deploy
+    # ...
+    one_at_a_time: true # No concurent deployments
 ```

--- a/docs/content/docs/concepts/workflow/mutex.md
+++ b/docs/content/docs/concepts/workflow/mutex.md
@@ -12,3 +12,7 @@ Click on the pipeline  → Edit the pipeline context → enable  "Limit one run 
 ![Pipeline Mutex](/images/workflows.design.mutex.png)
 
 Examplary use case: run an integration test once on a particular environment.
+
+To configure a Mutex with the configuration as code, use the boolean property `one_at_a_time`
+in the workflow definition file, in a pipeline context section:
+[Mutex configuration as code example]({{<relref "/docs/concepts/files/workflow-syntax.md#mutex">}}).


### PR DESCRIPTION
1. Description

Following #4565 , the documentation has to mention the configuration as code keyword to define a mutex.

1. Related issues

#4551 (closed by the implementation PR)

1. About tests

- Visual test done on a local Hugo Server

1. Mentions

@ovh/cds
