### PR TITLE
feat(ui): cursor pointer on ng router link

### DIFF
--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -557,3 +557,7 @@ foreignObject {
 .bottomBtnsWrapper {
     z-index: 5; // an index to be over all codemirror elements
 }
+
+[ng-reflect-router-link] {
+  cursor: pointer;
+}


### PR DESCRIPTION
1. Description

Displays a pointer instead of a standard cursor when hovering an element inside a `[routerLink]`

For example, hovering a project in projects list now displays a pointer cursor.

1. Related issues

No related issues founds

1. About tests

UI only

1. Mentions

@ovh/cds
