### PR TITLE
fix(contrib): typo in workflow.go

### DIFF
--- a/sdk/exportentities/v2/workflow.go
+++ b/sdk/exportentities/v2/workflow.go
@@ -27,7 +27,7 @@ type VariableValue struct {
 type Workflow struct {
 	Name        string `json:"name" yaml:"name" jsonschema_description:"The name of the workflow."`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	Version     string `json:"version,omitempty" yaml:"version,omitempty" jsonschema_description:"Version for the yaml syntax, latest is v1.0."`
+	Version     string `json:"version,omitempty" yaml:"version,omitempty" jsonschema_description:"Version for the yaml syntax, latest is v2.0."`
 
 	Workflow map[string]NodeEntry   `json:"workflow,omitempty" yaml:"workflow,omitempty" jsonschema_description:"Workflow nodes list."`
 	Hooks    map[string][]HookEntry `json:"hooks,omitempty" yaml:"hooks,omitempty" jsonschema_description:"Workflow hooks list."`


### PR DESCRIPTION
Typo: the version number in the json schema was incorrect.

Signed-off-by: Stéphane Roy <stephane.roy@ovhcloud.com>

@ovh/cds
