### PR TITLE
feat(sdk.cdsclient): allow to pass modifiers on template apply

### DIFF
--- a/sdk/cdsclient/client_template.go
+++ b/sdk/cdsclient/client_template.go
@@ -34,7 +34,7 @@ func (c *client) TemplateGetAll() ([]sdk.WorkflowTemplate, error) {
 	return wts, nil
 }
 
-func (c *client) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest) (*tar.Reader, error) {
+func (c *client) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest, mods ...RequestModifier) (*tar.Reader, error) {
 	url := fmt.Sprintf("/template/%s/%s/apply", groupName, templateSlug)
 
 	bs, err := json.Marshal(req)
@@ -42,7 +42,7 @@ func (c *client) TemplateApply(groupName, templateSlug string, req sdk.WorkflowT
 		return nil, err
 	}
 
-	body, _, _, err := c.Request(context.Background(), "POST", url, bytes.NewReader(bs))
+	body, _, _, err := c.Request(context.Background(), "POST", url, bytes.NewReader(bs), mods...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cdsclient/interface.go
+++ b/sdk/cdsclient/interface.go
@@ -25,7 +25,7 @@ type Filter struct {
 type TemplateClient interface {
 	TemplateGet(groupName, templateSlug string) (*sdk.WorkflowTemplate, error)
 	TemplateGetAll() ([]sdk.WorkflowTemplate, error)
-	TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest) (*tar.Reader, error)
+	TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest, mods ...RequestModifier) (*tar.Reader, error)
 	TemplateBulk(groupName, templateSlug string, req sdk.WorkflowTemplateBulk) (*sdk.WorkflowTemplateBulk, error)
 	TemplateGetBulk(groupName, templateSlug string, id int64) (*sdk.WorkflowTemplateBulk, error)
 	TemplatePull(groupName, templateSlug string) (*tar.Reader, error)

--- a/sdk/cdsclient/mock_cdsclient/interface_mock.go
+++ b/sdk/cdsclient/mock_cdsclient/interface_mock.go
@@ -45,18 +45,23 @@ func (m *MockTemplateClient) EXPECT() *MockTemplateClientMockRecorder {
 }
 
 // TemplateApply mocks base method.
-func (m *MockTemplateClient) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest) (*tar.Reader, error) {
+func (m *MockTemplateClient) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest, mods ...cdsclient.RequestModifier) (*tar.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemplateApply", groupName, templateSlug, req)
+	varargs := []interface{}{groupName, templateSlug, req}
+	for _, a := range mods {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TemplateApply", varargs...)
 	ret0, _ := ret[0].(*tar.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TemplateApply indicates an expected call of TemplateApply.
-func (mr *MockTemplateClientMockRecorder) TemplateApply(groupName, templateSlug, req interface{}) *gomock.Call {
+func (mr *MockTemplateClientMockRecorder) TemplateApply(groupName, templateSlug, req interface{}, mods ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateApply", reflect.TypeOf((*MockTemplateClient)(nil).TemplateApply), groupName, templateSlug, req)
+	varargs := append([]interface{}{groupName, templateSlug, req}, mods...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateApply", reflect.TypeOf((*MockTemplateClient)(nil).TemplateApply), varargs...)
 }
 
 // TemplateBulk mocks base method.
@@ -7541,18 +7546,23 @@ func (mr *MockInterfaceMockRecorder) Stream(ctx, httpClient, method, path, body 
 }
 
 // TemplateApply mocks base method.
-func (m *MockInterface) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest) (*tar.Reader, error) {
+func (m *MockInterface) TemplateApply(groupName, templateSlug string, req sdk.WorkflowTemplateRequest, mods ...cdsclient.RequestModifier) (*tar.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemplateApply", groupName, templateSlug, req)
+	varargs := []interface{}{groupName, templateSlug, req}
+	for _, a := range mods {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TemplateApply", varargs...)
 	ret0, _ := ret[0].(*tar.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TemplateApply indicates an expected call of TemplateApply.
-func (mr *MockInterfaceMockRecorder) TemplateApply(groupName, templateSlug, req interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) TemplateApply(groupName, templateSlug, req interface{}, mods ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateApply", reflect.TypeOf((*MockInterface)(nil).TemplateApply), groupName, templateSlug, req)
+	varargs := append([]interface{}{groupName, templateSlug, req}, mods...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateApply", reflect.TypeOf((*MockInterface)(nil).TemplateApply), varargs...)
 }
 
 // TemplateBulk mocks base method.


### PR DESCRIPTION
1. Description
Allow to pass request modifiers (query parameters) when applying a template
