### PR TITLE
fix #6313

### DIFF
--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -1085,7 +1085,7 @@ func checkHooks(ctx context.Context, db gorp.SqlExecutor, w *sdk.Workflow, n *sd
 			h2 := n.Hooks[j]
 			if i != j && h.Ref() == h2.Ref() {
 				log.ErrorWithStackTrace(ctx, sdk.NewErrorFrom(sdk.ErrWrongRequest, "invalid workflow: duplicate hook %s", model.Name))
-				if !sdk.IsInInt64Array(int64(i), duplicateHookIdx) && !sdk.IsInInt64Array(int64(i), duplicateHookIdx) {
+				if !sdk.IsInInt64Array(int64(i), duplicateHookIdx) && !sdk.IsInInt64Array(int64(j), duplicateHookIdx) {
 					duplicateHookIdx = append(duplicateHookIdx, int64(j))
 				}
 			}

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -1085,9 +1085,7 @@ func checkHooks(ctx context.Context, db gorp.SqlExecutor, w *sdk.Workflow, n *sd
 			h2 := n.Hooks[j]
 			if i != j && h.Ref() == h2.Ref() {
 				log.ErrorWithStackTrace(ctx, sdk.NewErrorFrom(sdk.ErrWrongRequest, "invalid workflow: duplicate hook %s", model.Name))
-				if !sdk.IsInInt64Array(int64(i), duplicateHookIdx) && !sdk.IsInInt64Array(int64(j), duplicateHookIdx) {
-					duplicateHookIdx = append(duplicateHookIdx, int64(j))
-				}
+			duplicateHookIdx = append(duplicateHookIdx, int64(j))
 			}
 		}
 	}

--- a/engine/api/workflow/dao.go
+++ b/engine/api/workflow/dao.go
@@ -1085,7 +1085,7 @@ func checkHooks(ctx context.Context, db gorp.SqlExecutor, w *sdk.Workflow, n *sd
 			h2 := n.Hooks[j]
 			if i != j && h.Ref() == h2.Ref() {
 				log.ErrorWithStackTrace(ctx, sdk.NewErrorFrom(sdk.ErrWrongRequest, "invalid workflow: duplicate hook %s", model.Name))
-			duplicateHookIdx = append(duplicateHookIdx, int64(j))
+			  duplicateHookIdx = append(duplicateHookIdx, int64(j))
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Salvador Cavadini <salvadorcavadini+github@gmail.com>

1. Fix a bug in the detection of hook duplication (dao.go) caused by a typo in a slice index
1. #6313 

@ovh/cds
