### PR TITLE
fix(engine): dropped filepath.Walk() error

### DIFF
--- a/engine/cdn/storage/local/buffer.go
+++ b/engine/cdn/storage/local/buffer.go
@@ -66,6 +66,9 @@ func (b *Buffer) BufferType() storage.CDNBufferType {
 func (b *Buffer) ResyncWithDatabase(ctx context.Context, db gorp.SqlExecutor, t sdk.CDNItemType, dryRun bool) {
 	root := fmt.Sprintf("%s/%s", b.config.Path, string(t))
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info == nil {
 			return nil
 		}


### PR DESCRIPTION
This fixes an `err` variable passed into `filepath.Walk()` and then dropped in `engine/cdn/storage/local`

@ovh/cds