### PR TITLE
refactor: clean logs and retention feature flipping

### DIFF
--- a/cli/cdsctl/workflow_log.go
+++ b/cli/cdsctl/workflow_log.go
@@ -301,7 +301,7 @@ func workflowLogDownloadRun(v cli.Values) error {
 
 		// If cdn logs is enabled for current project, first check if logs can be downloaded from it
 		var link *sdk.CDNLogLink
-		if feature.Enabled {
+		if !feature.Exists || feature.Enabled {
 			if log.detailType == workflowLogDetailTypeService {
 				link, err = client.WorkflowNodeRunJobServiceLink(context.Background(), projectKey, workflowName, log.runID, log.jobID, log.serviceName)
 			} else {
@@ -369,16 +369,6 @@ var workflowLogStreamCmd = cli.Command{
 func workflowLogStreamRun(v cli.Values) error {
 	projectKey := v.GetString(_ProjectKey)
 	workflowName := v.GetString(_WorkflowName)
-
-	feature, err := client.FeatureEnabled(sdk.FeatureCDNJobLogs, map[string]string{
-		"project_key": projectKey,
-	})
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return sdk.WithStack(fmt.Errorf("cdn log processing is not active for given project"))
-	}
 
 	runNumber, err := workflowLogSearchNumber(v)
 	if err != nil {

--- a/docs/content/docs/components/cdn/_index.md
+++ b/docs/content/docs/components/cdn/_index.md
@@ -4,12 +4,12 @@ weight: 3
 ---
 
 ## What's CDN
-CDN is a service dedicated to receive and store CDS's logs. In a near future it will also be able to manage artifacts and cache used by your jobs. 
+CDN is a service dedicated to receive and store CDS's logs. In a near future, it will also be able to manage artifacts and cache used by your jobs. 
 
-CDN stores the list of all known log or artifact items in a Postgres database and communicate with storage backends to store the content of this items.
-This backends are call units and there are two types of units in CDN:
+CDN stores the list of all known log or artifact items in a Postgres database and communicates with storage backends to store the contents of those items.
+These backends are call units and there are two types of units in CDN:
 
-* Buffer Unit: to store incoming job's logs and artifact, this units are designed to be fast for read/write operations but with a limited capacity.
+* Buffer unit: To store logs and artifacts of incoming jobs, these units are designed to be fast for read / write operations, but with limited capacity.
 
 * Storage Unit: to store complete job's logs and artifact.
 
@@ -18,7 +18,7 @@ If CDN is setup with multiple storage units, each unit will periodically checks 
 
 
 ## Configuration
-Like any other CDS service, CDN requires to be authenticated with a consumer. The required scope are Service, Worker and RunExecution.
+Like any other CDS service, CDN requires to be authenticated with a consumer. The required scopes are Service, Worker and RunExecution.
 
 You must have at least one storage unit, one file buffer and one log buffer to be able to run CDN.
 

--- a/docs/content/docs/components/cdn/_index.md
+++ b/docs/content/docs/components/cdn/_index.md
@@ -13,8 +13,13 @@ This backends are call units and there are two types of units in CDN:
 
 * Storage Unit: to store complete job's logs and artifact.
 
+When logs or file are received by CDN, it will first store this items in its buffer. Then when the item is fully received, it will be moved to one of configured storage unit.
+If CDN is setup with multiple storage units, each unit will periodically checks for missing item and sync this items from other units.
+
+
 ## Configuration
 Like any other CDS service, CDN requires to be authenticated with a consumer. The required scope are Service, Worker and RunExecution.
+
 You must have at least one storage unit, one file buffer and one log buffer to be able to run CDN.
 
 ## Supported units

--- a/docs/content/docs/components/cdn/_index.md
+++ b/docs/content/docs/components/cdn/_index.md
@@ -3,26 +3,30 @@ title: "CDN"
 weight: 3
 ---
 
-<b style="color: red">⚠ Do not activate CDN log processing in production yet. It's in active development.
-Be sure that config flag 'enableLogProcessing' is set to false</b>
-
 ## What's CDN
+CDN is a service dedicated to receive and store CDS's logs. In a near future it will also be able to manage artifacts and cache used by your jobs. 
 
-CDN is a service dedicated to receive and retrieve logs. 
+CDN stores the list of all known log or artifact items in a Postgres database and communicate with storage backends to store the content of this items.
+This backends are call units and there are two types of units in CDN:
 
-A CDN instance is started with scope Project and Run using token.
+* Buffer Unit: to store incoming job's logs and artifact, this units are designed to be fast for read/write operations but with a limited capacity.
 
-CDN is linked to 2 types of storages:
+* Storage Unit: to store complete job's logs and artifact.
 
-* Buffer Unit: to store step log temporarily during the execution of a job
+## Configuration
+Like any other CDS service, CDN requires to be authenticated with a consumer. The required scope are Service, Worker and RunExecution.
+You must have at least one storage unit, one file buffer and one log buffer to be able to run CDN.
 
-* Storage Unit: to store complete step logs when it ends
+## Supported units
+* Buffer (type: log): Redis.
+* Buffer (type: file): Local.
+* Storage: Local, Swift, Webdav, CDS (cds unit is used for migration purpose and will be removed in future release).
+
 
 ## Use case
 
 Workers and hatcheries communicate with CDN, sending step logs and service log
 ![CDN_RECEIVE](/images/cdn_receive.png)
-
 
 CDS UI and CLI communicate with CDN to get entire logs, or stream them
 ![CDN_GET](/images/cdn_get.png)

--- a/docs/content/docs/components/cdn/_index.md
+++ b/docs/content/docs/components/cdn/_index.md
@@ -13,8 +13,8 @@ These backends are call units and there are two types of units in CDN:
 
 * Storage Unit: to store complete job's logs and artifact.
 
-When logs or file are received by CDN, it will first store this items in its buffer. Then when the item is fully received, it will be moved to one of configured storage unit.
-If CDN is setup with multiple storage units, each unit will periodically checks for missing item and sync this items from other units.
+When logs or file are received by CDN, it will first store these items in its buffer. Then, when the item is fully received, it will be moved to one of the configured storage units.
+If the CDN service is configured with multiple storage units, each unit periodically checks for missing items and synchronizes these items from other units.
 
 
 ## Configuration

--- a/docs/content/docs/components/cdn/migration.md
+++ b/docs/content/docs/components/cdn/migration.md
@@ -3,47 +3,73 @@ title: "Migrate logs into CDN"
 weight: 1
 ---
 
-Here the steps to follow to migrate all your logs from CDS database into CDN
+# Prepare CDN service configuration
+* Init CDN configuration using "engine" binary.
 
-* Generate a token
+Depending your needs you can change the default configuration to use a different storage unit, the default configuration is using a local encrypted one.
+```sh
+$ engine config new cdn > cdn.toml
+```
 
-```bash
+
+
+* Generate a auth consumer for your new CDN service.
+```sh
 $ cdsctl consumer new me \
---scopes=Project,Run \
+--scopes=Service,Worker,RunExecution \
 --name="cdn" \
---description="Consumer token for cds storage unit " \
+--description="Consumer for cdn service" \
 --groups="shared.infra" \
 --no-interactive
 
 Builtin consumer successfully created, use the following token to sign in:
 xxxxxxxx.xxxxxxx.4Bd9XJMIWrfe8Lwb-Au68TKUqflPorY2Fmcuw5vIoUs5gQyCLuxxxxxxxxxxxxxx
-```
-* Update your CDN configuration to add CDS as a CDN Storage Unit
 
-```
-# Must be true to activate CDN
-enableLogProcessing = true 
-
-
-# Configuration of a CDS backend
-[[cdn.storageUnits.storages]]
-    cron = "* * * * * ?"
-    name = "cds-backend"
-
-    [cdn.storageUnits.storages.cds]
-        host = "http://cdsapi:8081"
-        insecureSkipVerifyTLS = false
-        token = "<token.generated.previously>"
-
+$ engine config edit --output cdn.toml cdn.toml cdn.api.token=xxxxxxxx.xxxxxxx.4Bd9XJMIWrfe8Lwb-Au68TKUqflPorY2Fmcuw5vIoUs5gQyCLuxxxxxxxxxxxxxx
 ```
 
-* Start CDN
+* Generate a auth consumer for CDS unit for CDN
 
-* Start migration using the command line
-```
-cdsctl admin cdn migrate
+This unit will be useful to migrate logs from CDS database to CDN.
+```sh
+$ cdsctl consumer new me \
+--scopes=Project,Run \
+--name="cdn-storage-cds" \
+--description="Consumer for cds storage unit" \
+--groups="shared.infra" \
+--no-interactive
+
+Builtin consumer successfully created, use the following token to sign in:
+xxxxxxxx.xxxxxxx.4Bd9XJMIWrfe8Lwb-Au68TKUqflPorY2Fmcuw5vIoUs5gQyCLuxxxxxxxxxxxxxx
+
+$ engine config edit --output cdn.toml cdn.toml cdn.storageUnits.storages.cds.token=xxxxxxxx.xxxxxxx.4Bd9XJMIWrfe8Lwb-Au68TKUqflPorY2Fmcuw5vIoUs5gQyCLuxxxxxxxxxxxxxx
 ```
 
-* You can follow the migration from CDN logs or with the CDS command line:
+# Start CDN service
+By default CDN log processing and migration is active for all projects and you'll have to start the migration process manually. 
+
+Migration will be executed in two steps, the first one will populate the CDN database from known log items and log data will be accessible through the temporary CDS unit. Then CDN will start to sync your storage unit with CDS unit.
+
+If your CDS instance manage a lot of workflow the migration can take a long time, thanks to feature flipping you will be able to manually set the list of CDS project that should use CDN to gradually migrate your projects to CDN.
+
+* (Optional) Set feature flipping for CDN logs to migrate only some projects.
+```sh
+
+```
+
+* Start CDN service and migration.
+
+At this steps you will be able to start CDN service. It will start to process logs for activated projects. 
+
+Start migration using the command line:
+```sh
+$ cdsctl admin cdn migrate
+```
+This will only migrate activated project, if your are using feature flipping to gradually migrate your projects, you will have to reexecute this command each time you change this projects list.
+
+You can follow the migration from CDN logs or with the CDS command line:
+```sh
+$ cdsctl admin cdn status
+```
 
 ![CDN_STATUS](/images/cdn_status.png)

--- a/docs/content/docs/components/cdn/migration.md
+++ b/docs/content/docs/components/cdn/migration.md
@@ -4,7 +4,7 @@ weight: 1
 ---
 
 # Prepare CDN service configuration
-* Init CDN configuration using "engine" binary.
+* Init CDN configuration using `engine` binary.
 ```sh
 $ engine config new cdn > cdn.toml
 ```
@@ -51,7 +51,7 @@ By default CDN log processing and migration is active for all projects and you'l
 
 Migration will be executed in two steps, the first one will populate the CDN database from known log items. Then log content will be accessible through the temporary CDS unit and CDN will start to sync your storage unit with CDS unit.
 
-If your CDS instance manage a lot of workflow the migration can take a long time, thanks to feature flipping you will be able to manually set the list of CDS project that should use CDN to gradually migrate your projects to CDN.
+If your CDS instance handles a lot of workflows, the migration may take a long time, thanks to the feature flip, you will be able to manually define the list of CDS projects that should use CDN to gradually migrate your projects to CDN.
 
 * (Optional) Set feature flipping for CDN logs to migrate only some projects.
 ```sh
@@ -64,13 +64,13 @@ cdsctl admin feature import feature.yaml
 
 * Start CDN service and migration.
 
-At this steps you will be able to start CDN service. It will start to process logs for activated projects. 
+At this step, you will be able to start the CDN service. It will start processing logs for activated projects. 
 
 Start migration using the command line:
 ```sh
 $ cdsctl admin cdn migrate
 ```
-This will only migrate activated projects. If you are using feature flipping to gradually migrate your projects, you will have to reexecute this command each time you change this projects list.
+This will only migrate activated projects. If you are using feature flipping to gradually migrate your projects, you will need to rerun this command each time you change this list of projects.
 
 You can follow the migration from CDN logs or with the CDS command line:
 ```sh

--- a/engine/api/admin.go
+++ b/engine/api/admin.go
@@ -332,6 +332,8 @@ func (api *API) putAdminFeatureFlipping() service.Handler {
 			return err
 		}
 
+		featureflipping.InvalidateCache(ctx, f.Name)
+
 		return service.WriteJSON(w, f, http.StatusOK)
 	}
 }
@@ -341,14 +343,16 @@ func (api *API) deleteAdminFeatureFlipping() service.Handler {
 		vars := mux.Vars(r)
 		name := sdk.FeatureName(vars["name"])
 
-		oldF, err := featureflipping.LoadByName(ctx, gorpmapping.Mapper, api.mustDB(), name)
+		feature, err := featureflipping.LoadByName(ctx, gorpmapping.Mapper, api.mustDB(), name)
 		if err != nil {
 			return err
 		}
 
-		if err := featureflipping.Delete(api.mustDB(), oldF.ID); err != nil {
+		if err := featureflipping.Delete(api.mustDB(), feature.ID); err != nil {
 			return err
 		}
+
+		featureflipping.InvalidateCache(ctx, feature.Name)
 
 		return nil
 	}

--- a/engine/api/auth_local.go
+++ b/engine/api/auth_local.go
@@ -131,7 +131,7 @@ func initBuiltinConsumersFromStartupConfig(ctx context.Context, tx gorpmapper.Sq
 		case StartupConfigConsumerTypeCDN:
 			scopes = sdk.NewAuthConsumerScopeDetails(sdk.AuthConsumerScopeService, sdk.AuthConsumerScopeWorker, sdk.AuthConsumerScopeRunExecution)
 		case StartupConfigConsumerTypeCDNStorageCDS:
-			scopes = sdk.NewAuthConsumerScopeDetails(sdk.AuthConsumerScopeService, sdk.AuthConsumerScopeWorker, sdk.AuthConsumerScopeRunExecution)
+			scopes = sdk.NewAuthConsumerScopeDetails(sdk.AuthConsumerScopeProject, sdk.AuthConsumerScopeRun)
 		case StartupConfigConsumerTypeVCS:
 			scopes = sdk.NewAuthConsumerScopeDetails(sdk.AuthConsumerScopeService, sdk.AuthConsumerScopeProject, sdk.AuthConsumerScopeRun)
 		case StartupConfigConsumerTypeRepositories:

--- a/engine/api/feature.go
+++ b/engine/api/feature.go
@@ -22,11 +22,12 @@ func (api *API) isFeatureEnabledHandler() service.Handler {
 			return err
 		}
 
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), name, params)
+		exists, enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), name, params)
 
 		return service.WriteJSON(w, sdk.FeatureEnabledResponse{
 			Name:    name,
 			Enabled: enabled,
+			Exists:  exists,
 		}, http.StatusOK)
 	}
 }

--- a/engine/api/observability/observability.go
+++ b/engine/api/observability/observability.go
@@ -51,9 +51,10 @@ func Start(ctx context.Context, s telemetry.Service, w http.ResponseWriter, req 
 		telemetry.UserAgentAttribute: req.UserAgent(),
 	}
 
+	_, tracingEnabled := featureflipping.IsEnabled(ctx, m, db, sdk.FeatureTracing, mapVars)
 	var sampler trace.Sampler
 	switch {
-	case featureflipping.IsEnabled(ctx, m, db, sdk.FeatureTracing, mapVars):
+	case tracingEnabled:
 		sampler = trace.AlwaysSample()
 	case hasSpanContext && rootSpanContext.IsSampled():
 		sampler = trace.AlwaysSample()

--- a/engine/api/project.go
+++ b/engine/api/project.go
@@ -669,7 +669,7 @@ func (api *API) getProjectAccessHandler() service.Handler {
 		var enabled bool
 		switch sdk.CDNItemType(itemType) {
 		case sdk.CDNTypeItemWorkerCache:
-			enabled = featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
+			_, enabled = featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
 				"project_key": projectKey,
 			})
 		}

--- a/engine/api/purge/purge.go
+++ b/engine/api/purge/purge.go
@@ -10,14 +10,12 @@ import (
 	"github.com/rockbears/log"
 	"go.opencensus.io/stats"
 
-	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/integration"
 	"github.com/ovh/cds/engine/api/objectstore"
 	"github.com/ovh/cds/engine/api/project"
 	"github.com/ovh/cds/engine/api/services"
 	"github.com/ovh/cds/engine/api/workflow"
 	"github.com/ovh/cds/engine/cache"
-	"github.com/ovh/cds/engine/featureflipping"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/telemetry"
 )
@@ -100,10 +98,6 @@ func MarkWorkflowRuns(ctx context.Context, db *gorp.DbMap, workflowRunsMarkToDel
 		return err
 	}
 	for _, wf := range wfs {
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, db, sdk.FeaturePurgeName, map[string]string{"project_key": wf.ProjectKey})
-		if enabled {
-			continue
-		}
 		tx, err := db.Begin()
 		if err != nil {
 			log.Error(ctx, "workflow.PurgeWorkflowRuns> error %v", err)

--- a/engine/api/purge/purge_run.go
+++ b/engine/api/purge/purge_run.go
@@ -11,12 +11,10 @@ import (
 	"github.com/rockbears/log"
 	"go.opencensus.io/stats"
 
-	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/event"
 	"github.com/ovh/cds/engine/api/repositoriesmanager"
 	"github.com/ovh/cds/engine/api/workflow"
 	"github.com/ovh/cds/engine/cache"
-	"github.com/ovh/cds/engine/featureflipping"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/luascript"
 )
@@ -46,10 +44,6 @@ func markWorkflowRunsToDelete(ctx context.Context, store cache.Store, db *gorp.D
 		return err
 	}
 	for _, wf := range wfs {
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, db, sdk.FeaturePurgeName, map[string]string{"project_key": wf.ProjectKey})
-		if !enabled {
-			continue
-		}
 		if err := ApplyRetentionPolicyOnWorkflow(ctx, store, db, wf, MarkAsDeleteOptions{DryRun: false}, nil); err != nil {
 			ctx = sdk.ContextWithStacktrace(ctx, err)
 			log.Error(ctx, "%v", err)

--- a/engine/api/router_middleware_auth_permission.go
+++ b/engine/api/router_middleware_auth_permission.go
@@ -112,10 +112,9 @@ func (api *API) checkProjectPermissions(ctx context.Context, w http.ResponseWrit
 	defer end()
 
 	if MFASupport(ctx) && !isMFA(ctx) {
-		mapVars := map[string]string{
+		_, requireMFA := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureMFARequired, map[string]string{
 			"project_key": projectKey,
-		}
-		requireMFA := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureMFARequired, mapVars)
+		})
 		if requireMFA {
 			return sdk.WithStack(sdk.ErrMFARequired)
 		}
@@ -175,10 +174,9 @@ func (api *API) checkWorkflowPermissions(ctx context.Context, w http.ResponseWri
 	}
 
 	if MFASupport(ctx) && !isMFA(ctx) {
-		mapVars := map[string]string{
+		_, requireMFA := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureMFARequired, map[string]string{
 			"project_key": projectKey,
-		}
-		requireMFA := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureMFARequired, mapVars)
+		})
 		if requireMFA {
 			return sdk.WithStack(sdk.ErrMFARequired)
 		}

--- a/engine/api/workflow_queue.go
+++ b/engine/api/workflow_queue.go
@@ -118,10 +118,12 @@ func (api *API) postTakeWorkflowJobHandler() service.Handler {
 
 		pbji.CDNHttpAddr, err = services.GetCDNPublicHTTPAdress(ctx, api.mustDB())
 
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{"project_key": pbji.ProjectKey})
-
-		pbji.Features = make(map[sdk.FeatureName]bool, 1)
-		pbji.Features[sdk.FeatureCDNArtifact] = enabled
+		_, enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
+			"project_key": pbji.ProjectKey,
+		})
+		pbji.Features = map[sdk.FeatureName]bool{
+			sdk.FeatureCDNArtifact: enabled,
+		}
 
 		workflow.ResyncNodeRunsWithCommits(ctx, api.mustDB(), api.Cache, *p, report)
 		go api.WorkflowSendEvent(context.Background(), *p, report)

--- a/engine/api/workflow_run_artifact.go
+++ b/engine/api/workflow_run_artifact.go
@@ -20,7 +20,7 @@ func (api *API) getWorkflowRunArtifactLinksHandler() service.Handler {
 		vars := mux.Vars(r)
 
 		projectKey := vars["key"]
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
+		_, enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
 			"project_key": projectKey,
 		})
 		if !enabled {

--- a/engine/api/workflow_run_craft.go
+++ b/engine/api/workflow_run_craft.go
@@ -110,7 +110,7 @@ func (api *API) workflowRunCraft(ctx context.Context, id int64) error {
 		return sdk.WrapError(err, "unable to load workflow %d", run.WorkflowID)
 	}
 
-	enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeaturePurgeMaxRuns, map[string]string{"project_key": wf.ProjectKey})
+	_, enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeaturePurgeMaxRuns, map[string]string{"project_key": wf.ProjectKey})
 	if enabled {
 		countRuns, err := workflow.CountNotPendingWorkflowRunsByWorkflowID(api.mustDB(), run.WorkflowID)
 		if err != nil {

--- a/engine/api/workflow_run_log.go
+++ b/engine/api/workflow_run_log.go
@@ -119,13 +119,6 @@ func (api *API) getWorkflowNodeRunJobStepLinksHandler() service.Handler {
 		vars := mux.Vars(r)
 
 		projectKey := vars["key"]
-		enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNJobLogs, map[string]string{
-			"project_key": projectKey,
-		})
-		if !enabled {
-			return sdk.NewErrorFrom(sdk.ErrNotFound, "cdn is not enable for project %s", projectKey)
-		}
-
 		workflowName := vars["permWorkflowName"]
 		nodeRunID, err := requestVarInt(r, "nodeRunID")
 		if err != nil {
@@ -215,13 +208,6 @@ func (api *API) getWorkflowNodeRunJobLogLinkHandler(ctx context.Context, w http.
 	vars := mux.Vars(r)
 
 	projectKey := vars["key"]
-	enabled := featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNJobLogs, map[string]string{
-		"project_key": projectKey,
-	})
-	if !enabled {
-		return sdk.NewErrorFrom(sdk.ErrNotFound, "cdn is not enable for project %s", projectKey)
-	}
-
 	workflowName := vars["permWorkflowName"]
 	nodeRunID, err := requestVarInt(r, "nodeRunID")
 	if err != nil {
@@ -328,11 +314,9 @@ func (api *API) getWorkflowAccessHandler() service.Handler {
 		var enabled bool
 		switch sdk.CDNItemType(itemType) {
 		case sdk.CDNTypeItemStepLog, sdk.CDNTypeItemServiceLog:
-			enabled = featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNJobLogs, map[string]string{
-				"project_key": projectKey,
-			})
+			enabled = true
 		case sdk.CDNTypeItemArtifact:
-			enabled = featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
+			_, enabled = featureflipping.IsEnabled(ctx, gorpmapping.Mapper, api.mustDB(), sdk.FeatureCDNArtifact, map[string]string{
 				"project_key": projectKey,
 			})
 		}

--- a/engine/api/workflow_run_log_test.go
+++ b/engine/api/workflow_run_log_test.go
@@ -76,11 +76,6 @@ func Test_getWorkflowNodeRunJobLinkHandler(t *testing.T) {
 
 	u, pass, proj, w1, lastRun, jobRun := initGetWorkflowNodeRunJobTest(t, api, db)
 
-	require.NoError(t, featureflipping.Insert(gorpmapping.Mapper, db, &sdk.Feature{
-		Name: "cdn-job-logs",
-		Rule: fmt.Sprintf("return project_key == \"%s\"", proj.Key),
-	}))
-
 	mockCDNService, _ := assets.InitCDNService(t, db)
 	t.Cleanup(func() { _ = services.Delete(db, mockCDNService) })
 

--- a/engine/cdn/cdn_log_engine.go
+++ b/engine/cdn/cdn_log_engine.go
@@ -195,17 +195,19 @@ func (s *Service) canDequeue(ctx context.Context, jobID string) (string, error) 
 // Check if storage on CDN is enabled
 func (s *Service) cdnEnabled(ctx context.Context, projectKey string) bool {
 	cacheKey := fmt.Sprintf("cdn-job-logs-enabled-project-%s", projectKey)
-	enabled, has := runCache.Get(cacheKey)
-	if !has {
-		m := make(map[string]string, 1)
-		m["project_key"] = projectKey
-		resp, err := s.Client.FeatureEnabled(sdk.FeatureCDNJobLogs, m)
-		if err != nil {
-			log.Error(ctx, "unable to get job logs feature for project %s: %v", projectKey, err)
-			return false
-		}
-		runCache.Set(cacheKey, resp.Enabled, gocache.DefaultExpiration)
-		return resp.Enabled
+	enabledI, has := runCache.Get(cacheKey)
+	if has {
+		return enabledI.(bool)
 	}
-	return enabled.(bool)
+
+	resp, err := s.Client.FeatureEnabled(sdk.FeatureCDNJobLogs, map[string]string{
+		"project_key": projectKey,
+	})
+	if err != nil {
+		log.Error(ctx, "unable to get job logs feature for project %s: %v", projectKey, err)
+		return false
+	}
+	enabled := !resp.Exists || resp.Enabled
+	runCache.Set(cacheKey, enabled, gocache.DefaultExpiration)
+	return enabled
 }

--- a/engine/cdn/cdn_log_tcp_test.go
+++ b/engine/cdn/cdn_log_tcp_test.go
@@ -120,7 +120,11 @@ func TestWorkerLogCDNEnabled(t *testing.T) {
 	gock.InterceptClient(s.Client.(cdsclient.Raw).HTTPClient())
 
 	gock.New("http://lolcat.host").Post("/queue/workflows/1/log").Reply(200)
-	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: true, Exists: true})
+	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{
+		Name:    sdk.FeatureCDNJobLogs,
+		Enabled: true,
+		Exists:  true,
+	})
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	t.Cleanup(cancel)
@@ -242,7 +246,11 @@ func TestServiceLogCDNDisabled(t *testing.T) {
 	gock.InterceptClient(s.Client.(cdsclient.Raw).HTTPClient())
 
 	gock.New("http://lolcat.host").Post("/queue/workflows/log/service").Reply(200)
-	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: false, Exists: true})
+	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{
+		Name:    sdk.FeatureCDNJobLogs,
+		Enabled: false,
+		Exists:  true,
+	})
 
 	t0 := time.Now()
 	require.NoError(t, s.handleLogMessage(context.TODO(), []byte(message)))

--- a/engine/cdn/cdn_log_tcp_test.go
+++ b/engine/cdn/cdn_log_tcp_test.go
@@ -120,7 +120,7 @@ func TestWorkerLogCDNEnabled(t *testing.T) {
 	gock.InterceptClient(s.Client.(cdsclient.Raw).HTTPClient())
 
 	gock.New("http://lolcat.host").Post("/queue/workflows/1/log").Reply(200)
-	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: true})
+	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: true, Exists: true})
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	t.Cleanup(cancel)
@@ -242,7 +242,7 @@ func TestServiceLogCDNDisabled(t *testing.T) {
 	gock.InterceptClient(s.Client.(cdsclient.Raw).HTTPClient())
 
 	gock.New("http://lolcat.host").Post("/queue/workflows/log/service").Reply(200)
-	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: false})
+	gock.New("http://lolcat.host").Post("/feature/enabled/cdn-job-logs").Reply(200).JSON(sdk.FeatureEnabledResponse{Name: sdk.FeatureCDNJobLogs, Enabled: false, Exists: true})
 
 	t0 := time.Now()
 	require.NoError(t, s.handleLogMessage(context.TODO(), []byte(message)))

--- a/engine/cdn/cdn_sync.go
+++ b/engine/cdn/cdn_sync.go
@@ -102,7 +102,7 @@ func (s *Service) syncProjectLogs(ctx context.Context, cdsStorage *cds.CDS, pKey
 	if err != nil {
 		return err
 	}
-	if !resp.Enabled || !s.Cfg.EnableLogProcessing {
+	if resp.Exists && !resp.Enabled {
 		return nil
 	}
 

--- a/engine/cdn/cdn_sync.go
+++ b/engine/cdn/cdn_sync.go
@@ -84,7 +84,7 @@ func (s *Service) SyncLogs(ctx context.Context, cdsStorage *cds.CDS) error {
 		log.Info(ctx, "cdn:cds:sync:log: project done %d/%d (+%d failed)", statusSync.nbProjectsDone, len(projects), statusSync.nbProjectsFailed)
 		if err := s.syncProjectLogs(ctx, cdsStorage, p.Key); err != nil {
 			statusSync.nbProjectsFailed++
-			log.Error(ctx, "cdn:cds:sync:log  failed to sync project %s: %+v", p.Key, err)
+			log.Error(ctx, "cdn:cds:sync:log: failed to sync project %s: %+v", p.Key, err)
 			continue
 		}
 		statusSync.nbProjectsDone++
@@ -160,7 +160,7 @@ func (s *Service) syncProjectLogs(ctx context.Context, cdsStorage *cds.CDS, pKey
 		err := <-results
 		if err != nil {
 			statusSync.runPerProjectFailed[pKey]++
-			log.Error(ctx, "cdn:cds:sync:log: unable to sync node runs: %v", err)
+			log.Error(ctx, "cdn:cds:sync:log: unable to sync node runs: %+v", err)
 		} else {
 			statusSync.runPerProjectDone[pKey]++
 		}

--- a/engine/cdn/cdn_sync_test.go
+++ b/engine/cdn/cdn_sync_test.go
@@ -72,6 +72,7 @@ func TestSyncBuffer(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, b)
 }
+
 func TestSyncLog(t *testing.T) {
 	m := gorpmapper.New()
 	item.InitDBMapping(m)
@@ -150,13 +151,19 @@ func TestSyncLog(t *testing.T) {
 
 	// Mock feature enable
 	gock.New("http://lolcat.host:8081").Post("/feature/enabled/cdn-job-logs").BodyString(`{"project_key": "key1"}`).Reply(200).JSON(sdk.FeatureEnabledResponse{
+		Name:    sdk.FeatureCDNJobLogs,
 		Enabled: false,
+		Exists:  true,
 	})
 	gock.New("http://lolcat.host:8081").Post("/feature/enabled/cdn-job-logs").BodyString(`{"project_key": "key2"}`).Reply(200).JSON(sdk.FeatureEnabledResponse{
+		Name:    sdk.FeatureCDNJobLogs,
 		Enabled: true,
+		Exists:  true,
 	})
 	gock.New("http://lolcat.host:8081").Post("/feature/enabled/cdn-job-logs").BodyString(`{"project_key": "key3"}`).Reply(200).JSON(sdk.FeatureEnabledResponse{
+		Name:    sdk.FeatureCDNJobLogs,
 		Enabled: true,
+		Exists:  true,
 	})
 
 	// List node run identifiers for project 2

--- a/engine/cdn/cdn_sync_test.go
+++ b/engine/cdn/cdn_sync_test.go
@@ -34,9 +34,6 @@ func TestSyncBuffer(t *testing.T) {
 		DBConnectionFactory: factory,
 		Cache:               cache,
 		Mapper:              m,
-		Cfg: Configuration{
-			EnableLogProcessing: true,
-		},
 		Common: service.Common{
 			GoRoutines: sdk.NewGoRoutines(),
 		},
@@ -91,9 +88,6 @@ func TestSyncLog(t *testing.T) {
 		DBConnectionFactory: factory,
 		Cache:               cache,
 		Mapper:              m,
-		Cfg: Configuration{
-			EnableLogProcessing: true,
-		},
 		Common: service.Common{
 			GoRoutines: sdk.NewGoRoutines(),
 		},

--- a/engine/cdn/item_handler.go
+++ b/engine/cdn/item_handler.go
@@ -17,9 +17,6 @@ import (
 
 func (s *Service) bulkDeleteItemsHandler() service.Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-		if !s.Cfg.EnableLogProcessing {
-			return nil
-		}
 		var req sdk.CDNMarkDelete
 		if err := service.UnmarshalBody(r, &req); err != nil {
 			return err

--- a/engine/cdn/item_handler_test.go
+++ b/engine/cdn/item_handler_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestMarkItemToDeleteHandler(t *testing.T) {
 	s, db := newTestService(t)
-	s.Cfg.EnableLogProcessing = true
 	cdntest.ClearItem(t, context.TODO(), s.Mapper, db)
 
 	item1 := sdk.CDNItem{
@@ -339,7 +338,6 @@ func TestGetItemArtifactDownloadHandler(t *testing.T) {
 
 func TestGetItemsArtefactHandler(t *testing.T) {
 	s, db := newTestService(t)
-	s.Cfg.EnableLogProcessing = true
 
 	cdntest.ClearItem(t, context.TODO(), s.Mapper, db)
 	cdntest.ClearItem(t, context.TODO(), s.Mapper, db)

--- a/engine/cdn/item_upload_test.go
+++ b/engine/cdn/item_upload_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
-	"github.com/ovh/symmecrypt/keyloader"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ovh/symmecrypt/keyloader"
 
 	"github.com/ovh/symmecrypt/ciphers/aesgcm"
 	"github.com/ovh/symmecrypt/convergent"
@@ -38,7 +39,6 @@ import (
 
 func TestPostUploadHandler(t *testing.T) {
 	s, db := newTestService(t)
-	s.Cfg.EnableLogProcessing = true
 
 	cfg := test.LoadTestingConf(t, sdk.TypeCDN)
 

--- a/engine/cdn/status_handler.go
+++ b/engine/cdn/status_handler.go
@@ -35,10 +35,6 @@ func addMonitoringLine(nb int64, text string, err error, status string) sdk.Moni
 func (s *Service) Status(ctx context.Context) *sdk.MonitoringStatus {
 	m := s.NewMonitoringStatus()
 
-	if !s.Cfg.EnableLogProcessing {
-		return m
-	}
-
 	m.AddLine(s.LogCache.Status(ctx)...)
 
 	for _, st := range s.Units.Storages {

--- a/engine/cdn/types.go
+++ b/engine/cdn/types.go
@@ -70,12 +70,11 @@ type Configuration struct {
 		Addr string `toml:"addr" default:"" commented:"true" comment:"Listen address without port, example: 127.0.0.1" json:"addr"`
 		Port int    `toml:"port" default:"8089" json:"port"`
 	} `toml:"http" comment:"######################\n CDS CDN HTTP Configuration \n######################" json:"http"`
-	URL                 string                                 `default:"http://localhost:8089" json:"url" comment:"Private URL for communication with API"`
-	PublicTCP           string                                 `toml:"publicTCP" default:"localhost:8090" comment:"Public address to access to CDN TCP server" json:"public_tcp"`
-	PublicHTTP          string                                 `toml:"publicHTTP" default:"http://localhost:8089" comment:"Public address to access to CDN HTTP server" json:"public_http"`
-	EnableLogProcessing bool                                   `toml:"enableLogProcessing" comment:"Enable CDN preview feature that will index logs (this require a database)" json:"enableDatabaseFeatures"`
-	Database            database.DBConfigurationWithEncryption `toml:"database" comment:"################################\n Postgresql Database settings \n###############################" json:"database"`
-	Cache               struct {
+	URL        string                                 `default:"http://localhost:8089" json:"url" comment:"Private URL for communication with API"`
+	PublicTCP  string                                 `toml:"publicTCP" default:"localhost:8090" comment:"Public address to access to CDN TCP server" json:"public_tcp"`
+	PublicHTTP string                                 `toml:"publicHTTP" default:"http://localhost:8089" comment:"Public address to access to CDN HTTP server" json:"public_http"`
+	Database   database.DBConfigurationWithEncryption `toml:"database" comment:"################################\n Postgresql Database settings \n###############################" json:"database"`
+	Cache      struct {
 		TTL     int   `toml:"ttl" default:"60" json:"ttl"`
 		LruSize int64 `toml:"lruSize" default:"134217728" json:"lruSize" comment:"Redis LRU cache for logs items in bytes (default: 128MB)"`
 		Redis   struct {

--- a/engine/config.go
+++ b/engine/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fsamin/go-dump"
 	defaults "github.com/mcuadros/go-defaults"
+	"github.com/ovh/symmecrypt/convergent"
 	"github.com/ovh/symmecrypt/keyloader"
 	"github.com/spf13/viper"
 
@@ -175,6 +176,12 @@ func configBootstrap(args []string) Configuration {
 					SyncParallel:  2,
 					Local: &storage.LocalStorageConfiguration{
 						Path: "/var/lib/cds-engine/cdn",
+						Encryption: []convergent.ConvergentEncryptionConfig{{
+							Cipher:      "aes-gcm",
+							Identifier:  "cdn-storage-local",
+							LocatorSalt: sdk.RandomString(9),
+							SecretValue: sdk.RandomString(17),
+						}},
 					},
 				},
 				{

--- a/engine/featureflipping/featureflipping.go
+++ b/engine/featureflipping/featureflipping.go
@@ -23,13 +23,13 @@ func Exists(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name
 	return f.ID != 0
 }
 
-func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name sdk.FeatureName, vars map[string]string) bool {
+func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name sdk.FeatureName, vars map[string]string) (bool, bool) {
 	cachedFeatureI, has := cacheFeature.Get(string(name))
 	if !has {
 		f, err := LoadByName(ctx, m, db, name)
 		if err != nil {
 			log.Info(ctx, "featureflipping.IsEnabled> error: unable to load Feature '%s' from database: %v", name, err)
-			return false
+			return false, false
 		}
 		cacheFeature.SetDefault(string(name), f)
 		cachedFeatureI = f
@@ -42,13 +42,18 @@ func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, n
 	luaRule, err := luascript.NewCheck()
 	if err != nil {
 		log.Error(ctx, "featureflipping.IsEnabled> error: unable to create new lua check: %v", err)
-		return false
+		return true, false
 	}
 	luaRule.SetVariables(vars)
 	if err := luaRule.Perform(cachedFeature.Rule); err != nil {
 		log.Error(ctx, "featureflipping.IsEnabled> error: unable to perform lua check '%s': %v", name, err)
-		return false
+		return true, false
 	}
 
-	return luaRule.Result
+	return true, luaRule.Result
+}
+
+func InvalidateCache(ctx context.Context, name sdk.FeatureName) {
+	cacheFeature.Delete(string(name))
+	log.Debug(ctx, "featureflipping.InvalidateCache> clear cache for '%s' feature", name)
 }

--- a/engine/featureflipping/featureflipping.go
+++ b/engine/featureflipping/featureflipping.go
@@ -23,13 +23,13 @@ func Exists(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name
 	return f.ID != 0
 }
 
-func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name sdk.FeatureName, vars map[string]string) (bool, bool) {
+func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, name sdk.FeatureName, vars map[string]string) (exists bool, enabled bool) {
 	cachedFeatureI, has := cacheFeature.Get(string(name))
 	if !has {
 		f, err := LoadByName(ctx, m, db, name)
 		if err != nil {
 			log.Info(ctx, "featureflipping.IsEnabled> error: unable to load Feature '%s' from database: %v", name, err)
-			return false, false
+			return
 		}
 		cacheFeature.SetDefault(string(name), f)
 		cachedFeatureI = f
@@ -37,20 +37,23 @@ func IsEnabled(ctx context.Context, m *gorpmapper.Mapper, db gorp.SqlExecutor, n
 		log.Debug(ctx, "featureflipping.IsEnabled> feature_flipping '%s' loaded from cache", name)
 	}
 
+	exists = true
+
 	cachedFeature := cachedFeatureI.(sdk.Feature)
 
 	luaRule, err := luascript.NewCheck()
 	if err != nil {
 		log.Error(ctx, "featureflipping.IsEnabled> error: unable to create new lua check: %v", err)
-		return true, false
+		return
 	}
 	luaRule.SetVariables(vars)
 	if err := luaRule.Perform(cachedFeature.Rule); err != nil {
 		log.Error(ctx, "featureflipping.IsEnabled> error: unable to perform lua check '%s': %v", name, err)
-		return true, false
+		return
 	}
 
-	return true, luaRule.Result
+	enabled = luaRule.Result
+	return
 }
 
 func InvalidateCache(ctx context.Context, name sdk.FeatureName) {

--- a/sdk/featureflipping.go
+++ b/sdk/featureflipping.go
@@ -6,7 +6,6 @@ const (
 	FeatureCDNArtifact  FeatureName = "cdn-artifact"
 	FeatureCDNJobLogs   FeatureName = "cdn-job-logs"
 	FeatureMFARequired  FeatureName = "mfa_required"
-	FeaturePurgeName    FeatureName = "workflow-retention-policy"
 	FeaturePurgeMaxRuns FeatureName = "workflow-retention-maxruns"
 	FeatureTracing      FeatureName = "tracing"
 )
@@ -20,4 +19,5 @@ type Feature struct {
 type FeatureEnabledResponse struct {
 	Name    FeatureName `json:"name"`
 	Enabled bool        `json:"enabled"`
+	Exists  bool        `json:"exists"`
 }

--- a/ui/src/app/model/feature.model.ts
+++ b/ui/src/app/model/feature.model.ts
@@ -1,4 +1,6 @@
+import { FeatureNames } from 'app/service/feature/feature.service';
 export class FeatureEnabledResponse {
-    name: string;
+    name: FeatureNames;
     enabled: boolean;
+    exists: boolean;
 }

--- a/ui/src/app/service/feature/feature.service.ts
+++ b/ui/src/app/service/feature/feature.service.ts
@@ -6,7 +6,6 @@ import { Observable } from 'rxjs';
 export enum FeatureNames {
     CDNJobLogs = 'cdn-job-logs',
     CDNArtifact = 'cdn-artifact',
-    WorkflowRetentionPolicy = 'workflow-retention-policy',
     WorkflowRetentionMaxRuns = 'workflow-retention-maxruns'
 }
 

--- a/ui/src/app/store/feature.state.ts
+++ b/ui/src/app/store/feature.state.ts
@@ -11,6 +11,7 @@ export class FeatureResults {
 export class FeatureResult {
     paramString: string;
     enabled: boolean;
+    exists: boolean;
 }
 
 export class FeatureStateModel {
@@ -26,14 +27,9 @@ export class FeatureStateModel {
 export class FeatureState {
     constructor() { }
 
-    static feature(key: FeatureNames) {
-        return createSelector([FeatureState], (state: FeatureStateModel) => state.features.filter(f => f.key === key));
-    }
-
     static featureProject(key: FeatureNames, params: string) {
         return createSelector([FeatureState], (state: FeatureStateModel) => state.features.find(f => f.key === key)?.results.find(r => r.paramString === params));
     }
-
 
     @Action(actionFeature.AddFeatureResult)
     addFeatureResult(ctx: StateContext<FeatureStateModel>, action: actionFeature.AddFeatureResult) {
@@ -44,7 +40,6 @@ export class FeatureState {
         let existingFeature = state.features.find(f => f.key === action.payload.key);
         if (existingFeature) {
             feature.results = existingFeature.results.filter(r => r.paramString !== action.payload.result.paramString);
-
         }
         feature.results.push(action.payload.result)
 

--- a/ui/src/app/views/workflow/run/node/pipeline/node.pipeline.component.ts
+++ b/ui/src/app/views/workflow/run/node/pipeline/node.pipeline.component.ts
@@ -67,9 +67,9 @@ export class WorkflowRunNodePipelineComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        let featCDN = this._store.selectSnapshot(FeatureState.featureProject(FeatureNames.CDNJobLogs,
+        const featCDN = this._store.selectSnapshot(FeatureState.featureProject(FeatureNames.CDNJobLogs,
             JSON.stringify({ project_key: this.project.key })))
-        this.cdnEnabled = featCDN?.enabled;
+        this.cdnEnabled = featCDN && (!featCDN?.exists || featCDN.enabled);
 
         this.nodeJobRunSubs = this.nodeJobRun$.subscribe(rj => {
             if (!rj && !this.currentJob) {

--- a/ui/src/app/views/workflow/run/node/pipeline/service/service.log.component.ts
+++ b/ui/src/app/views/workflow/run/node/pipeline/service/service.log.component.ts
@@ -101,7 +101,9 @@ export class WorkflowServiceLogComponent implements OnInit, OnDestroy {
         let nodeRunId = (<WorkflowStateModel>this._store.selectSnapshot(WorkflowState)).workflowNodeRun.id;
         let runJobId = this.currentRunJobID;
 
-        const cdnEnabled = !!this._store.selectSnapshot(FeatureState.feature(FeatureNames.CDNJobLogs)).find(f => !!f.results.find(r => r.enabled && r.paramString === JSON.stringify({ project_key: projectKey })));
+        const featCDN = this._store.selectSnapshot(FeatureState.featureProject(FeatureNames.CDNJobLogs,
+            JSON.stringify({ project_key: projectKey })))
+        const cdnEnabled = featCDN && (!featCDN?.exists || featCDN.enabled);
 
         let logLink: CDNLogLink;
         if (cdnEnabled) {

--- a/ui/src/app/views/workflow/run/node/pipeline/step/step.log.component.ts
+++ b/ui/src/app/views/workflow/run/node/pipeline/step/step.log.component.ts
@@ -181,8 +181,9 @@ export class WorkflowStepLogComponent implements OnInit, OnDestroy {
         }
         let stepOrder = this.stepOrder < this.job.step_status.length ? this.stepOrder : this.job.step_status.length - 1;
 
-        const cdnEnabled = !!this._store.selectSnapshot(FeatureState.feature(FeatureNames.CDNJobLogs))
-            .find(f => !!f.results.find(r => r.enabled && r.paramString === JSON.stringify({ project_key: projectKey })));
+        const featCDN = this._store.selectSnapshot(FeatureState.featureProject(FeatureNames.CDNJobLogs,
+            JSON.stringify({ project_key: projectKey })))
+        const cdnEnabled = featCDN && (!featCDN?.exists || featCDN.enabled);
 
         let logLink: CDNLogLink;
         if (cdnEnabled) {

--- a/ui/src/app/views/workflow/workflow.component.ts
+++ b/ui/src/app/views/workflow/workflow.component.ts
@@ -102,7 +102,8 @@ export class WorkflowComponent implements OnInit, OnDestroy {
                     key: f.name,
                     result: {
                         paramString: JSON.stringify(data),
-                        enabled: f.enabled
+                        enabled: f.enabled,
+                        exists: f.exists
                     }
                 }));
             });
@@ -111,16 +112,8 @@ export class WorkflowComponent implements OnInit, OnDestroy {
                     key: f.name,
                     result: {
                         paramString: JSON.stringify(data),
-                        enabled: f.enabled
-                    }
-                }));
-            });
-            this._featureService.isEnabled(FeatureNames.WorkflowRetentionPolicy, data).subscribe(f => {
-                this._store.dispatch(new AddFeatureResult(<FeaturePayload>{
-                    key: f.name,
-                    result: {
-                        paramString: JSON.stringify(data),
-                        enabled: f.enabled
+                        enabled: f.enabled,
+                        exists: f.exists
                     }
                 }));
             });
@@ -129,7 +122,8 @@ export class WorkflowComponent implements OnInit, OnDestroy {
                     key: f.name,
                     result: {
                         paramString: JSON.stringify(data),
-                        enabled: f.enabled
+                        enabled: f.enabled,
+                        exists: f.exists
                     }
                 }));
             });


### PR DESCRIPTION
Signed-off-by: richardlt <richard.le.terrier@gmail.com>

1. Description
Remove the feature flipping for workflow run retention.
CDN logs processing is enabled by default if "cdn-job-logs" feature is not set.
Add docs about CDN migration.
1. Related issues
1. About tests
1. Mentions

@ovh/cds
