### PR TITLE
Add uuidv4 helper function

### DIFF
--- a/sdk/interpolate/go.mod
+++ b/sdk/interpolate/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/aokoli/goutils v1.1.0
+	github.com/google/uuid v1.3.0
 	github.com/huandu/xstrings v1.2.0
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.5.1

--- a/sdk/interpolate/go.sum
+++ b/sdk/interpolate/go.sum
@@ -3,6 +3,8 @@ github.com/aokoli/goutils v1.1.0/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sdk/interpolate/interpolate_helper.go
+++ b/sdk/interpolate/interpolate_helper.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 
 	util "github.com/aokoli/goutils"
+	"github.com/google/uuid"
 	"github.com/huandu/xstrings"
 	"github.com/spf13/cast"
 )
@@ -48,6 +49,7 @@ func init() {
 		"randAlpha":    randAlpha,
 		"randASCII":    randASCII,
 		"randNumeric":  randNumeric,
+		"uuidv4":       uuidv4,
 		"swapcase":     util.SwapCase,
 		"shuffle":      xstrings.Shuffle,
 		"snakecase":    xstrings.ToSnakeCase,
@@ -262,6 +264,11 @@ func randASCII(count int) string {
 func randNumeric(count int) string {
 	r, _ := util.RandomNumeric(count)
 	return r
+}
+
+// uuidv4 generates a random UUID v4 as string.
+func uuidv4() string {
+	return uuid.New().String()
 }
 
 func untitle(str string) string {

--- a/sdk/interpolate/interpolate_test.go
+++ b/sdk/interpolate/interpolate_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkDo(b *testing.B) {
@@ -568,6 +570,13 @@ func TestDo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUUID(t *testing.T) {
+	got, err := Do("{{ uuidv4 }}", nil)
+	require.NoError(t, err)
+	_, err = uuid.Parse(got)
+	require.NoError(t, err)
 }
 
 func TestWrapHelpers(t *testing.T) {


### PR DESCRIPTION
1. Description

Using ovh/venom, I found the variables helpers are not using latest version
from `Masterminds/sprig` package so I backported the one that could be really
useful (`uuidv4` generation) here.

Taken from
https://github.com/Masterminds/sprig/blob/3ac42c7bc5e4be6aa534e036fb19dde4a996da2e/functions.go#L355

1. Related issues

I didn't use `sdk.UUID()` because it's a different package and I see there is a
different Go module.

Let me know what you think.

1. About tests
1. Mentions

@ovh/cds
