### PR TITLE
doc: typo Service Requirement NGINX

### DIFF
--- a/docs/content/docs/tutorials/service-requirement-nginx.md
+++ b/docs/content/docs/tutorials/service-requirement-nginx.md
@@ -8,7 +8,7 @@ card:
 
 ## Add the service requirement
 
-* Name: `mypg`. This will be the service hostname
+* Name: `mynginx`. This will be the service hostname
 * Type: `service`
 * Docker Image: `nginx:1.11.1`. This is the name of Docker image to link to current job
 


### PR DESCRIPTION
1. Correct  typo Service Requirement NGINX
1. Related to [this page](https://ovh.github.io/cds/docs/tutorials/service-requirement-nginx/)

![image](https://github.com/ovh/cds/assets/26463615/776e7102-7777-4b69-989e-fae9db546503)


@ovh/cds
