### PR TITLE
fix(engine): close the archive before deleting it

### DIFF
--- a/engine/worker/internal/handler_cache.go
+++ b/engine/worker/internal/handler_cache.go
@@ -214,6 +214,16 @@ func cachePullHandler(ctx context.Context, wk *CurrentWorker) http.HandlerFunc {
 			writeError(w, req, err)
 			return
 		}
+		//close archive before removing it
+		if err := archive.Close(); err != nil {
+			err = sdk.Error{
+				Message: fmt.Sprintf("worker cache pull > unable to close archive %s: %v", dest, err),
+				Status:  http.StatusInternalServerError,
+			}
+			log.Error(ctx, "%v", err)
+			writeError(w, req, err)
+			return
+		}
 		if err := wkDirFS.Remove(dest); err != nil {
 			e := sdk.Error{
 				Message: "unable to remove worker cache archive: " + err.Error(),


### PR DESCRIPTION
1. Description

"worker pull" command on Windows crashes at deleting workercache.tar. The code forgets to close the file before deleting it.
![image](https://github.com/user-attachments/assets/013116a4-e828-41be-9add-23e5c7555d69)

2. Mentions

@ovh/cds