### PR TITLE
fix(cdn): manage worker without private key in cache

### DIFF
--- a/engine/cdn/cdn_log_tcp.go
+++ b/engine/cdn/cdn_log_tcp.go
@@ -29,6 +29,10 @@ var (
 
 var globalRateLimit *rateLimiter
 
+type GetWorkerOptions struct {
+	NeedPrivateKey bool
+}
+
 // Start TCP Server
 func (s *Service) runTCPLogServer(ctx context.Context) error {
 	// Init hatcheries cache
@@ -166,7 +170,7 @@ func (s *Service) handleWorkerLog(ctx context.Context, workerName string, worker
 	var signature log.Signature
 
 	// Get worker data from cache
-	workerData, err := s.getClearWorker(ctx, workerName)
+	workerData, err := s.getClearWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: true})
 	if err != nil {
 		return err
 	}
@@ -282,8 +286,7 @@ func (s *Service) handleServiceLog(ctx context.Context, hatcheryID int64, hatche
 	}
 
 	// Get worker + check hatchery ID
-	w, err := s.getClearWorker(ctx, workerName)
-
+	w, err := s.getClearWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: false})
 	if err != nil {
 		return err
 	}
@@ -313,12 +316,12 @@ func (s *Service) handleServiceLog(ctx context.Context, hatcheryID int64, hatche
 	return nil
 }
 
-func (s *Service) getClearWorker(ctx context.Context, workerName string) (sdk.Worker, error) {
+func (s *Service) getClearWorker(ctx context.Context, workerName string, opts GetWorkerOptions) (sdk.Worker, error) {
 	workerKey := fmt.Sprintf("worker-%s", workerName)
 
 	// Get worker from cache
 	cacheData, ok := logCache.Get(workerKey)
-	if ok {
+	if ok && (!opts.NeedPrivateKey || len(cacheData.(sdk.Worker).PrivateKey) > 0) {
 		return cacheData.(sdk.Worker), nil
 	}
 
@@ -327,11 +330,11 @@ func (s *Service) getClearWorker(ctx context.Context, workerName string) (sdk.Wo
 	if err != nil {
 		return sdk.Worker{}, err
 	}
-	publicKeyDecoded, err := base64.StdEncoding.DecodeString(string(w.PrivateKey))
+	privateKeyDecoded, err := base64.StdEncoding.DecodeString(string(w.PrivateKey))
 	if err != nil {
 		return sdk.Worker{}, sdk.WithStack(err)
 	}
-	w.PrivateKey = publicKeyDecoded
+	w.PrivateKey = privateKeyDecoded
 	logCache.Set(workerKey, *w, gocache.DefaultExpiration)
 
 	return *w, nil

--- a/engine/cdn/cdn_log_tcp.go
+++ b/engine/cdn/cdn_log_tcp.go
@@ -321,8 +321,11 @@ func (s *Service) getWorker(ctx context.Context, workerName string, opts GetWork
 
 	// Get worker from cache
 	cacheData, ok := logCache.Get(workerKey)
-	if ok && (!opts.NeedPrivateKey || len(cacheData.(sdk.Worker).PrivateKey) > 0) {
-		return cacheData.(sdk.Worker), nil
+	if ok {
+	    w, ok := cacheData.(sdk.Worker)
+	    if ok && (!opts.NeedPrivateKey || len(w.PrivateKey) > 0) {
+		      return w, nil
+		  }
 	}
 
 	// Get worker from API

--- a/engine/cdn/cdn_log_tcp.go
+++ b/engine/cdn/cdn_log_tcp.go
@@ -170,7 +170,7 @@ func (s *Service) handleWorkerLog(ctx context.Context, workerName string, worker
 	var signature log.Signature
 
 	// Get worker data from cache
-	workerData, err := s.getClearWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: true})
+	workerData, err := s.getWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: true})
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (s *Service) handleServiceLog(ctx context.Context, hatcheryID int64, hatche
 	}
 
 	// Get worker + check hatchery ID
-	w, err := s.getClearWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: false})
+	w, err := s.getWorker(ctx, workerName, GetWorkerOptions{NeedPrivateKey: false})
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func (s *Service) handleServiceLog(ctx context.Context, hatcheryID int64, hatche
 	return nil
 }
 
-func (s *Service) getClearWorker(ctx context.Context, workerName string, opts GetWorkerOptions) (sdk.Worker, error) {
+func (s *Service) getWorker(ctx context.Context, workerName string, opts GetWorkerOptions) (sdk.Worker, error) {
 	workerKey := fmt.Sprintf("worker-%s", workerName)
 
 	// Get worker from cache


### PR DESCRIPTION
If service log arrive before worker registering, worker in cdn cache doesn't have a private key

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
