### PR TITLE
fix(contrib/integrations): arsenal deployment plugin retry on 503

### DIFF
--- a/contrib/integrations/arsenal/plugin-arsenal/main.go
+++ b/contrib/integrations/arsenal/plugin-arsenal/main.go
@@ -162,6 +162,11 @@ func (e *arsenalDeploymentPlugin) Deploy(ctx context.Context, q *integrationplug
 		defer res.Body.Close()
 
 		body, _ := ioutil.ReadAll(res.Body)
+		if res.StatusCode == http.StatusServiceUnavailable {
+			retry++
+			fmt.Println("Arsenal service unavailable, waiting for next retry")
+			continue
+		}
 		if res.StatusCode != http.StatusOK {
 			fmt.Println("Body: ", string(body))
 			return fail("deployment failure")


### PR DESCRIPTION
Arsenal can be temporarily unavailable while it redeploys itself. This
change introduce a new condition to allow follow up retries on 503 status
codes.

@ovh/cds
