### PR TITLE
fix: local artifact directory creation error segfault

### DIFF
--- a/sdk/common.go
+++ b/sdk/common.go
@@ -196,6 +196,9 @@ func DirectoryExists(path string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	}
+	if s == nil {
+		return false, err
+	}
 	return s.IsDir(), err
 }
 


### PR DESCRIPTION
1. Description
Starting the API with a missing directory and/or permission issue wihle trying to create said directory generates a segfault error
This is preventing new cds users from swiftly standing up cds

1. Related issues

https://github.com/ovh/cds/issues/7199

1. About tests

The compiled binary with this patch now clearly tells me I have a permission issue, this is what I expect
```
make[1]: Leaving directory '/home/gsalingu/github/ovh/cds/engine/worker'
gsalingu@cds:~/github/ovh/cds$ cp /home/gsalingu/github/ovh/cds/engine/dist/cds-engine-linux-amd64 ~/cds/cds-engine
gsalingu@cds:~/github/ovh/cds$ ~/cds/cds-engine start api --config ~/cds/conf.toml
Reading configuration file @ /home/gsalingu/cds/conf.toml
Starting service api
Unable to init service api: unable to create directory /var/lib/cds-engine/artifacts: mkdir /var/lib/cds-engine/artifacts: permission denied
```

1. Mentions

@ovh/cds
