### PR TITLE
fix(ui): set correct doc link for mutex workflow

### DIFF
--- a/ui/src/app/shared/workflow/wizard/context/wizard.context.html
+++ b/ui/src/app/shared/workflow/wizard/context/wizard.context.html
@@ -42,7 +42,7 @@
         </nz-form-item>
         <nz-form-item>
             <nz-form-label [nzSpan]="6">
-                <a href="#" [routerLink]="['/docs', 'docs', 'workflow', 'mutex']" target="_blank" rel="noopener noreferrer">
+                <a href="#" [routerLink]="['/docs', 'docs', 'concepts', 'workflow', 'mutex']" target="_blank" rel="noopener noreferrer">
                     {{ 'workflow_root_context_mutex' | translate }}
                     <span nz-icon nzType="link" nzTheme="outline"></span>
                 </a>


### PR DESCRIPTION
Fix router link for workflow mutex documentation

@ovh/cds
