### PR TITLE
docs(variables): fix markdown syntax for yaml code

### DIFF
--- a/docs/content/docs/concepts/variables.md
+++ b/docs/content/docs/concepts/variables.md
@@ -151,6 +151,7 @@ parameters:
 
 stages:
   ...
+```
 
 This will let you to use `{{.cds.pip.param_name}}` in your pipeline.
 Then, in the workflow, you can set the value for pipeline parameter in the `pipeline context`.


### PR DESCRIPTION
In the variables concepts page, the markdown was broken after YAML code (section "Git variables"). This patch fixes the markdown syntax.

@ovh/cds
