### PR TITLE
feat(interpolation): add fromFile interpolation helper

### DIFF
--- a/sdk/interpolate/interpolate_helper.go
+++ b/sdk/interpolate/interpolate_helper.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
 	"strconv"
@@ -89,6 +90,7 @@ func init() {
 		"urlencode": func(s string) string { return url.QueryEscape(s) },
 		"dirname":   func(s string) string { return path.Dir(s) },
 		"basename":  func(s string) string { return path.Base(s) },
+		"fromFile":  fromFile,
 	})
 }
 
@@ -404,4 +406,12 @@ func ternary(v, v2, a interface{}) interface{} {
 // toInt64 converts integer types to 64-bit integers
 func toInt64(v interface{}) int64 {
 	return cast.ToInt64(v)
+}
+
+func fromFile(s string) string {
+	bytes, err := os.ReadFile(s)
+	if err != nil {
+		return ""
+	}
+	return string(bytes)
 }

--- a/sdk/interpolate/interpolate_test.go
+++ b/sdk/interpolate/interpolate_test.go
@@ -3,6 +3,8 @@ package interpolate
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path"
 	"testing"
 	"text/template"
 
@@ -587,6 +589,30 @@ func TestDo(t *testing.T) {
 			want:   "bar",
 			enable: true,
 		},
+		{
+			name: "fromFile truthy",
+			args: args{
+				input: "{{.assert | fromFile}}",
+				vars: map[string]string{
+					"assert": tempFileWithContent("foobar"),
+				},
+			},
+			wantErr: false,
+			want:    "foobar",
+			enable:  true,
+		},
+		{
+			name: "fromFile falsy path",
+			args: args{
+				input: "{{.assert | fromFile}}",
+				vars: map[string]string{
+					"assert": path.Join(os.TempDir(), "nonexistent"),
+				},
+			},
+			wantErr: false,
+			want:    "",
+			enable:  true,
+		},
 	}
 	for _, tt := range tests {
 		if !tt.enable {
@@ -604,6 +630,15 @@ func TestDo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func tempFileWithContent(s string) string {
+	f := path.Join(os.TempDir(), s)
+	err := os.WriteFile(f, []byte(s), 0600)
+	if err != nil {
+		panic(err)
+	}
+	return f
 }
 
 func TestWrapHelpers(t *testing.T) {


### PR DESCRIPTION
1. Description

Add interpolation helper that reads a file path and returns the contents of the file if exists, empty string otherwise. The method is intended to be used for example chained to `toJSON` helper, given a correctly formatted JSON file.

2. Related issues

#7213

3. About tests

Added unit tests with both existing and non-existing paths.