### PR TITLE
feat(sdk): add basic string manipulation functions

### DIFF
--- a/sdk/action_parser_funcs.go
+++ b/sdk/action_parser_funcs.go
@@ -34,6 +34,10 @@ var (
 		"cancelled":  cancelled,
 		"failure":    failure,
 		"result":     result,
+		"toLower":    newStringActionFunc("toLower", strings.ToLower),
+		"toUpper":    newStringActionFunc("toUpper", strings.ToUpper),
+		"toTitle":    newStringActionFunc("toTitle", strings.ToTitle),
+		"title":      newStringActionFunc("title", strings.Title),
 	}
 )
 
@@ -399,4 +403,21 @@ func failure(_ context.Context, a *ActionParser, inputs ...interface{}) (interfa
 		return false, nil
 	}
 	return nil, NewErrorFrom(ErrInvalidData, "missing step and jobs contexts")
+}
+
+type stringActionFunc func(string) string
+
+func newStringActionFunc(name string, fn stringActionFunc) ActionFunc {
+	return func(ctx context.Context, _ *ActionParser, inputs ...interface{}) (interface{}, error) {
+		log.Debug(ctx, "function: %s with args: %v", name, inputs)
+
+		if len(inputs) != 1 {
+			return nil, NewErrorFrom(ErrInvalidData, "%s: requires one argument", name)
+		}
+		s, ok := inputs[0].(string)
+		if !ok {
+			return nil, NewErrorFrom(ErrInvalidData, "%s: item argument must be a string", name)
+		}
+		return fn(s), nil
+	}
 }

--- a/sdk/action_parser_funcs_test.go
+++ b/sdk/action_parser_funcs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rockbears/log"
@@ -87,4 +88,37 @@ func TestHashFiles(t *testing.T) {
 	t.Logf("%s", hashSum2)
 
 	require.Equal(t, fmt.Sprintf("%s", hashSum1), fmt.Sprintf("%s", hashSum2))
+}
+
+func Test_newStringActionFunc(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		actionFn stringActionFunc
+	}{
+		{"toLower", strings.ToLower},
+		{"toUpper", strings.ToUpper},
+		{"toTitle", strings.ToTitle},
+		{"title", strings.Title},
+	} {
+		fn, ok := DefaultFuncs[tt.name]
+		if !ok {
+			t.Errorf("func %s not found", tt.name)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			const arg = "foo bar"
+
+			v, err := fn(context.TODO(), nil, arg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s, ok := v.(string)
+			if !ok {
+				t.Fatalf("expected string, got %T", v)
+			}
+			if want := tt.actionFn(arg); s != want {
+				t.Errorf("got %q, want %q", s, want)
+			}
+			t.Logf(s)
+		})
+	}
 }


### PR DESCRIPTION
Adds basic string manipulation functions:
- `toLower`
- `toUpper`
- `totitle`
- `title`: This one uses the `strings.Tittle` func which is marked as deprecated, but the alternative is to use the more complex [`x/text/cases`](https://pkg.go.dev/golang.org/x/text/cases) package. For this usecase, I think we can accept the downside of the function (does not handle Unicode punctuation properly for word boundaries).

Tests have been added.

@ovh/cds
