### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/engine/api/migrate/migrate_organization.go
+++ b/engine/api/migrate/migrate_organization.go
@@ -33,7 +33,7 @@ func GetOrganizationUsersToMigrate(ctx context.Context, db *gorp.DbMap) ([]UserO
 		return nil, err
 	}
 
-	userIds := make([]string, len(allUsers))
+	userIds := make([]string, 0, len(allUsers))
 	mapUsers := make(map[string]*sdk.AuthentifiedUser)
 	for i := range allUsers {
 		u := &allUsers[i]

--- a/engine/hooks/trigger_workflow.go
+++ b/engine/hooks/trigger_workflow.go
@@ -84,7 +84,7 @@ func (s *Service) triggerWorkflows(ctx context.Context, hre *sdk.HookRepositoryE
 					wh.Status = sdk.HookEventWorkflowStatusSkipped
 				} else {
 					// Query params to select the right workflow version to run
-					mods := make([]cdsclient.RequestModifier, 2)
+					mods := make([]cdsclient.RequestModifier, 0, 2)
 					mods = append(mods, cdsclient.WithQueryParameter("ref", wh.Ref), cdsclient.WithQueryParameter("commit", wh.Commit))
 
 					runRequest := sdk.V2WorkflowRunHookRequest{


### PR DESCRIPTION
1. Description

I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output  https://github.com/alingse/go-linter-runner/actions/runs/9242659719/job/25425759865

```
====================================================================================================
append to slice `userIds` with non-zero initialized length at https://github.com/ovh/cds/blob/master/engine/api/migrate/migrate_organization.go#L40:13
append to slice `mods` with non-zero initialized length at https://github.com/ovh/cds/blob/master/engine/hooks/trigger_workflow.go#L88:13
====================================================================================================
```

1. Related issues
1. About tests
1. Mentions

@ovh/cds
