### PR TITLE
feat(engine,cli): add coverage report in workflow run result

### DIFF
--- a/cli/cdsctl/workflow.go
+++ b/cli/cdsctl/workflow.go
@@ -37,6 +37,7 @@ func workflow() *cobra.Command {
 		workflowArtifact(),
 		workflowLog(),
 		workflowAdvanced(),
+		workflowRunResult(),
 	})
 }
 

--- a/cli/cdsctl/workflow_run_result.go
+++ b/cli/cdsctl/workflow_run_result.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ovh/cds/cli"
+	"github.com/ovh/cds/sdk"
+)
+
+var workflowRunResultCmd = cli.Command{
+	Name:    "result",
+	Aliases: []string{"results"},
+	Short:   "Manage Workflow Run Result",
+}
+
+type RunResultCli struct {
+	ID   string                    `cli:"id"`
+	Type sdk.WorkflowRunResultType `cli:"type"`
+	Name string                    `cli:"name"`
+}
+
+func workflowRunResult() *cobra.Command {
+	return cli.NewCommand(workflowRunResultCmd, nil, []*cobra.Command{
+		cli.NewListCommand(workflowRunResultListCmd, workflowRunResultList, nil, withAllCommandModifiers()...),
+		cli.NewCommand(workflowRunResultGetCmd, workflowRunResultGet, nil, withAllCommandModifiers()...),
+	})
+}
+
+var workflowRunResultGetCmd = cli.Command{
+	Name:  "download",
+	Short: "download workflow run result",
+	Ctx: []cli.Arg{
+		{Name: _ProjectKey},
+		{Name: _WorkflowName},
+	},
+	Args: []cli.Arg{
+		{
+			Name: "run-number",
+			IsValid: func(s string) bool {
+				match, _ := regexp.MatchString(`[0-9]?`, s)
+				return match
+			},
+		},
+		{
+			Name: "result-id",
+			IsValid: func(s string) bool {
+				match, _ := regexp.MatchString(`[0-9]?`, s)
+				return match
+			},
+		},
+	},
+}
+
+func workflowRunResultGet(v cli.Values) error {
+	ctx := context.Background()
+	runNumber, err := v.GetInt64("run-number")
+	if err != nil {
+		return err
+	}
+	resultID := v.GetString("result-id")
+
+	confCDN, err := client.ConfigCDN()
+	if err != nil {
+		return err
+	}
+
+	runResults, err := client.WorkflowRunResultsList(ctx, v.GetString(_ProjectKey), v.GetString(_WorkflowName), runNumber)
+	if err != nil {
+		return err
+	}
+	for _, r := range runResults {
+		if r.ID != resultID {
+			continue
+		}
+		var cdnHash string
+		var fileName string
+		var perm uint32
+		var md5 string
+		switch r.Type {
+		case sdk.WorkflowRunResultTypeArtifact:
+			art, err := r.GetArtifact()
+			if err != nil {
+				return err
+			}
+			cdnHash = art.CDNRefHash
+			fileName = art.Name
+			perm = art.Perm
+			md5 = art.MD5
+		case sdk.WorkflowRunResultTypeCoverage:
+			cov, err := r.GetCoverage()
+			if err != nil {
+				return err
+			}
+			cdnHash = cov.CDNRefHash
+			fileName = cov.Name
+			perm = cov.Perm
+			md5 = cov.MD5
+		default:
+			return fmt.Errorf("cannot get result of type %s", r.Type)
+		}
+
+		var f *os.File
+		var toDownload bool
+		if _, err := os.Stat(fileName); os.IsNotExist(err) {
+			toDownload = true
+		} else {
+			// file exists, check sha512
+			var errf error
+			f, errf = os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, os.FileMode(perm))
+			if errf != nil {
+				return errf
+			}
+			md5Sum, err := sdk.FileMd5sum(fileName)
+			if err != nil {
+				return err
+			}
+			if md5Sum != md5 {
+				toDownload = true
+			}
+		}
+
+		if toDownload {
+			var err error
+			f, err = os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(perm))
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Downloading %s...\n", fileName)
+			r, err := client.CDNItemDownload(context.Background(), confCDN.HTTPURL, cdnHash, sdk.CDNTypeItemRunResult)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, r); err != nil {
+				return sdk.WrapError(err, "unable to write file")
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		}
+
+		md5Sum, err := sdk.FileMd5sum(fileName)
+		if err != nil {
+			return err
+		}
+
+		if md5Sum != md5 {
+			return fmt.Errorf("Invalid md5Sum \ndownloaded file:%s\n%s:%s", md5Sum, f.Name(), md5)
+		}
+
+		if toDownload {
+			fmt.Printf("File %s created, checksum OK\n", f.Name())
+		} else {
+			fmt.Printf("File %s already downloaded, checksum OK\n", f.Name())
+		}
+	}
+	return nil
+}
+
+var workflowRunResultListCmd = cli.Command{
+	Name:  "list",
+	Short: "List workflow run result",
+	Ctx: []cli.Arg{
+		{Name: _ProjectKey},
+		{Name: _WorkflowName},
+	},
+	Args: []cli.Arg{
+		{
+			Name: "run-number",
+			IsValid: func(s string) bool {
+				match, _ := regexp.MatchString(`[0-9]?`, s)
+				return match
+			},
+		},
+	},
+	Flags: []cli.Flag{
+		{
+			Name:      "type",
+			ShortHand: "t",
+			Usage:     "List only result of one type",
+			IsValid: func(s string) bool {
+				match, _ := regexp.MatchString(`[0-9]?`, s)
+				return match
+			},
+		},
+	},
+}
+
+func workflowRunResultList(v cli.Values) (cli.ListResult, error) {
+	ctx := context.Background()
+
+	runNumber, err := v.GetInt64("run-number")
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := client.WorkflowRunResultsList(ctx, v.GetString(_ProjectKey), v.GetString(_WorkflowName), runNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.GetString("type") == "" {
+		cliResults, err := toCLIRunResult(results)
+		return cli.AsListResult(cliResults), err
+	}
+
+	resultsFiltered := make([]sdk.WorkflowRunResult, 0)
+	for _, r := range results {
+		if string(r.Type) != v.GetString("type") {
+			continue
+		}
+		resultsFiltered = append(resultsFiltered, r)
+	}
+	cliResults, err := toCLIRunResult(resultsFiltered)
+	return cli.AsListResult(cliResults), err
+}
+
+func toCLIRunResult(results []sdk.WorkflowRunResult) ([]RunResultCli, error) {
+	cliresults := make([]RunResultCli, 0, len(results))
+	for _, r := range results {
+		var name string
+		switch r.Type {
+		case sdk.WorkflowRunResultTypeCoverage:
+			covResult, err := r.GetCoverage()
+			if err != nil {
+				return nil, err
+			}
+			name = covResult.Name
+		case sdk.WorkflowRunResultTypeArtifact:
+			artiResult, err := r.GetArtifact()
+			if err != nil {
+				return nil, err
+			}
+			name = artiResult.Name
+		}
+
+		cliresults = append(cliresults, RunResultCli{
+			ID:   r.ID,
+			Type: r.Type,
+			Name: name,
+		})
+	}
+	return cliresults, nil
+}

--- a/engine/api/workflow_run.go
+++ b/engine/api/workflow_run.go
@@ -1448,10 +1448,6 @@ func (api *API) postWorkflowRunResultsHandler() service.Handler {
 			return sdk.WithStack(err)
 		}
 
-		if runResult.Type != sdk.WorkflowRunResultTypeArtifact {
-			return sdk.WrapError(sdk.ErrForbidden, "unable to manage non artifact result")
-		}
-
 		wr, err := workflow.LoadRun(ctx, api.mustDB(), key, name, number, workflow.LoadRunOptions{WithArtifacts: true})
 		if err != nil {
 			return err

--- a/sdk/workflow_run_result.go
+++ b/sdk/workflow_run_result.go
@@ -72,6 +72,7 @@ type WorkflowRunResultCoverage struct {
 	Size       int64  `json:"size"`
 	MD5        string `json:"md5"`
 	CDNRefHash string `json:"cdn_hash"`
+	Perm       uint32 `json:"perm"`
 }
 
 func (a *WorkflowRunResultCoverage) IsValid() error {
@@ -86,6 +87,9 @@ func (a *WorkflowRunResultCoverage) IsValid() error {
 	}
 	if a.CDNRefHash == "" {
 		return WrapError(ErrInvalidData, "missing cdn item hash")
+	}
+	if a.Perm == 0 {
+		return WrapError(ErrInvalidData, "missing file permission")
 	}
 	return nil
 }


### PR DESCRIPTION
CLi Run result List:
```
+--------------------------------------+-------------+----------+
|                  ID                  |    NAME     |   TYPE   |
+--------------------------------------+-------------+----------+
| 692cb48e-577b-4f0a-8d47-d37a4874bb4f | lcov.info   | coverage |
| 161cc6d4-9563-40e2-bb5c-e7b23883f4c3 | workin.log  | artifact |
| 79a64549-0a36-411a-afd2-0fb3cb617b21 | workout.log | artifact |
| 2f6215c0-dc69-42b8-b426-3578a956310c | artin.log   | artifact |
| af98b219-7957-4353-8e74-edc08017a09e | artout.log  | artifact |
+--------------------------------------+-------------+----------+
```

