### PR TITLE
Introducing CDS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CDS is an Enterprise-Grade Continuous Delivery & DevOps Automation Platform writ
 
 **[Documentation](https://ovh.github.io/cds/)**
 
+You can also [Ask CDS Guru](https://gurubase.io/g/cds), it is a CDS-focused AI to answer your questions.
 
 ## Intuitive UI
 CDS provides an intuitive UI that allows you to build complex workflows, run them and dig into the logs when needed.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CDS Guru](https://gurubase.io/g/cds) to Gurubase. CDS Guru uses the data from this repo and data from the [docs](https://ovh.github.io/cds/) to answer questions by leveraging the LLM.

In this PR, I showcased the "CDS Guru", which highlights that CDS now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CDS Guru in Gurubase, just let me know that's totally fine.