### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cli/cdsctl/admin_feature.go
+++ b/cli/cdsctl/admin_feature.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/ovh/cds/cli"
 	"github.com/ovh/cds/sdk"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -84,7 +85,7 @@ var adminFeatureImportCmd = cli.Command{
 }
 
 func adminFeatureImportRun(v cli.Values) error {
-	btes, err := ioutil.ReadFile(v.GetString("file"))
+	btes, err := os.ReadFile(v.GetString("file"))
 	if err != nil {
 		return err
 	}

--- a/cli/cdsctl/admin_integration.go
+++ b/cli/cdsctl/admin_integration.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -97,7 +97,7 @@ var adminIntegrationModelImportCmd = cli.Command{
 }
 
 func adminIntegrationModelImportRun(v cli.Values) error {
-	b, err := ioutil.ReadFile(v.GetString("file"))
+	b, err := os.ReadFile(v.GetString("file"))
 	if err != nil {
 		return cli.WrapError(err, "unable to read file %s", v.GetString("file"))
 	}

--- a/cli/cdsctl/admin_plugin.go
+++ b/cli/cdsctl/admin_plugin.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -56,7 +55,7 @@ var adminPluginsImportCmd = cli.Command{
 }
 
 func adminPluginsImportFunc(v cli.Values) error {
-	b, err := ioutil.ReadFile(v.GetString("file"))
+	b, err := os.ReadFile(v.GetString("file"))
 	if err != nil {
 		return cli.WrapError(err, "unable to read file %s", v.GetString("file"))
 	}
@@ -160,7 +159,7 @@ func adminPluginsAddBinaryFunc(v cli.Values) error {
 		return cli.WrapError(err, "unable to open file %s", v.GetString("filename"))
 	}
 
-	b, err := ioutil.ReadFile(v.GetString("descriptor"))
+	b, err := os.ReadFile(v.GetString("descriptor"))
 	if err != nil {
 		return cli.WrapError(err, "unable to read file %s", v.GetString("file"))
 	}
@@ -172,7 +171,7 @@ func adminPluginsAddBinaryFunc(v cli.Values) error {
 
 	desc.Name = filepath.Base(f.Name())
 	desc.Perm = uint32(fi.Mode().Perm())
-	desc.FileContent, err = ioutil.ReadFile(f.Name())
+	desc.FileContent, err = os.ReadFile(f.Name())
 	if err != nil {
 		return cli.WrapError(err, "unable to open file %s ", v.GetString("filename"))
 	}
@@ -202,7 +201,7 @@ var adminPluginsDocCmd = cli.Command{
 }
 
 func adminPluginsDocFunc(v cli.Values) error {
-	btes, errRead := ioutil.ReadFile(v.GetString("path"))
+	btes, errRead := os.ReadFile(v.GetString("path"))
 	if errRead != nil {
 		return cli.NewError("error while reading file: %s", errRead)
 	}

--- a/cli/cdsctl/preview_workflowv3_validate.go
+++ b/cli/cdsctl/preview_workflowv3_validate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,7 +56,7 @@ func workflowV3ValidateRun(v cli.Values) error {
 
 	workflowIn := workflowv3.NewWorkflow()
 	for i := range files {
-		buf, err := ioutil.ReadFile(files[i])
+		buf, err := os.ReadFile(files[i])
 		if err != nil {
 			return errors.Wrapf(err, "cannot read file at %q", files[i])
 		}

--- a/cli/cdsctl/tools.go
+++ b/cli/cdsctl/tools.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -105,22 +104,22 @@ func toolsYamlSchemaRun(v cli.Values) error {
 		Environment: fmt.Sprintf("%s/environment.schema.json", targetFolder),
 	}
 
-	if err := ioutil.WriteFile(paths.Workflow, []byte(res.Workflow), 0775); err != nil {
+	if err := os.WriteFile(paths.Workflow, []byte(res.Workflow), 0775); err != nil {
 		return cli.WrapError(err, "Cannot write file at %s", paths.Workflow)
 	}
 	fmt.Printf("File %s successfully written.\n", paths.Workflow)
 
-	if err := ioutil.WriteFile(paths.Pipeline, []byte(res.Pipeline), 0775); err != nil {
+	if err := os.WriteFile(paths.Pipeline, []byte(res.Pipeline), 0775); err != nil {
 		return cli.WrapError(err, "Cannot write file at %s", paths.Pipeline)
 	}
 	fmt.Printf("File %s successfully written.\n", paths.Pipeline)
 
-	if err := ioutil.WriteFile(paths.Application, []byte(res.Application), 0775); err != nil {
+	if err := os.WriteFile(paths.Application, []byte(res.Application), 0775); err != nil {
 		return cli.WrapError(err, "Cannot write file at %s", paths.Application)
 	}
 	fmt.Printf("File %s successfully written.\n", paths.Application)
 
-	if err := ioutil.WriteFile(paths.Environment, []byte(res.Environment), 0775); err != nil {
+	if err := os.WriteFile(paths.Environment, []byte(res.Environment), 0775); err != nil {
 		return cli.WrapError(err, "Cannot write file at %s", paths.Environment)
 	}
 	fmt.Printf("File %s successfully written.\n", paths.Environment)

--- a/cli/cdsctl/workflow_init.go
+++ b/cli/cdsctl/workflow_init.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -277,7 +276,7 @@ func craftWorkflowFile(workflowName, appName, pipName, destinationDir string) (s
 	}
 
 	wFilePath := filepath.Join(destinationDir, workflowName+".yml")
-	if err := ioutil.WriteFile(wFilePath, b, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(wFilePath, b, os.FileMode(0644)); err != nil {
 		return "", cli.WrapError(err, "Unable to write workflow file")
 	}
 
@@ -408,7 +407,7 @@ func craftApplicationFile(proj *sdk.Project, existingApp *sdk.Application, fetch
 	}
 
 	appFilePath := filepath.Join(destinationDir, fmt.Sprintf(exportentities.PullApplicationName, appName))
-	if err := ioutil.WriteFile(appFilePath, b, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(appFilePath, b, os.FileMode(0644)); err != nil {
 		return "", cli.WrapError(err, "Unable to write application file")
 	}
 
@@ -444,7 +443,7 @@ func craftPipelineFile(proj *sdk.Project, existingPip *sdk.Pipeline, pipName, de
 	}
 
 	pipFilePath := filepath.Join(destinationDir, fmt.Sprintf(exportentities.PullPipelineName, pipName))
-	if err := ioutil.WriteFile(pipFilePath, b, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(pipFilePath, b, os.FileMode(0644)); err != nil {
 		return pipName, cli.WrapError(err, "Unable to write application file")
 	}
 

--- a/cli/cdsctl/workflow_log.go
+++ b/cli/cdsctl/workflow_log.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -317,7 +317,7 @@ func workflowLogDownloadRun(v cli.Values) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(log.getFilename(), data, 0644); err != nil {
+		if err := os.WriteFile(log.getFilename(), data, 0644); err != nil {
 			return err
 		}
 		fmt.Printf("file %s created\n", log.getFilename())

--- a/cli/cdsctl/workflow_push.go
+++ b/cli/cdsctl/workflow_push.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +107,7 @@ func workflowFilesToTarWriter(files []string, buf io.Writer) error {
 
 	// add some files to the archive
 	for _, file := range files {
-		filBuf, err := ioutil.ReadFile(file)
+		filBuf, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/contrib/grpcplugins/action/plugin-clair/clairctl/docker/dockercli/dockercli.go
+++ b/contrib/grpcplugins/action/plugin-clair/clairctl/docker/dockercli/dockercli.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -42,7 +42,7 @@ import (
 	"github.com/ovh/cds/contrib/grpcplugins/action/clair/clairctl/config"
 )
 
-//GetLocalManifest retrieve manifest for local image
+// GetLocalManifest retrieve manifest for local image
 func GetLocalManifest(imageName string, withExport bool) (reference.NamedTagged, distribution.Manifest, error) {
 	n, err := reference.ParseNamed(imageName)
 	if err != nil {
@@ -101,7 +101,7 @@ func save(imageName string) (distribution.Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot save image %s: %s", imageName, err)
 	}
-	all, err := ioutil.ReadAll(img)
+	all, err := io.ReadAll(img)
 	if err != nil {
 		panic(err)
 	}

--- a/contrib/grpcplugins/action/plugin-group-tmpl/applications.go
+++ b/contrib/grpcplugins/action/plugin-group-tmpl/applications.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -35,7 +35,7 @@ type VariableAlteration func(interface{}) (interface{}, error)
 func NewApplications(file string) (*Applications, error) {
 	var ret Applications
 
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read applications file : %s", err)
 	}

--- a/contrib/grpcplugins/action/plugin-group-tmpl/main.go
+++ b/contrib/grpcplugins/action/plugin-group-tmpl/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -62,7 +61,7 @@ func (actPlugin *groupTmplActionPlugin) Run(ctx context.Context, q *actionplugin
 	}
 
 	// get template config content
-	configContent, err := ioutil.ReadFile(config)
+	configContent, err := os.ReadFile(config)
 	if err != nil {
 		return actionplugin.Fail("Failed to read config template file: %s", err)
 	}

--- a/contrib/grpcplugins/action/plugin-group-tmpl/plugin_test.go
+++ b/contrib/grpcplugins/action/plugin-group-tmpl/plugin_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -56,7 +55,7 @@ func TestRun(t *testing.T) {
         ]
     }`
 
-	configfile, err := ioutil.TempFile(tmpdir, "config.tmpl")
+	configfile, err := os.CreateTemp(tmpdir, "config.tmpl")
 	if err != nil {
 		t.Fatalf("unexpected error creating temporary config file: %s", err)
 	}
@@ -68,7 +67,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("unexpected error writing config content: %s", err)
 	}
 
-	applicationsfile, err := ioutil.TempFile(tmpdir, "applications.json")
+	applicationsfile, err := os.CreateTemp(tmpdir, "applications.json")
 	if err != nil {
 		t.Fatalf("unexpected error creating temporary applications file: %s", err)
 	}
@@ -104,7 +103,7 @@ func TestRun(t *testing.T) {
 		return
 	}
 
-	gotContent, err := ioutil.ReadFile(outputfile)
+	gotContent, err := os.ReadFile(outputfile)
 	if err != nil {
 		t.Fatalf("unexpected error reading generated content: %s", err)
 		return

--- a/contrib/grpcplugins/action/plugin-kafka-publish/cli_actions.go
+++ b/contrib/grpcplugins/action/plugin-kafka-publish/cli_actions.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/bgentry/speakeasy"
@@ -59,7 +58,7 @@ func listenAction(c *cli.Context) error {
 	var pgpPrivateKey, pgpPassphrase []byte
 	if pgpPrivKey != "" {
 		var err error
-		pgpPrivateKey, err = ioutil.ReadFile(pgpPrivKey)
+		pgpPrivateKey, err = os.ReadFile(pgpPrivKey)
 		if err != nil {
 			return cli.NewExitError(err.Error(), 11)
 		}
@@ -139,7 +138,7 @@ func ackAction(c *cli.Context) error {
 	var logsBody []byte
 	if logFile := c.String("log"); logFile != "" {
 		var err error
-		logsBody, err = ioutil.ReadFile(logFile)
+		logsBody, err = os.ReadFile(logFile)
 		if err != nil {
 			return cli.NewExitError(err.Error(), 41)
 		}
@@ -149,7 +148,7 @@ func ackAction(c *cli.Context) error {
 	}
 
 	//Read the context json file
-	contextBody, err := ioutil.ReadFile(contextFile)
+	contextBody, err := os.ReadFile(contextFile)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 42)
 	}

--- a/contrib/grpcplugins/action/plugin-kafka-publish/kafka_consumer.go
+++ b/contrib/grpcplugins/action/plugin-kafka-publish/kafka_consumer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -237,7 +236,7 @@ func fileHandler(ctx *kafkapublisher.Context, filename string, data []byte) erro
 	//No context
 	if ctx == nil {
 		fmt.Printf("Received file %s\n", filename)
-		if err := ioutil.WriteFile(filename, data, os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(filename, data, os.FileMode(0644)); err != nil {
 			return err
 		}
 		return nil
@@ -265,7 +264,7 @@ func fileHandler(ctx *kafkapublisher.Context, filename string, data []byte) erro
 	//Write the file
 	filepath := path.Join(ctx.Directory, filename)
 	fmt.Printf("Received file %s in context %d => %s\n", filename, ctx.ActionID, filepath)
-	if err := ioutil.WriteFile(filepath, data, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath, data, os.FileMode(0644)); err != nil {
 		return err
 	}
 
@@ -279,7 +278,7 @@ func fileHandler(ctx *kafkapublisher.Context, filename string, data []byte) erro
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(name, buff, os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(name, buff, os.FileMode(0644)); err != nil {
 			return err
 		}
 		ctx.Closed = true

--- a/contrib/grpcplugins/action/plugin-kafka-publish/kafkapublisher/chunks_test.go
+++ b/contrib/grpcplugins/action/plugin-kafka-publish/kafkapublisher/chunks_test.go
@@ -1,7 +1,7 @@
 package kafkapublisher
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/fsamin/go-shredder"
@@ -32,7 +32,7 @@ func TestKafkaMessages(t *testing.T) {
 	ctx, err := shredder.Reassemble(chunks2, nil)
 	test.NoError(t, err)
 
-	btes, err := ioutil.ReadFile("chunks.go")
+	btes, err := os.ReadFile("chunks.go")
 	test.NoError(t, err)
 
 	assert.EqualValues(t, btes, ctx.Bytes())

--- a/contrib/grpcplugins/action/plugin-kafka-publish/plugin_test.go
+++ b/contrib/grpcplugins/action/plugin-kafka-publish/plugin_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ func Test_tmplMessage(t *testing.T) {
 	}
 
 	var checkFile = func(str string) string {
-		b, err := ioutil.ReadFile(str)
+		b, err := os.ReadFile(str)
 		if err != nil {
 			return err.Error()
 		}

--- a/contrib/grpcplugins/action/plugin-marathon/main.go
+++ b/contrib/grpcplugins/action/plugin-marathon/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -248,7 +247,7 @@ func main() {
 
 func tmplApplicationConfigFile(q *actionplugin.ActionQuery, filepath string) (string, error) {
 	//Read initial marathon.json file
-	buff, err := ioutil.ReadFile(filepath)
+	buff, err := os.ReadFile(filepath)
 	if err != nil {
 		fmt.Printf("Configuration file error: %s\n", err)
 		return "", err
@@ -262,7 +261,7 @@ func tmplApplicationConfigFile(q *actionplugin.ActionQuery, filepath string) (st
 	}
 
 	// create file
-	outfile, errtemp := ioutil.TempFile(os.TempDir(), "marathon.json")
+	outfile, errtemp := os.CreateTemp(os.TempDir(), "marathon.json")
 	if errtemp != nil {
 		fmt.Printf("Error writing temporary file: %s\n", errtemp.Error())
 		return "", errtemp
@@ -282,7 +281,7 @@ func tmplApplicationConfigFile(q *actionplugin.ActionQuery, filepath string) (st
 
 func parseApplicationConfigFile(f string) (*marathon.Application, error) {
 	//Read marathon.json
-	buff, errf := ioutil.ReadFile(f)
+	buff, errf := os.ReadFile(f)
 	if errf != nil {
 		fmt.Printf("Configuration file error: %s\n", errf)
 		return nil, errf
@@ -301,14 +300,14 @@ func parseApplicationConfigFile(f string) (*marathon.Application, error) {
 		fmt.Printf("Error with working directory : %s\n", erro)
 		return nil, erro
 	}
-	schemaPath, errt := ioutil.TempFile(os.TempDir(), "marathon.schema")
+	schemaPath, errt := os.CreateTemp(os.TempDir(), "marathon.schema")
 	if errt != nil {
 		fmt.Printf("Error marathon schema (%s) : %s\n", schemaPath.Name(), errt)
 		return nil, errt
 	}
 	defer os.RemoveAll(schemaPath.Name())
 
-	if err := ioutil.WriteFile(schemaPath.Name(), []byte(schema), 0644); err != nil {
+	if err := os.WriteFile(schemaPath.Name(), []byte(schema), 0644); err != nil {
 		fmt.Printf("Error marathon schema : %s\n", err)
 		return nil, err
 	}

--- a/contrib/grpcplugins/action/plugin-npm-audit-parser/main.go
+++ b/contrib/grpcplugins/action/plugin-npm-audit-parser/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -35,7 +35,7 @@ func (actPlugin *npmAuditParserActionPlugin) Run(ctx context.Context, q *actionp
 	if file == "" {
 		return actionplugin.Fail("File parameter must not be empty")
 	}
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return actionplugin.Fail("Unable to read file %s: %v", file, err)
 	}

--- a/contrib/grpcplugins/action/plugin-tmpl/main.go
+++ b/contrib/grpcplugins/action/plugin-tmpl/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -63,7 +62,7 @@ func (actPlugin *tmplActionPlugin) Run(ctx context.Context, q *actionplugin.Acti
 	}
 
 	// get template file content
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return actionplugin.Fail("Failed to read template file: %v", err)
 	}

--- a/contrib/grpcplugins/action/plugin-tmpl/plugin_test.go
+++ b/contrib/grpcplugins/action/plugin-tmpl/plugin_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -19,7 +18,7 @@ func TestRun(t *testing.T) {
 	params := `name=toto
 age=42`
 
-	tmplfile, err := ioutil.TempFile(tmpdir, "plugintmpl")
+	tmplfile, err := os.CreateTemp(tmpdir, "plugintmpl")
 	if err != nil {
 		t.Fatalf("unexpected error creating temporary template file: %s", err)
 	}
@@ -52,7 +51,7 @@ age=42`
 	}
 
 	expectedContent := `My name is toto, I am 42!`
-	gotContent, err := ioutil.ReadFile(tmplfile.Name() + ".out")
+	gotContent, err := os.ReadFile(tmplfile.Name() + ".out")
 	if err != nil {
 		t.Errorf("unexpected error reading generated content: %s", err)
 		return

--- a/contrib/grpcplugins/action/plugin-venom/main.go
+++ b/contrib/grpcplugins/action/plugin-venom/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -139,7 +138,7 @@ func (actPlugin *venomActionPlugin) Run(ctx context.Context, q *actionplugin.Act
 
 	if varsFromFile != "" {
 		varFileMap := make(map[string]string)
-		bytes, err := ioutil.ReadFile(varsFromFile)
+		bytes, err := os.ReadFile(varsFromFile)
 		if err != nil {
 			return actionplugin.Fail("VENOM - Error while reading file: %v\n", err)
 		}

--- a/contrib/grpcplugins/grpcplugins.go
+++ b/contrib/grpcplugins/grpcplugins.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/ovh/cds/sdk"
@@ -25,7 +25,7 @@ func GetRunResults(workerHTTPPort int32) ([]sdk.WorkflowRunResult, error) {
 		return nil, fmt.Errorf("cannot get run result /run-result: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read body on get run result /run-result: %v", err)
 	}
@@ -89,7 +89,7 @@ func GetServices(workerHTTPPort int32, serviceType string) ([]sdk.ServiceConfigu
 		return nil, fmt.Errorf("cannot get services from worker /services: HTTP %d", resp.StatusCode)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read body /services: %v", err)
 	}

--- a/contrib/integrations/arsenal/plugin-arsenal/main.go
+++ b/contrib/integrations/arsenal/plugin-arsenal/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -128,7 +128,7 @@ func (e *arsenalDeploymentPlugin) Run(ctx context.Context, q *integrationplugin.
 	defer res.Body.Close()
 
 	//Check the result
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 	if res.StatusCode != http.StatusOK {
 		fmt.Println("Body: ", string(body))
 		return fail("deployment failure (HTTP Status Code: %d)", res.StatusCode)
@@ -163,7 +163,7 @@ func (e *arsenalDeploymentPlugin) Run(ctx context.Context, q *integrationplugin.
 		}
 		defer res.Body.Close()
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		if res.StatusCode == http.StatusServiceUnavailable {
 			retry++
 			fmt.Println("Arsenal service unavailable, waiting for next retry")

--- a/contrib/integrations/kubernetes/plugin-kubernetes/main.go
+++ b/contrib/integrations/kubernetes/plugin-kubernetes/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -136,7 +135,7 @@ current-context: default-context`, k8sToken, certb64, k8sAPIURL)
 		}
 	}()
 
-	if err := ioutil.WriteFile(".kube/config", []byte(kubecfg), 0755); err != nil {
+	if err := os.WriteFile(".kube/config", []byte(kubecfg), 0755); err != nil {
 		return fail("Cannot write kubeconfig : %v", err)
 	}
 
@@ -211,14 +210,14 @@ func executeK8s(q *integrationplugin.RunQuery) error {
 		}
 		defer response.Body.Close()
 
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			return fmt.Errorf("Cannot read body http response: %v", err)
 		}
 		fmt.Println("Download kubectl done...")
 
 		binaryName = project + "-" + workflow + "-kubectl"
-		if err := ioutil.WriteFile(binaryName, body, 0755); err != nil {
+		if err := os.WriteFile(binaryName, body, 0755); err != nil {
 			return fmt.Errorf("Cannot write file %s for kubectl : %v", binaryName, err)
 		}
 		defer func(binName string) {

--- a/engine/api/action_test.go
+++ b/engine/api/action_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,7 +84,7 @@ func Test_postActionImportHandler(t *testing.T) {
 	req := assets.NewJWTAuthentifiedRequest(t, jwt, "POST", uri, nil)
 
 	body, _ := yaml.Marshal(a)
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	req.Body = io.NopCloser(bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request

--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -876,7 +876,7 @@ func (a *API) Serve(ctx context.Context) error {
 		var buffer = new(bytes.Buffer)
 		pprof.Lookup("heap").WriteTo(buffer, 1)
 		var heapProfile = heapProfile{uuid: sdk.UUID()}
-		s, err := a.SharedStorage.Store(heapProfile, ioutil.NopCloser(buffer))
+		s, err := a.SharedStorage.Store(heapProfile, io.NopCloser(buffer))
 		if err != nil {
 			log.Error(ctx, "unable to upload heap profile: %v", err)
 			return

--- a/engine/api/application_import_test.go
+++ b/engine/api/application_import_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -49,7 +49,7 @@ variables:
   var4:
     type: number
     value: 42`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -152,7 +152,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecrets(t *testi
 	uri = api.Router.GetRoute("POST", api.postApplicationImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -260,7 +260,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 	uri = api.Router.GetRoute("POST", api.postApplicationImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -314,7 +314,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 	uri = api.Router.GetRoute("POST", api.postApplicationImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri+"?force=true", nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -473,7 +473,7 @@ func Test_postApplicationImportHandler_NewAppFromYAMLWithKeysAndSecretsAndReImpo
 	test.NotEmpty(t, uri)
 	uri += "?force=true"
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	rec = httptest.NewRecorder()
@@ -524,7 +524,7 @@ keys:
     regen: true
   app-mySSHKey:
     type: ssh`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -586,7 +586,7 @@ func Test_postApplicationImportHandler_ExistingAppFromYAMLWithoutForce(t *testin
 
 	body := `version: v1.0
 name: myNewApp`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -620,7 +620,7 @@ func Test_postApplicationImportHandler_ExistingAppFromYAMLInheritPermissions(t *
 
 	body := `version: v1.0
 name: myNewApp`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -706,7 +706,7 @@ func Test_postApplicationImportHandler_ExistingAppWithDeploymentStrategy(t *test
 
 	body = strings.Replace(body, "my-url-2", "my-url-3", 1)
 
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -814,7 +814,7 @@ func Test_postApplicationImportHandler_DontOverrideDeploymentPasswordIfNotGiven(
 
 	buf, err := yaml.Marshal(appUpdated)
 	test.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
+	req.Body = io.NopCloser(bytes.NewReader(buf))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	rec := httptest.NewRecorder()

--- a/engine/api/ascode_test.go
+++ b/engine/api/ascode_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -48,7 +47,7 @@ func mock(f func(r *http.Request) (*http.Response, error)) cdsclient.HTTPClient 
 func writeError(w *http.Response, err error) (*http.Response, error) {
 	body := new(bytes.Buffer)
 	enc := json.NewEncoder(body)
-	w.Body = ioutil.NopCloser(body)
+	w.Body = io.NopCloser(body)
 	sdkErr := sdk.ExtractHTTPError(err)
 	enc.Encode(sdkErr)
 	w.StatusCode = sdkErr.Status
@@ -84,7 +83,7 @@ func Test_postImportAsCodeHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/github/repos/myrepo/branches/?branch=&default=true":
@@ -177,7 +176,7 @@ func Test_postPerformImportAsCodeHandler(t *testing.T) {
 				body := new(bytes.Buffer)
 				w := new(http.Response)
 				enc := json.NewEncoder(body)
-				w.Body = ioutil.NopCloser(body)
+				w.Body = io.NopCloser(body)
 				if err := enc.Encode(hookInfo); err != nil {
 					return writeError(w, err)
 				}
@@ -193,7 +192,7 @@ func Test_postPerformImportAsCodeHandler(t *testing.T) {
 				body := new(bytes.Buffer)
 				w := new(http.Response)
 				enc := json.NewEncoder(body)
-				w.Body = ioutil.NopCloser(body)
+				w.Body = io.NopCloser(body)
 				if err := enc.Encode([]sdk.VCSBranch{b}); err != nil {
 					return writeError(w, err)
 				}
@@ -218,7 +217,7 @@ func Test_postPerformImportAsCodeHandler(t *testing.T) {
 				body := new(bytes.Buffer)
 				w := new(http.Response)
 				enc := json.NewEncoder(body)
-				w.Body = ioutil.NopCloser(body)
+				w.Body = io.NopCloser(body)
 				if err := enc.Encode(hooks); err != nil {
 					return writeError(w, err)
 				}
@@ -229,7 +228,7 @@ func Test_postPerformImportAsCodeHandler(t *testing.T) {
 				body := new(bytes.Buffer)
 				w := new(http.Response)
 				enc := json.NewEncoder(body)
-				w.Body = ioutil.NopCloser(body)
+				w.Body = io.NopCloser(body)
 
 				ope := new(sdk.Operation)
 				ope.URL = "https://github.com/fsamin/go-repo.git"
@@ -359,7 +358,7 @@ vcs_ssh_key: proj-blabla
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/github/repos/sguiheux/demo/pullrequests/666":

--- a/engine/api/download/download_test.go
+++ b/engine/api/download/download_test.go
@@ -2,14 +2,13 @@ package download
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestInit(t *testing.T) {
-	tmpDir1, _ := ioutil.TempDir(os.TempDir(), "download1")
-	tmpDir2, _ := ioutil.TempDir(os.TempDir(), "download2")
+	tmpDir1, _ := os.MkdirTemp(os.TempDir(), "download1")
+	tmpDir2, _ := os.MkdirTemp(os.TempDir(), "download2")
 	defer os.RemoveAll(tmpDir1)
 	defer os.RemoveAll(tmpDir2)
 

--- a/engine/api/environment_import_test.go
+++ b/engine/api/environment_import_test.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -44,7 +44,7 @@ variables:
   var4:
     type: number
     value: 42`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -148,7 +148,7 @@ func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecrets(t *testi
 	uri = api.Router.GetRoute("POST", api.postEnvironmentImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -265,7 +265,7 @@ func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecretsAndReImpo
 	uri = api.Router.GetRoute("POST", api.postEnvironmentImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -326,7 +326,7 @@ func Test_postEnvironmentImportHandler_NewEnvFromYAMLWithKeysAndSecretsAndReImpo
 	uri = api.Router.GetRoute("POST", api.postEnvironmentImportHandler, vars)
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri+"?force=true", nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -402,7 +402,7 @@ keys:
     type: pgp
   env-mySSHKey:
     type: ssh`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -468,7 +468,7 @@ func Test_postEnvironmentImportHandler_ExistingAppFromYAMLWithoutForce(t *testin
 
 	body := `version: v1.0
 name: myNewEnv`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -503,7 +503,7 @@ func Test_postEnvironmentImportHandler_ExistingAppFromYAMLInheritPermissions(t *
 
 	body := `version: v1.0
 name: myNewEnv`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request

--- a/engine/api/grpc_plugin.go
+++ b/engine/api/grpc_plugin.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -195,11 +194,11 @@ func (api *API) postGRPCluginBinaryHandler() service.Handler {
 
 		old := p.GetBinary(b.OS, b.Arch)
 		if old == nil {
-			if err := plugin.AddBinary(ctx, tx, api.SharedStorage, p, &b, ioutil.NopCloser(buff)); err != nil {
+			if err := plugin.AddBinary(ctx, tx, api.SharedStorage, p, &b, io.NopCloser(buff)); err != nil {
 				return sdk.WrapError(err, "unable to add plugin binary")
 			}
 		} else {
-			if err := plugin.UpdateBinary(ctx, tx, api.SharedStorage, p, &b, ioutil.NopCloser(buff)); err != nil {
+			if err := plugin.UpdateBinary(ctx, tx, api.SharedStorage, p, &b, io.NopCloser(buff)); err != nil {
 				return sdk.WrapError(err, "unable to add plugin binary")
 			}
 		}

--- a/engine/api/navbar/navbar.go
+++ b/engine/api/navbar/navbar.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/go-gorp/gorp"
 
-	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/group"
+	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/sdk"
 )
 

--- a/engine/api/notification/permission.go
+++ b/engine/api/notification/permission.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/go-gorp/gorp"
 
-	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/api/group"
 	"github.com/ovh/cds/engine/api/project"
+	"github.com/ovh/cds/engine/cache"
 )
 
 // projectPermissionUsers Get users that access to given project, without default group

--- a/engine/api/objectstore/ssh.go
+++ b/engine/api/objectstore/ssh.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/ovh/cds/sdk"
@@ -67,7 +66,7 @@ func (s *SSHStore) read(session *ssh.Session, path string) (io.ReadCloser, error
 		return nil, err
 	}
 
-	return ioutil.NopCloser(bytes.NewReader(output)), nil
+	return io.NopCloser(bytes.NewReader(output)), nil
 }
 
 // Store store a object on disk

--- a/engine/api/pipeline_import_test.go
+++ b/engine/api/pipeline_import_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -43,7 +42,7 @@ jobs:
   - script:
     - echo "test"
     - echo {{.limit | default ""}}`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -89,7 +88,7 @@ jobs:
   - script:
     - echo "test"
     - echo {{.limit | default ""}}`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -115,7 +114,7 @@ func Test_putPipelineImportJSONWithoutVersionHandler(t *testing.T) {
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri+"?format=json", nil)
 
 	bodyjson := `{"name":"testest","stages":["Stage 1"],"jobs":[{"job":"echo with default","stage":"Stage 1","steps":[{"script":["echo \"test\"","echo {{.limit | default \"\"}}"]}]}]}`
-	req.Body = ioutil.NopCloser(strings.NewReader(bodyjson))
+	req.Body = io.NopCloser(strings.NewReader(bodyjson))
 	req.Header.Set("Content-Type", "application/json")
 
 	//Do the request
@@ -153,7 +152,7 @@ options:
         value: ""
 jobs:
 - job: New Job`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -183,7 +182,7 @@ jobs:
   - script:
     - echo "coucou"
 `
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request

--- a/engine/api/pipeline_test.go
+++ b/engine/api/pipeline_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -59,13 +58,13 @@ func TestUpdateAsCodePipelineHandler(t *testing.T) {
 		_ = services.Delete(db, b) // nolint
 		_ = services.Delete(db, c) // nolint
 	}()
-	//This is a mock for the repositories service
+	// This is a mock for the repositories service
 	services.HTTPClient = mock(
 		func(r *http.Request) (*http.Response, error) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			w.StatusCode = http.StatusOK
 			switch r.URL.String() {
 			case "/operations":

--- a/engine/api/repositories_manager_test.go
+++ b/engine/api/repositories_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +51,7 @@ func TestAPI_detachRepositoriesManagerHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO

--- a/engine/api/router_middleware_tracing.go
+++ b/engine/api/router_middleware_tracing.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/go-gorp/gorp"
-	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/observability"
+	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk/telemetry"
 )

--- a/engine/api/timeline_test.go
+++ b/engine/api/timeline_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +63,7 @@ func Test_getTimelineHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			requestBody := new(bytes.Buffer)
 			if _, err := requestBody.ReadFrom(r.Body); err != nil {
 				return writeError(w, err)

--- a/engine/api/workflow/dao_run_test.go
+++ b/engine/api/workflow/dao_run_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -93,7 +93,7 @@ func TestPurgeWorkflowRun(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -358,7 +358,7 @@ func TestPurgeWorkflowRunWithOneSuccessWorkflowRun(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -558,7 +558,7 @@ func TestPurgeWorkflowRunWithNoSuccessWorkflowRun(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO

--- a/engine/api/workflow/dao_test.go
+++ b/engine/api/workflow/dao_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -1357,7 +1356,7 @@ func TestInsertSimpleWorkflowWithHookAndExport(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -1643,7 +1642,7 @@ func TestInsertAndDeleteMultiHook(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 
@@ -1950,7 +1949,7 @@ func TestDeleteWorkflowWithDependencies(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 			case "/vcs/github/repos/sguiheux/demo":
@@ -2143,7 +2142,7 @@ func TestDeleteWorkflowWithDependencies2(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 			case "/vcs/github/repos/sguiheux/demo":

--- a/engine/api/workflow/process_node_test.go
+++ b/engine/api/workflow/process_node_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -81,7 +80,7 @@ func TestHookRunWithoutPayloadProcessNodeBuildParameter(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 			case "/vcs/github/repos/sguiheux/demo":
@@ -275,7 +274,7 @@ func TestHookRunWithHashOnlyProcessNodeBuildParameter(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 			case "/vcs/github/repos/sguiheux/demo":
@@ -452,7 +451,7 @@ func TestManualRunWithPayloadProcessNodeBuildParameter(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -598,13 +597,13 @@ func TestManualRunBranchAndCommitInPayloadProcessNodeBuildParameter(t *testing.T
 		services.Delete(db, mockVCSSservice)
 	}()
 
-	//This is a mock for the vcs service
+	// This is a mock for the vcs service
 	services.HTTPClient = mock(
 		func(r *http.Request) (*http.Response, error) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -745,7 +744,7 @@ func TestManualRunBranchAndRepositoryInPayloadProcessNodeBuildParameter(t *testi
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -989,7 +988,7 @@ func TestManualRunBuildParameterMultiApplication(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/stash/repos/ovh/cds":
@@ -1231,7 +1230,7 @@ func TestManualRunBuildParameterNoApplicationOnRoot(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/stash/repos/ovh/cds":
@@ -1463,7 +1462,7 @@ func TestGitParamOnPipelineWithoutApplication(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -1650,7 +1649,7 @@ func TestGitParamOnApplicationWithoutRepo(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -1836,7 +1835,7 @@ func TestGitParamOn2ApplicationSameRepo(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -2039,7 +2038,7 @@ func TestGitParamWithJoin(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -2377,7 +2376,7 @@ func TestGitParamOn2ApplicationSameRepoWithFork(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -2585,7 +2584,7 @@ func TestManualRunWithPayloadAndRunCondition(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			// NEED get REPO
@@ -2880,7 +2879,7 @@ func (m *mockServiceClient) Do(r *http.Request) (*http.Response, error) {
 func writeError(w *http.Response, err error) (*http.Response, error) {
 	body := new(bytes.Buffer)
 	enc := json.NewEncoder(body)
-	w.Body = ioutil.NopCloser(body)
+	w.Body = io.NopCloser(body)
 	sdkErr := sdk.ExtractHTTPError(err)
 	_ = enc.Encode(sdkErr) // nolint
 	w.StatusCode = sdkErr.Status

--- a/engine/api/workflow/workflow_importer_test.go
+++ b/engine/api/workflow/workflow_importer_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"testing"
@@ -25,7 +25,7 @@ type mockHTTPClient struct {
 }
 
 func (h *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
-	body := ioutil.NopCloser(bytes.NewReader([]byte("{}")))
+	body := io.NopCloser(bytes.NewReader([]byte("{}")))
 	return &http.Response{Body: body}, nil
 }
 

--- a/engine/api/workflow/workflow_parser_test.go
+++ b/engine/api/workflow/workflow_parser_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -149,7 +148,7 @@ func TestParseAndImportFromRepository(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			w.StatusCode = http.StatusOK
 			switch r.URL.String() {
 			case "/operations":

--- a/engine/api/workflow_application_test.go
+++ b/engine/api/workflow_application_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +37,7 @@ func Test_releaseApplicationWorkflowHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			wri := new(http.Response)
 			enc := json.NewEncoder(body)
-			wri.Body = ioutil.NopCloser(body)
+			wri.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/github/repos/myproj/myapp":

--- a/engine/api/workflow_ascode_test.go
+++ b/engine/api/workflow_ascode_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -80,7 +79,7 @@ func TestPostUpdateWorkflowAsCodeHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			w.StatusCode = http.StatusOK
 			switch r.URL.String() {
 			case "/operations":
@@ -287,7 +286,7 @@ func TestPostMigrateWorkflowAsCodeHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			w.StatusCode = http.StatusOK
 			switch r.URL.String() {
 			case "/operations":

--- a/engine/api/workflow_import_test.go
+++ b/engine/api/workflow_import_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"sort"
 	"strings"
@@ -60,7 +60,7 @@ workflow:
     pipeline: pip1
 metadata:
   default_tags: git.branch,git.author,git.hash`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -132,7 +132,7 @@ workflow:
 permissions:
   ` + g1.Name + `: 5
   ` + g2.Name + `: 7`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -192,7 +192,7 @@ workflow:
     pipeline: pip1
 metadata:
   default_tags: git.branch,git.author,git.hash`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request
@@ -284,7 +284,7 @@ workflow:
       - pip1
     pipeline: pip1`
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rec = httptest.NewRecorder()
 	api.Router.Mux.ServeHTTP(rec, req)
@@ -410,7 +410,7 @@ metadata:
   default_tags: git.branch,git.tag`
 
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rec = httptest.NewRecorder()
 	api.Router.Mux.ServeHTTP(rec, req)
@@ -542,7 +542,7 @@ metadata:
   default_tags: git.branch,git.tag`
 
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rec = httptest.NewRecorder()
 	api.Router.Mux.ServeHTTP(rec, req)
@@ -680,7 +680,7 @@ metadata:
   default_tags: git.branch,git.tag`
 
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rec = httptest.NewRecorder()
 	api.Router.Mux.ServeHTTP(rec, req)
@@ -842,7 +842,7 @@ func Test_getWorkflowPushHandler(t *testing.T) {
 
 	test.NotEmpty(t, uri)
 	req = assets.NewAuthentifiedRequest(t, u, pass, "POST", uri+"?force=true", nil)
-	req.Body = ioutil.NopCloser(r)
+	req.Body = io.NopCloser(r)
 	req.Header.Set("Content-Type", "application/tar")
 
 	//Do the request
@@ -971,7 +971,7 @@ metadata:
 `
 
 	req := assets.NewAuthentifiedRequest(t, u, pass, "PUT", uri, nil)
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rec = httptest.NewRecorder()
 	api.Router.Mux.ServeHTTP(rec, req)
@@ -1022,7 +1022,7 @@ version: v2.0
 workflow:
   pip1:
     pipeline: pip1`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	rec := httptest.NewRecorder()
@@ -1062,7 +1062,7 @@ workflow:
 permissions:
   ` + proj.ProjectGroups[0].Group.Name + `: 7
   ` + g2.Name + `: 4`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	rec = httptest.NewRecorder()
@@ -1096,7 +1096,7 @@ version: v2.0
 workflow:
   pip1:
     pipeline: pip1`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	rec = httptest.NewRecorder()
@@ -1192,7 +1192,7 @@ integrations:
         value: myvalue
 metadata:
   default_tags: git.branch,git.author,git.hash`
-	req.Body = ioutil.NopCloser(strings.NewReader(body))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-yaml")
 
 	//Do the request

--- a/engine/api/workflow_queue_test.go
+++ b/engine/api/workflow_queue_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1451,7 +1450,7 @@ func TestInsertNewCodeCoverageReport(t *testing.T) {
 			body := new(bytes.Buffer)
 			wri := new(http.Response)
 			enc := json.NewEncoder(body)
-			wri.Body = ioutil.NopCloser(body)
+			wri.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/repoManServ/repos/foo/bar":

--- a/engine/api/workflow_run_test.go
+++ b/engine/api/workflow_run_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1311,7 +1310,7 @@ func Test_postWorkflowRunAsyncFailedHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/operations/123":
@@ -1632,7 +1631,7 @@ func Test_postWorkflowRunHandlerWithoutRightConditionsOnHook(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/task/bulk":
@@ -1801,7 +1800,7 @@ func Test_postWorkflowRunHandlerHookWithMutex(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/task/bulk":
@@ -2259,7 +2258,7 @@ func Test_postWorkflowRunHandlerHook(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/task/bulk":

--- a/engine/api/workflow_test.go
+++ b/engine/api/workflow_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -668,7 +667,7 @@ func Test_putWorkflowHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 
 			switch r.URL.String() {
 			case "/vcs/github/repos/foo/bar/branches/?branch=&default=true":
@@ -1958,7 +1957,7 @@ func Test_getWorkfloDependencieswHandler(t *testing.T) {
 			body := new(bytes.Buffer)
 			w := new(http.Response)
 			enc := json.NewEncoder(body)
-			w.Body = ioutil.NopCloser(body)
+			w.Body = io.NopCloser(body)
 			switch r.URL.String() {
 			// NEED get REPO
 			case "/vcs/github/repos/sguiheux/demo":

--- a/engine/cache/redis.go
+++ b/engine/cache/redis.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdlog "log"
 	"math"
 	"reflect"
@@ -59,7 +58,7 @@ func NewRedisStore(host, password string, ttl int) (*RedisStore, error) {
 		})
 	}
 
-	redis.SetLogger(stdlog.New(ioutil.Discard, "", stdlog.LstdFlags|stdlog.Lshortfile))
+	redis.SetLogger(stdlog.New(io.Discard, "", stdlog.LstdFlags|stdlog.Lshortfile))
 
 	pong, err := client.Ping().Result()
 	if err != nil {

--- a/engine/cdn/cdn_gc_test.go
+++ b/engine/cdn/cdn_gc_test.go
@@ -2,7 +2,7 @@ package cdn
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -42,7 +42,7 @@ func TestCleanSynchronizedItem(t *testing.T) {
 	}
 	s.GoRoutines = sdk.NewGoRoutines(context.TODO())
 
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
@@ -171,7 +171,7 @@ func TestCleanSynchronizedItemWithDisabledStorage(t *testing.T) {
 	}
 	s.GoRoutines = sdk.NewGoRoutines(context.TODO())
 
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)

--- a/engine/cdn/cdn_sync_test.go
+++ b/engine/cdn/cdn_sync_test.go
@@ -2,7 +2,7 @@ package cdn
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,7 @@ func TestSyncBuffer(t *testing.T) {
 	cdntest.ClearItem(t, context.Background(), m, db)
 	cdntest.ClearUnits(t, context.Background(), m, db)
 
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-*")
 	require.NoError(t, err)
 
 	// Create cdn service

--- a/engine/cdn/cdn_test.go
+++ b/engine/cdn/cdn_test.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -114,10 +114,10 @@ var fakeAPIPrivateKey = struct {
 
 func newRunningStorageUnits(t *testing.T, m *gorpmapper.Mapper, dbMap *gorp.DbMap, ctx context.Context, store cache.Store) *storage.RunningStorageUnits {
 	cfg := test.LoadTestingConf(t, sdk.TypeCDN)
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
-	tmpDirBuf, err := ioutil.TempDir("", t.Name()+"-cdn-1-buf-*")
+	tmpDirBuf, err := os.MkdirTemp("", t.Name()+"-cdn-1-buf-*")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/engine/cdn/item_upload_test.go
+++ b/engine/cdn/item_upload_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,10 +46,10 @@ func TestPostUploadHandler(t *testing.T) {
 	// Start CDN
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
-	tmpDir2, err := ioutil.TempDir("", t.Name()+"-cdn-2-*")
+	tmpDir2, err := os.MkdirTemp("", t.Name()+"-cdn-2-*")
 	require.NoError(t, err)
 
 	cdnUnits, err := storage.Init(ctx, s.Mapper, s.Cache, db.DbMap, sdk.NewGoRoutines(ctx), storage.Configuration{

--- a/engine/cdn/storage/dao_test.go
+++ b/engine/cdn/storage/dao_test.go
@@ -2,7 +2,7 @@ package storage_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -42,7 +42,7 @@ func TestLoadAllItemIDUnknownByUnit(t *testing.T) {
 	i4 := sdk.CDNItem{ID: sdk.UUID(), APIRefHash: sdk.RandomString(10), Status: sdk.CDNStatusItemCompleted}
 	require.NoError(t, item.Insert(context.TODO(), m, db, &i4))
 
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)

--- a/engine/cdn/storage/storageunit_test.go
+++ b/engine/cdn/storage/storageunit_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -42,9 +41,9 @@ func TestDeduplicationCrossType(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	t.Cleanup(cancel)
 
-	bufferDir, err := ioutil.TempDir("", t.Name()+"-cdnbuffer-1-*")
+	bufferDir, err := os.MkdirTemp("", t.Name()+"-cdnbuffer-1-*")
 	require.NoError(t, err)
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
 	cdnUnits, err := storage.Init(ctx, m, cache, db.DbMap, sdk.NewGoRoutines(ctx), storage.Configuration{
@@ -237,9 +236,9 @@ func TestRun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	t.Cleanup(cancel)
 
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
-	tmpDir2, err := ioutil.TempDir("", t.Name()+"-cdn-2-*")
+	tmpDir2, err := os.MkdirTemp("", t.Name()+"-cdn-2-*")
 	require.NoError(t, err)
 
 	cdnUnits, err := storage.Init(ctx, m, cache, db.DbMap, sdk.NewGoRoutines(ctx), storage.Configuration{

--- a/engine/cdn/storage/webdav/webdav_test.go
+++ b/engine/cdn/storage/webdav/webdav_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ import (
 
 func TestWebdav(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
-	dir, err := ioutil.TempDir("", t.Name()+"-cdn-webdav-*")
+	dir, err := os.MkdirTemp("", t.Name()+"-cdn-webdav-*")
 	require.NoError(t, err)
 	srv := &webdav.Handler{
 		FileSystem: webdav.Dir(dir),

--- a/engine/cdn/unit_handler_test.go
+++ b/engine/cdn/unit_handler_test.go
@@ -3,6 +3,11 @@ package cdn
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/ovh/cds/engine/cdn/item"
 	"github.com/ovh/cds/engine/cdn/storage"
 	cdntest "github.com/ovh/cds/engine/cdn/test"
@@ -14,11 +19,6 @@ import (
 	"github.com/ovh/symmecrypt/keyloader"
 	"github.com/rockbears/log"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"net/http/httptest"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestMarkItemUnitAsDeleteHandler(t *testing.T) {
@@ -115,10 +115,10 @@ func TestPostAdminResyncBackendWithDatabaseHandler(t *testing.T) {
 	// Start CDN
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-cdn-1-*")
+	tmpDir, err := os.MkdirTemp("", t.Name()+"-cdn-1-*")
 	require.NoError(t, err)
 
-	tmpDir2, err := ioutil.TempDir("", t.Name()+"-cdn-2-*")
+	tmpDir2, err := os.MkdirTemp("", t.Name()+"-cdn-2-*")
 	require.NoError(t, err)
 
 	cdnUnits, err := storage.Init(ctx, s.Mapper, s.Cache, db.DbMap, sdk.NewGoRoutines(ctx), storage.Configuration{

--- a/engine/cmd_config.go
+++ b/engine/cmd_config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -282,7 +281,7 @@ var configEditCmd = &cobra.Command{
 			sdk.Exit("File %s doesn't exist", cfgFile)
 		}
 
-		btes, err := ioutil.ReadFile(cfgFile)
+		btes, err := os.ReadFile(cfgFile)
 		if err != nil {
 			sdk.Exit("Error while read content of file %s - err:%v", cfgFile, err)
 		}
@@ -308,7 +307,7 @@ var configEditCmd = &cobra.Command{
 		}
 
 		tmpFile := "cds.tmp.toml"
-		if err := ioutil.WriteFile(tmpFile, []byte(tomlConf.String()), os.FileMode(0640)); err != nil {
+		if err := os.WriteFile(tmpFile, []byte(tomlConf.String()), os.FileMode(0640)); err != nil {
 			sdk.Exit("Error while create tempfile: %v", err)
 		}
 		defer os.Remove(tmpFile)

--- a/engine/cmd_database.go
+++ b/engine/cmd_database.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -171,7 +170,7 @@ func databaseDownloadSQLTarGz(currentVersion string, artifactName string, migrat
 		return fmt.Errorf("invalid content type: %s", err.Error())
 	}
 
-	tmpfile, err := ioutil.TempFile(os.TempDir(), artifactName)
+	tmpfile, err := os.CreateTemp(os.TempDir(), artifactName)
 	if err != nil {
 		sdk.Exit(err.Error())
 	}
@@ -189,7 +188,7 @@ func databaseDownloadSQLTarGz(currentVersion string, artifactName string, migrat
 	fmt.Printf("Unarchive to %s\n", dest)
 
 	dirFiles := dest + "/sql"
-	files, err := ioutil.ReadDir(dirFiles)
+	files, err := os.ReadDir(dirFiles)
 	if err != nil {
 		return fmt.Errorf("error on readDir %s", dirFiles)
 	}

--- a/engine/hatchery/hatchery_helper_test.go
+++ b/engine/hatchery/hatchery_helper_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -91,7 +90,7 @@ func InitMock(t *testing.T, url string) {
 		}
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 		}

--- a/engine/hatchery/marathon/marathon_test.go
+++ b/engine/hatchery/marathon/marathon_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -290,7 +289,7 @@ func TestSpawnWorkerTimeout(t *testing.T) {
 		}
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			switch {
 			case request.Method == http.MethodPost && request.URL.String() == "http://mara.thon/v2/apps":

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -84,20 +83,20 @@ func (h *HatcherySwarm) InitHatchery(ctx context.Context) error {
 					continue
 				}
 			} else if cfg.TLSCAPEM != "" && cfg.TLSCERTPEM != "" && cfg.TLSKEYPEM != "" {
-				tempDir, err := ioutil.TempDir("", "cert-"+hostName)
+				tempDir, err := os.MkdirTemp("", "cert-"+hostName)
 				if err != nil {
 					log.Error(ctx, "hatchery> swarm> docker client error: unable to create temp dir: %v", err)
 					continue
 				}
-				if err := ioutil.WriteFile(filepath.Join(tempDir, "ca.pem"), []byte(cfg.TLSCAPEM), os.FileMode(0600)); err != nil {
+				if err := os.WriteFile(filepath.Join(tempDir, "ca.pem"), []byte(cfg.TLSCAPEM), os.FileMode(0600)); err != nil {
 					log.Error(ctx, "hatchery> swarm> docker client error: unable to create ca.pem: %v", err)
 					continue
 				}
-				if err := ioutil.WriteFile(filepath.Join(tempDir, "cert.pem"), []byte(cfg.TLSCERTPEM), os.FileMode(0600)); err != nil {
+				if err := os.WriteFile(filepath.Join(tempDir, "cert.pem"), []byte(cfg.TLSCERTPEM), os.FileMode(0600)); err != nil {
 					log.Error(ctx, "hatchery> swarm> docker client error: unable to create cert.pem: %v", err)
 					continue
 				}
-				if err := ioutil.WriteFile(filepath.Join(tempDir, "key.pem"), []byte(cfg.TLSKEYPEM), os.FileMode(0600)); err != nil {
+				if err := os.WriteFile(filepath.Join(tempDir, "key.pem"), []byte(cfg.TLSKEYPEM), os.FileMode(0600)); err != nil {
 					log.Error(ctx, "hatchery> swarm> docker client error: unable to create key.pem:  %v", err)
 					continue
 				}

--- a/engine/test/config/load.go
+++ b/engine/test/config/load.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -21,7 +20,7 @@ func LoadTestingConf(t require.TestingT, serviceType string) map[string]string {
 	_, err := os.Stat(f)
 	require.NoError(t, err, "error no test configuration file found at %s", f)
 
-	btes, err := ioutil.ReadFile(f)
+	btes, err := os.ReadFile(f)
 	require.NoError(t, err, "error reading test configuration file from %s", f)
 	if len(btes) != 0 {
 		cfg := map[string]string{}

--- a/engine/ui/ui.go
+++ b/engine/ui/ui.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -159,7 +158,7 @@ func (s *Service) checkChecksumFiles() error {
 	log.Debug(context.Background(), "ui> checking checksum files...")
 
 	filesUI := filepath.Join(s.HTMLDir, "FILES_UI")
-	content, err := ioutil.ReadFile(filesUI)
+	content, err := os.ReadFile(filesUI)
 	if err != nil {
 		return sdk.WrapError(err, "error while reading file %s", filesUI)
 	}
@@ -230,7 +229,7 @@ func (s *Service) prepareIndexHTML() (bool, error) {
 func (s *Service) indexHTMLReplaceVar() error {
 	indexHTML := filepath.Join(s.HTMLDir, "index.html")
 
-	read, err := ioutil.ReadFile(indexHTML)
+	read, err := os.ReadFile(indexHTML)
 	if err != nil {
 		return sdk.WrapError(err, "error while reading %s file", indexHTML)
 	}
@@ -244,7 +243,7 @@ func (s *Service) indexHTMLReplaceVar() error {
 	if s.Cfg.SentryURL != "" {
 		indexContent = strings.Replace(indexContent, "window.cds_sentry_url = '';", "window.cds_sentry_url = '"+s.Cfg.SentryURL+"';", -1)
 	}
-	return ioutil.WriteFile(indexHTML, []byte(indexContent), 0)
+	return os.WriteFile(indexHTML, []byte(indexContent), 0)
 }
 
 func (s *Service) askForGettingStaticFiles(ctx context.Context, version string) error {

--- a/engine/vcs/bitbucketcloud/http.go
+++ b/engine/vcs/bitbucketcloud/http.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -177,7 +176,7 @@ func (client *bitbucketcloudClient) do(ctx context.Context, method, api, path st
 
 	if len(values) > 0 {
 		buf := bytes.NewBuffer(values)
-		req.Body = ioutil.NopCloser(buf)
+		req.Body = io.NopCloser(buf)
 		req.ContentLength = int64(buf.Len())
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.OAuthToken))

--- a/engine/vcs/bitbucketserver/http.go
+++ b/engine/vcs/bitbucketserver/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
@@ -111,7 +110,7 @@ func (c *bitbucketClient) do(ctx context.Context, method, api, path string, para
 
 	if values != nil && len(values) > 0 {
 		buf := bytes.NewBuffer(values)
-		req.Body = ioutil.NopCloser(buf)
+		req.Body = io.NopCloser(buf)
 		req.ContentLength = int64(buf.Len())
 	}
 

--- a/engine/worker/cmd_junit_parser.go
+++ b/engine/worker/cmd_junit_parser.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ovh/venom"
@@ -49,7 +49,7 @@ func junitParserCmd() func(cmd *cobra.Command, args []string) error {
 		var tests venom.Tests
 		for _, f := range filepaths {
 			var ftests venom.Tests
-			data, err := ioutil.ReadFile(f)
+			data, err := os.ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("junit parser: cannot read file %s (%s)", f, err)
 			}

--- a/engine/worker/internal/action/builtin_artifact_upload_test.go
+++ b/engine/worker/internal/action/builtin_artifact_upload_test.go
@@ -3,7 +3,6 @@ package action
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -26,7 +25,7 @@ func TestRunArtifactUpload_Absolute(t *testing.T) {
 		{Name: "cds.project", Value: "project"},
 	}
 
-	assert.NoError(t, ioutil.WriteFile("foo", []byte("something"), os.ModePerm))
+	assert.NoError(t, os.WriteFile("foo", []byte("something"), os.ModePerm))
 
 	fi, err := os.Open("foo")
 	require.NoError(t, err)
@@ -44,7 +43,7 @@ func TestRunArtifactUpload_Absolute(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 		}
@@ -108,7 +107,7 @@ func TestRunArtifactUpload_Relative(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 		}

--- a/engine/worker/internal/action/builtin_coverage_test.go
+++ b/engine/worker/internal/action/builtin_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -49,7 +48,7 @@ func TestRunCoverage_Absolute(t *testing.T) {
 	defer gock.Off()
 
 	wk, ctx := SetupTest(t)
-	assert.NoError(t, ioutil.WriteFile("results.xml", []byte(cobertura_result), os.ModePerm))
+	assert.NoError(t, os.WriteFile("results.xml", []byte(cobertura_result), os.ModePerm))
 	defer os.RemoveAll("results.xml")
 
 	fi, err := os.Open("results.xml")
@@ -63,7 +62,7 @@ func TestRunCoverage_Absolute(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {
@@ -117,7 +116,7 @@ func TestRunCoverage_Relative(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {
@@ -162,7 +161,7 @@ func TestRunCoverageMinimumFail(t *testing.T) {
 	defer gock.Off()
 
 	wk, ctx := SetupTest(t)
-	assert.NoError(t, ioutil.WriteFile("results.xml", []byte(cobertura_result), os.ModePerm))
+	assert.NoError(t, os.WriteFile("results.xml", []byte(cobertura_result), os.ModePerm))
 	defer os.RemoveAll("results.xml")
 
 	fi, err := os.Open("results.xml")
@@ -176,7 +175,7 @@ func TestRunCoverageMinimumFail(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {

--- a/engine/worker/internal/action/builtin_gittag.go
+++ b/engine/worker/internal/action/builtin_gittag.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"time"
 
@@ -117,10 +117,10 @@ func RunGitTag(ctx context.Context, wk workerruntime.Runtime, a sdk.Action, secr
 		tagOpts.SignKey = auth.SignKey.Private
 		tagOpts.SignID = auth.SignKey.ID
 
-		if err := ioutil.WriteFile("pgp.pub.key", []byte(auth.SignKey.Public), 0600); err != nil {
+		if err := os.WriteFile("pgp.pub.key", []byte(auth.SignKey.Public), 0600); err != nil {
 			return sdk.Result{}, fmt.Errorf("Cannot create pgp pub key file")
 		}
-		if err := ioutil.WriteFile("pgp.key", []byte(tagOpts.SignKey), 0600); err != nil {
+		if err := os.WriteFile("pgp.key", []byte(tagOpts.SignKey), 0600); err != nil {
 			return sdk.Result{}, fmt.Errorf("Cannot create pgp key file")
 		}
 	}

--- a/engine/worker/internal/action/builtin_junit_test.go
+++ b/engine/worker/internal/action/builtin_junit_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func TestRunParseJunitTestResultAction_Absolute(t *testing.T) {
 	defer gock.Off()
 
 	wk, ctx := SetupTest(t)
-	assert.NoError(t, ioutil.WriteFile("results.xml", []byte(fileContent), os.ModePerm))
+	assert.NoError(t, os.WriteFile("results.xml", []byte(fileContent), os.ModePerm))
 	defer os.RemoveAll("results.xml")
 
 	fi, err := os.Open("results.xml")
@@ -58,7 +57,7 @@ func TestRunParseJunitTestResultAction_Absolute(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {
@@ -123,7 +122,7 @@ func TestRunParseJunitTestResultAction_Relative(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {

--- a/engine/worker/internal/action/builtin_release_vcs_test.go
+++ b/engine/worker/internal/action/builtin_release_vcs_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestRunRelease(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			t.Logf("%s %s - Body: %s", mock.Request().Method, mock.Request().URLStruct.String(), string(bodyContent))
 			switch mock.Request().URLStruct.String() {

--- a/engine/worker/internal/handler_cache_test.go
+++ b/engine/worker/internal/handler_cache_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -83,7 +82,7 @@ func Test_cachePushPullHandler(t *testing.T) {
 	absoluteFilePath, err := filepath.Abs(afero.FullBaseFsPath(wkPush.basedir.(*afero.BasePathFs), "/absolute.txt"))
 	require.NoError(t, err)
 	t.Logf("Creating absolute file at %s", absoluteFilePath)
-	require.NoError(t, ioutil.WriteFile(absoluteFilePath, []byte("absolute"), os.FileMode(0755)))
+	require.NoError(t, os.WriteFile(absoluteFilePath, []byte("absolute"), os.FileMode(0755)))
 
 	// Prepare mock client for cds workers
 	ctrl := gomock.NewController(t)
@@ -167,11 +166,11 @@ func Test_cachePushPullHandler(t *testing.T) {
 	_, err = os.Stat(expectedAbsolutePath)
 	require.NoError(t, err, "absolute pulled file should exists")
 
-	btsRelative, err := ioutil.ReadFile(expectedRelativePath)
+	btsRelative, err := os.ReadFile(expectedRelativePath)
 	require.NoError(t, err)
 	assert.Equal(t, "relative", string(btsRelative))
 
-	btsAbsolute, err := ioutil.ReadFile(expectedAbsolutePath)
+	btsAbsolute, err := os.ReadFile(expectedAbsolutePath)
 	require.NoError(t, err)
 	assert.Equal(t, "absolute", string(btsAbsolute))
 }

--- a/engine/worker/internal/handler_check_secret.go
+++ b/engine/worker/internal/handler_check_secret.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/ovh/cds/engine/worker/pkg/workerruntime"
@@ -30,7 +30,7 @@ func checkSecretHandler(ctx context.Context, wk *CurrentWorker) http.HandlerFunc
 			return
 		}
 
-		btes, err := ioutil.ReadFile(a.Path)
+		btes, err := os.ReadFile(a.Path)
 		if err != nil {
 			returnHTTPError(ctx, w, 400, fmt.Errorf("failed to read file %s", a.Path))
 			return

--- a/engine/worker/internal/handler_tmpl.go
+++ b/engine/worker/internal/handler_tmpl.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -35,7 +34,7 @@ func tmplHandler(ctx context.Context, wk *CurrentWorker) http.HandlerFunc {
 			return
 		}
 
-		btes, err := ioutil.ReadFile(a.Path)
+		btes, err := os.ReadFile(a.Path)
 		if err != nil {
 			newError := sdk.NewError(sdk.ErrWrongRequest, err)
 			writeError(w, r, newError)
@@ -61,7 +60,7 @@ func tmplHandler(ctx context.Context, wk *CurrentWorker) http.HandlerFunc {
 			return
 		}
 
-		if err := ioutil.WriteFile(a.Destination, []byte(res), os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(a.Destination, []byte(res), os.FileMode(0644)); err != nil {
 			log.Error(ctx, "tmpl> Unable to write file: %v", err)
 			writeError(w, r, sdk.NewError(sdk.ErrWrongRequest, err))
 			return

--- a/engine/worker/internal/keys.go
+++ b/engine/worker/internal/keys.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -56,7 +55,7 @@ func (wk *CurrentWorker) InstallKey(key sdk.Variable) (*workerruntime.KeyRespons
 			}
 		}
 		content := []byte(key.Value)
-		tmpfile, errTmpFile := ioutil.TempFile("", key.Name)
+		tmpfile, errTmpFile := os.CreateTemp("", key.Name)
 		if errTmpFile != nil {
 			return nil, sdk.NewError(sdk.ErrWorkerErrorCommand, fmt.Errorf("Cannot setup pgp key %s : %v", key.Name, errTmpFile))
 		}
@@ -138,7 +137,7 @@ func (wk *CurrentWorker) InstallKeyTo(key sdk.Variable, destinationPath string) 
 			}
 		}
 		content := []byte(key.Value)
-		tmpfile, errTmpFile := ioutil.TempFile("", key.Name)
+		tmpfile, errTmpFile := os.CreateTemp("", key.Name)
 		if errTmpFile != nil {
 			return nil, sdk.NewError(sdk.ErrWorkerErrorCommand, fmt.Errorf("Cannot setup pgp key %s : %v", key.Name, errTmpFile))
 		}

--- a/engine/worker/internal/keys_test.go
+++ b/engine/worker/internal/keys_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -91,7 +90,7 @@ func TestInstallKey_SSHKeyWithoutDestination(t *testing.T) {
 	resp, err := w.InstallKey(priKeyVar)
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(resp.PKey)
+	content, err := os.ReadFile(resp.PKey)
 	require.NoError(t, err)
 	assert.Equal(t, string(priKeyPEM), string(content))
 
@@ -135,7 +134,7 @@ func TestInstallKey_SSHKeyWithRelativeDestination(t *testing.T) {
 	resp, err := w.InstallKeyTo(priKeyVar, "ssh/id_rsa")
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(resp.PKey)
+	content, err := os.ReadFile(resp.PKey)
 	require.NoError(t, err)
 	assert.Equal(t, string(priKeyPEM), string(content))
 	t.Logf("the path to the key is %s", resp.PKey)
@@ -174,7 +173,7 @@ func TestInstallKey_SSHKeyWithAbsoluteDestination(t *testing.T) {
 	resp, err := w.InstallKeyTo(priKeyVar, "/tmp/fake_id_rsa")
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(resp.PKey)
+	content, err := os.ReadFile(resp.PKey)
 	require.NoError(t, err)
 	assert.Equal(t, string(priKeyPEM), string(content))
 	assert.Equal(t, "/tmp/fake_id_rsa", resp.PKey)

--- a/engine/worker/internal/start_test.go
+++ b/engine/worker/internal/start_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -252,7 +251,7 @@ func TestStartWorkerWithABookedJob(t *testing.T) {
 	var checkRequest gock.ObserverFunc = func(request *http.Request, mock gock.Mock) {
 		bodyContent, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
-		request.Body = ioutil.NopCloser(bytes.NewReader(bodyContent))
+		request.Body = io.NopCloser(bytes.NewReader(bodyContent))
 		if mock != nil {
 			switch mock.Request().URLStruct.String() {
 			case "http://lolcat.host/queue/workflows/42/step":

--- a/sdk/cdsclient/client_workflowv3.go
+++ b/sdk/cdsclient/client_workflowv3.go
@@ -7,7 +7,7 @@ import (
 
 func (c *client) WorkflowV3Get(projectKey, workflowName string, mods ...RequestModifier) ([]byte, error) {
 	path := fmt.Sprintf("/project/%s/workflowv3/%s", projectKey, workflowName)
-  body, _, _, err := c.Request(context.Background(), "GET", path, nil, mods...)
+	body, _, _, err := c.Request(context.Background(), "GET", path, nil, mods...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cdsclient/http.go
+++ b/sdk/cdsclient/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -133,7 +132,7 @@ func (c *client) Request(ctx context.Context, method string, path string, body i
 	}
 	defer func() {
 		// Drain and close the body to let the Transport reuse the connection
-		_, _ = io.Copy(ioutil.Discard, respBody)
+		_, _ = io.Copy(io.Discard, respBody)
 		_ = respBody.Close()
 	}()
 

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -203,7 +202,7 @@ func DownloadFromGitHub(ctx context.Context, directory, filename string, version
 
 	fullpath := path.Join(directory, filename)
 	log.Debug(ctx, "downloading %v into  %v", urlBinary, fullpath)
-	if err := ioutil.WriteFile(fullpath, body, 0755); err != nil {
+	if err := os.WriteFile(fullpath, body, 0755); err != nil {
 		return WrapError(err, "error while write file content for %s in %s", filename, directory)
 	}
 

--- a/sdk/goroutine.go
+++ b/sdk/goroutine.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -328,7 +327,7 @@ func writeGoroutineStacks(w io.Writer) error {
 
 func parseGoRoutineStacks(r io.Reader, w io.Writer) ([]*stack.Goroutine, error) {
 	if w == nil {
-		w = ioutil.Discard
+		w = io.Discard
 	}
 	s, _, err := stack.ScanSnapshot(r, w, stack.DefaultOpts())
 	if err != nil && err != io.EOF {

--- a/sdk/log/log.go
+++ b/sdk/log/log.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -59,7 +59,7 @@ func Initialize(ctx context.Context, conf *Conf) {
 
 	switch conf.Format {
 	case "discard":
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 	case "json":
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	default:

--- a/sdk/vcs/git/git.go
+++ b/sdk/vcs/git/git.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -112,7 +111,7 @@ func runGitCommandsOverSSH(commands []cmd, auth *AuthOpts, output *OutputOpts) e
 		wrapperPath = filepath.Join(keyDir, "gitwrapper")
 	}
 
-	if err := ioutil.WriteFile(wrapperPath, []byte(wrapper), os.FileMode(0700)); err != nil {
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), os.FileMode(0700)); err != nil {
 		return sdk.WithStack(err)
 	}
 

--- a/sdk/vcs/git/git_clone_test.go
+++ b/sdk/vcs/git/git_clone_test.go
@@ -3,7 +3,6 @@ package git
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 
 func TestExtractInfo(t *testing.T) {
 	repo := "https://github.com/ovh/cds.git"
-	myrepo, _ := ioutil.TempDir(os.TempDir(), "cds_TestExtractInfo")
+	myrepo, _ := os.MkdirTemp(os.TempDir(), "cds_TestExtractInfo")
 	defer os.RemoveAll(myrepo)
 	opts := &CloneOpts{
 		CheckoutCommit: "f57e4c8405d5b6ffddc33755c105f73c64ed89da",
@@ -45,7 +44,7 @@ func TestExtractInfo(t *testing.T) {
 }
 func TestExtractInfoAbsPath(t *testing.T) {
 	repo := "https://github.com/ovh/cds.git"
-	myrepo, _ := ioutil.TempDir(os.TempDir(), "cds_TestExtractInfoAbsPath")
+	myrepo, _ := os.MkdirTemp(os.TempDir(), "cds_TestExtractInfoAbsPath")
 	defer os.RemoveAll(myrepo)
 	opts := &CloneOpts{
 		CheckoutCommit: "f57e4c8405d5b6ffddc33755c105f73c64ed89da",
@@ -76,7 +75,7 @@ func TestExtractInfoAbsPath(t *testing.T) {
 }
 func TestExtractInfoEmptyPath(t *testing.T) {
 	repo := "https://github.com/ovh/cds.git"
-	myrepo, _ := ioutil.TempDir(os.TempDir(), "cds_TestExtractInfoEmptyPath")
+	myrepo, _ := os.MkdirTemp(os.TempDir(), "cds_TestExtractInfoEmptyPath")
 	defer os.RemoveAll(myrepo)
 	opts := &CloneOpts{
 		CheckoutCommit: "f57e4c8405d5b6ffddc33755c105f73c64ed89da",

--- a/sdk/vcs/keys.go
+++ b/sdk/vcs/keys.go
@@ -1,7 +1,6 @@
 package vcs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +84,7 @@ func GetSSHKey(vars []sdk.Variable, path string, key *sdk.Variable) (*SSHKey, er
 	}
 
 	p := filepath.Join(path, k.Name)
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/debpacker/main.go
+++ b/tools/debpacker/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -25,7 +24,7 @@ func main() {
 			Action: func(c *cli.Context) error {
 				p := New(nil, Config{}, "")
 				b, _ := yaml.Marshal(p.Config())
-				return ioutil.WriteFile(".debpacker.yml", b, os.FileMode(0644))
+				return os.WriteFile(".debpacker.yml", b, os.FileMode(0644))
 			},
 		},
 		{
@@ -42,7 +41,7 @@ func main() {
 		{
 			Name: "make",
 			Action: func(c *cli.Context) error {
-				b, err := ioutil.ReadFile(c.String("config"))
+				b, err := os.ReadFile(c.String("config"))
 				if err != nil {
 					return err
 				}

--- a/tools/smtpmock/Dockerfile
+++ b/tools/smtpmock/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.15 AS builder
+FROM golang:1.17 AS builder
 ADD . $GOPATH/src/github.com/ovh/cds/tools/smtpmock
 WORKDIR $GOPATH/src/github.com/ovh/cds/tools/smtpmock
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /tmp/smtpmocksrv github.com/ovh/cds/tools/smtpmock/server

--- a/tools/smtpmock/client.go
+++ b/tools/smtpmock/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -47,7 +46,7 @@ func (c *client) requestJSON(method string, url string, body io.Reader, data int
 		return errors.New(fmt.Sprintf("error request at %s %s", method, req.URL.String()))
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/tools/smtpmock/go.mod
+++ b/tools/smtpmock/go.mod
@@ -6,9 +6,24 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsamin/smtp v0.0.0-20190904085838-54a7c428d4f9
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/urfave/cli/v2 v2.1.1
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.9 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.0.1 // indirect
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 // indirect
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
+	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
+	golang.org/x/text v0.3.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/tools/smtpmock/server/smtp.go
+++ b/tools/smtpmock/server/smtp.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/quotedprintable"
 	"strings"
 
@@ -28,7 +28,7 @@ func smtpHandler(envelope *smtp.Envelope) error {
 		User:          envelope.User,
 	}
 
-	btes, err := ioutil.ReadAll(envelope.MessageData)
+	btes, err := io.ReadAll(envelope.MessageData)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func smtpHandler(envelope *smtp.Envelope) error {
 	m.Content = string(btes)
 
 	r := quotedprintable.NewReader(strings.NewReader(m.Content))
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since CDS has been upgraded to Go 1.17 (#5973), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.