### PR TITLE
fix(hatchery): fix to manage worker model v2

### DIFF
--- a/engine/api/workflow/process_requirements.go
+++ b/engine/api/workflow/process_requirements.go
@@ -267,9 +267,6 @@ func processNodeJobRunRequirementsGetModelV2(ctx context.Context, db gorp.SqlExe
 		repoName = app.RepositoryFullname
 	}
 
-	if app.ID == 0 {
-		return nil, "", sdk.WrapError(sdk.ErrInvalidData, "unable to retrieve worker model data because the workflow root pipeline does not contain application in context")
-	}
 	if vcsName == "" || repoName == "" {
 		return nil, "", sdk.WrapError(sdk.ErrInvalidData, "unable to retrieve worker model data because the workflow root pipeline does not contain any vcs configuration")
 	}

--- a/sdk/cdsclient/client.go
+++ b/sdk/cdsclient/client.go
@@ -156,6 +156,7 @@ func NewHatcheryServiceClient(ctx context.Context, clientConfig ServiceConfig, r
 	cli.httpNoTimeoutClient = NewHTTPClient(0, conf.InsecureSkipVerifyTLS)
 	cli.httpWebsocketClient = NewWebsocketDialer(conf.InsecureSkipVerifyTLS)
 	cli.config.Verbose = clientConfig.Verbose
+	cli.consumerType = sdk.ConsumerHatchery
 	cli.init()
 
 	cli.signinRequest = requestSign

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -255,6 +255,9 @@ func Create(ctx context.Context, h Interface) error {
 					canTakeJob = false
 				} else if isWithModels {
 					if workerModelV2 != "" {
+						if h.CDSClientV2() == nil {
+							continue
+						}
 						chosenModel, err = canRunJobWithModelV2(currentCtx, hWithModels, workerModelV2)
 						if err != nil {
 							log.Error(currentCtx, "%v", err)


### PR DESCRIPTION
* Application are not mandatory to use worker model v2
* Missing consumer Type on hatchery client to be able to choose the right route to signin
* SKip job with worker modelv2 if no clientv2

@ovh/cds
