### PR TITLE
refactor: replace `github.com/ghodss/yaml` with `github.com/rockbears/yaml`

### DIFF
--- a/cli/cdsctl/experimental_project_repository_analyze.go
+++ b/cli/cdsctl/experimental_project_repository_analyze.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
+	"github.com/rockbears/yaml"
 
 	"github.com/ovh/cds/cli"
 )

--- a/cli/cdsctl/experimental_project_repository_analyze.go
+++ b/cli/cdsctl/experimental_project_repository_analyze.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ovh/cds/cli"
 )

--- a/cli/cdsctl/experimental_project_vcs.go
+++ b/cli/cdsctl/experimental_project_vcs.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	yaml "github.com/ghodss/yaml"
 	"github.com/ovh/cds/cli"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
+	yaml "sigs.k8s.io/yaml"
 )
 
 var projectVCSCmd = cli.Command{

--- a/cli/cdsctl/experimental_project_vcs.go
+++ b/cli/cdsctl/experimental_project_vcs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ovh/cds/cli"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
-	yaml "sigs.k8s.io/yaml"
+	yaml "github.com/rockbears/yaml"
 )
 
 var projectVCSCmd = cli.Command{

--- a/contrib/grpcplugins/action/plugin-artifactory-release-bundle-create/main.go
+++ b/contrib/grpcplugins/action/plugin-artifactory-release-bundle-create/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/distribution"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"

--- a/contrib/grpcplugins/action/plugin-artifactory-release-bundle-create/main.go
+++ b/contrib/grpcplugins/action/plugin-artifactory-release-bundle-create/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
-	"sigs.k8s.io/yaml"
+	"github.com/rockbears/yaml"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/distribution"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"

--- a/engine/api/rbac/dao_rbac_test.go
+++ b/engine/api/rbac/dao_rbac_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ovh/cds/engine/api/rbac"
 	"github.com/ovh/cds/engine/api/test"

--- a/engine/api/rbac/dao_rbac_test.go
+++ b/engine/api/rbac/dao_rbac_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
+	"github.com/rockbears/yaml"
 
 	"github.com/ovh/cds/engine/api/rbac"
 	"github.com/ovh/cds/engine/api/test"

--- a/engine/api/test/assets/assets.go
+++ b/engine/api/test/assets/assets.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/go-gorp/gorp"
 	"github.com/rockbears/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ovh/cds/engine/api/action"
 	"github.com/ovh/cds/engine/api/application"

--- a/engine/api/test/assets/assets.go
+++ b/engine/api/test/assets/assets.go
@@ -19,7 +19,7 @@ import (
 	"github.com/rockbears/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
+	"github.com/rockbears/yaml"
 
 	"github.com/ovh/cds/engine/api/action"
 	"github.com/ovh/cds/engine/api/application"

--- a/engine/service/http.go
+++ b/engine/service/http.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
-	yaml "github.com/ghodss/yaml"
 	"github.com/go-gorp/gorp"
 	"github.com/rockbears/log"
 	"gopkg.in/spacemonkeygo/httpsig.v0"
+	yaml "sigs.k8s.io/yaml"
 
 	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/sdk"

--- a/engine/service/http.go
+++ b/engine/service/http.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-gorp/gorp"
 	"github.com/rockbears/log"
 	"gopkg.in/spacemonkeygo/httpsig.v0"
-	yaml "sigs.k8s.io/yaml"
+	yaml "github.com/rockbears/yaml"
 
 	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/sdk"

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,6 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	layeh.com/gopher-json v0.0.0-20201124131017-552bb3c4c3bf
-	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -284,6 +283,7 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/invopop/jsonschema v0.6.0 => github.com/sguiheux/jsonschema v0.0.0-20230316145935-733732e89063

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/fsamin/go-repo v0.1.11-0.20220715092716-99f295919954
 	github.com/fsamin/go-shredder v0.0.0-20180118184739-b2488aedb5be
 	github.com/fujiwara/shapeio v0.0.0-20170602072123-c073257dd745
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-gorp/gorp v2.0.0+incompatible
 	github.com/go-redis/redis v6.15.2+incompatible
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -109,6 +108,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	layeh.com/gopher-json v0.0.0-20201124131017-552bb3c4c3bf
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -153,6 +153,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/frankban/quicktest v1.14.3 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
@@ -283,7 +284,6 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace github.com/invopop/jsonschema v0.6.0 => github.com/sguiheux/jsonschema v0.0.0-20230316145935-733732e89063

--- a/go.sum
+++ b/go.sum
@@ -1553,5 +1553,6 @@ sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
-sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
The package `github.com/ghodss/yaml` is no longer actively maintained. See discussion in https://github.com/ghodss/yaml/issues/75 and https://github.com/ghodss/yaml/issues/80. ~~[`sigs.k8s.io/yaml`](https://github.com/kubernetes-sigs/yaml) is a permanent fork of `github.com/ghodss/yaml`.~~

~~The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, but `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. Changes can be seen here [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), mostly bug fixes.~~

EDIT: Replace `github.com/ghodss/yaml` with `github.com/rockbears/yaml`