### PR TITLE
fix(engine): dropped cdn test error

### DIFF
--- a/engine/cdn/item_upload_test.go
+++ b/engine/cdn/item_upload_test.go
@@ -239,6 +239,7 @@ func TestPostUploadHandler(t *testing.T) {
 	}
 
 	iu, err := storage.LoadItemUnitByID(ctx, s.Mapper, db, iuID, gorpmapper.GetOptions.WithDecryption)
+	require.NoError(t, err)
 	buf = &bytes.Buffer{}
 
 	uiRead, err := s.Units.Storages[0].NewReader(ctx, *iu)


### PR DESCRIPTION
This fixes a dropped test `err` variable in `engine/cdn`.

@ovh/cds
