### PR TITLE
feat(api): export workflow purge info

### DIFF
--- a/engine/api/workflow/workflow_importer.go
+++ b/engine/api/workflow/workflow_importer.go
@@ -25,11 +25,6 @@ func Import(ctx context.Context, db gorpmapper.SqlExecutorWithTx, store cache.St
 	w.ProjectKey = proj.Key
 	w.ProjectID = proj.ID
 
-	// Default value of history length is 20
-	if w.HistoryLength == 0 {
-		w.HistoryLength = 20
-	}
-
 	if w.WorkflowData.Node.Context == nil {
 		w.WorkflowData.Node.Context = &sdk.NodeContext{}
 	}

--- a/engine/api/workflow_export_test.go
+++ b/engine/api/workflow_export_test.go
@@ -145,9 +145,7 @@ workflow:
     depends_on:
     - fork
     pipeline: pip1
-retention_policy: return (git_branch_exist == "false" and run_days_before < 2) or run_days_before < 365
 `, rec.Body.String())
-
 }
 
 func Test_getWorkflowExportHandlerWithPermissions(t *testing.T) {
@@ -209,10 +207,11 @@ func Test_getWorkflowExportHandlerWithPermissions(t *testing.T) {
 	}))
 
 	w := sdk.Workflow{
-		Name:          "test_1",
-		ProjectID:     proj.ID,
-		ProjectKey:    proj.Key,
-		HistoryLength: 25,
+		Name:            "test_1",
+		ProjectID:       proj.ID,
+		ProjectKey:      proj.Key,
+		RetentionPolicy: "return true",
+		HistoryLength:   25,
 		Groups: []sdk.GroupPermission{
 			{
 				Group:      *group2,
@@ -279,10 +278,9 @@ workflow:
     pipeline: pip1
 permissions:
   Test_getWorkflowExportHandlerWithPermissions-Group2: 7
-retention_policy: return (git_branch_exist == "false" and run_days_before < 2) or run_days_before < 365
+retention_policy: return true
 history_length: 25
 `, rec.Body.String())
-
 }
 
 func Test_getWorkflowPullHandler(t *testing.T) {

--- a/sdk/exportentities/v1/workflow.go
+++ b/sdk/exportentities/v1/workflow.go
@@ -205,8 +205,6 @@ func (w Workflow) GetWorkflow() (*sdk.Workflow, error) {
 	}
 	if w.HistoryLength != nil && *w.HistoryLength > 0 {
 		wf.HistoryLength = *w.HistoryLength
-	} else {
-		wf.HistoryLength = sdk.DefaultHistoryLength
 	}
 
 	rand.Seed(time.Now().Unix())

--- a/sdk/exportentities/v1/workflow_test.go
+++ b/sdk/exportentities/v1/workflow_test.go
@@ -229,8 +229,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "pipeline",
@@ -266,9 +265,8 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
-				Description:   "this is my description",
+				Name:        "myworkflow",
+				Description: "this is my description",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "pipeline",
@@ -331,8 +329,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -396,8 +393,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -511,8 +507,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -601,8 +596,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "A",
@@ -732,8 +726,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "pipeline",
@@ -767,8 +760,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myworkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myworkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "A",
@@ -838,17 +830,17 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			got.Environments = nil
 			got.ProjectIntegrations = nil
 
-			expextedValues, _ := dump.ToStringMap(tt.want)
+			expectedValues, _ := dump.ToStringMap(tt.want)
 			actualValues, _ := dump.ToStringMap(got)
 
-			var keysExpextedValues []string
-			for k := range expextedValues {
-				keysExpextedValues = append(keysExpextedValues, k)
+			var keysExpectedValues []string
+			for k := range expectedValues {
+				keysExpectedValues = append(keysExpectedValues, k)
 			}
-			sort.Strings(keysExpextedValues)
+			sort.Strings(keysExpectedValues)
 
-			for _, expectedKey := range keysExpextedValues {
-				expectedValue := expextedValues[expectedKey]
+			for _, expectedKey := range keysExpectedValues {
+				expectedValue := expectedValues[expectedKey]
 				actualValue, ok := actualValues[expectedKey]
 				if strings.Contains(expectedKey, ".Ref") {
 					assert.NotEmpty(t, actualValue, "value %s is empty but shoud not be empty", expectedKey)
@@ -859,7 +851,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			}
 
 			for actualKey := range actualValues {
-				_, ok := expextedValues[actualKey]
+				_, ok := expectedValues[actualKey]
 				assert.True(t, ok, "got %s, but not found is expected workflow", actualKey)
 			}
 		})

--- a/sdk/exportentities/v2/workflow_test.go
+++ b/sdk/exportentities/v2/workflow_test.go
@@ -188,8 +188,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myWorkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -254,8 +253,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myWorkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -317,12 +315,14 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 						PipelineName: "pipeline-root",
 					},
 				},
-				HistoryLength: 25,
+				HistoryLength:   25,
+				RetentionPolicy: "return true",
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: 25,
+				Name:            "myWorkflow",
+				HistoryLength:   25,
+				RetentionPolicy: "return true",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -369,8 +369,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myWorkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "root",
@@ -459,8 +458,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myWorkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "A",
@@ -600,8 +598,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			},
 			wantErr: false,
 			want: sdk.Workflow{
-				Name:          "myWorkflow",
-				HistoryLength: sdk.DefaultHistoryLength,
+				Name: "myWorkflow",
 				WorkflowData: sdk.WorkflowData{
 					Node: sdk.Node{
 						Name: "A",
@@ -643,7 +640,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 				Hooks:           tt.fields.Hooks,
 				Permissions:     tt.fields.Permissions,
 				HistoryLength:   &tt.fields.HistoryLength,
-				RetentionPolicy: tt.fields.RetentionPolicy,
+				RetentionPolicy: &tt.fields.RetentionPolicy,
 			}
 			got, err := exportentities.ParseWorkflow(w)
 			if (err != nil) != tt.wantErr {
@@ -663,17 +660,17 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			got.Environments = nil
 			got.ProjectIntegrations = nil
 
-			expextedValues, _ := dump.ToStringMap(tt.want)
+			expectedValues, _ := dump.ToStringMap(tt.want)
 			actualValues, _ := dump.ToStringMap(got)
 
-			var keysExpextedValues []string
-			for k := range expextedValues {
-				keysExpextedValues = append(keysExpextedValues, k)
+			var keysExpectedValues []string
+			for k := range expectedValues {
+				keysExpectedValues = append(keysExpectedValues, k)
 			}
-			sort.Strings(keysExpextedValues)
+			sort.Strings(keysExpectedValues)
 
-			for _, expectedKey := range keysExpextedValues {
-				expectedValue := expextedValues[expectedKey]
+			for _, expectedKey := range keysExpectedValues {
+				expectedValue := expectedValues[expectedKey]
 				actualValue, ok := actualValues[expectedKey]
 				if strings.Contains(expectedKey, ".Ref") {
 					assert.NotEmpty(t, actualValue, "value %s is empty but shoud not be empty", expectedKey)
@@ -684,7 +681,7 @@ func TestWorkflow_GetWorkflow(t *testing.T) {
 			}
 
 			for actualKey := range actualValues {
-				_, ok := expextedValues[actualKey]
+				_, ok := expectedValues[actualKey]
 				assert.True(t, ok, "got %s, but not found is expected workflow", actualKey)
 			}
 		})
@@ -1133,7 +1130,7 @@ workflow:
         script: return cds_manual == "true"
       one_at_a_time: true
 metadata:
-    default_tags: git.branch,git.author 
+    default_tags: git.branch,git.author
 notifications:
 - type: vcs
   settings:

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -13,7 +13,8 @@ import (
 
 // DefaultHistoryLength is the default history length
 const (
-	DefaultHistoryLength int64 = 20
+	DefaultHistoryLength int64  = 20
+	DefaultRetentionRule string = "return (git_branch_exist == \"false\" and run_days_before < 2) or run_days_before < 365"
 )
 
 // ColorRegexp represent the regexp for a format to hexadecimal color


### PR DESCRIPTION
1. Description
Exports purge info in workflow yaml files only if different than default values. This will hide retention_policy for project that are not using it.
When updating yaml, if purge values are removed, CDS API will preserve old values instead of reapplying default values. This will prevent from dropping legacy purge options when switching to retention policy.

1. Related issues
1. About tests
1. Mentions

@ovh/cds
