### PR TITLE
fix: doc generate error handling

### DIFF
--- a/engine/worker/internal/input
+++ b/engine/worker/internal/input
@@ -1,0 +1,2 @@
+{{.cds.stuff}}
+{{.cds.stuff.secret}}

--- a/engine/worker/internal/output
+++ b/engine/worker/internal/output
@@ -1,0 +1,2 @@
+stuff
+secret stuff

--- a/sdk/doc/generate.go
+++ b/sdk/doc/generate.go
@@ -215,6 +215,10 @@ func getAllRouteInfo(path string) []Doc {
 
 	// Get all Handlers
 	d, err := parser.ParseFile(fset, path+"/api_routes.go", nil, parser.AllErrors)
+	if err != nil {
+		sdk.Exit(err.Error())
+	}
+
 	v := newVisitor()
 	ast.Walk(v, d)
 


### PR DESCRIPTION
This fixes a dropped error in `sdk/doc`.

@ovh/cds
