### PR TITLE
fix(hatchery,repositories): use memory for kube hatchery and upgrade gorepo

### DIFF
--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -253,6 +253,10 @@ func (h *HatcheryKubernetes) SpawnWorker(ctx context.Context, spawnArgs hatchery
 	if memory == 0 {
 		memory = 1024
 	}
+	if spawnArgs.Model.Memory != 0 {
+		memory = spawnArgs.Model.Memory
+	}
+
 	for _, r := range spawnArgs.Requirements {
 		if r.Type == sdk.MemoryRequirement {
 			var err error

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/eapache/go-resiliency v1.3.0
 	github.com/fatih/color v1.16.0
 	github.com/fsamin/go-dump v1.0.9
-	github.com/fsamin/go-repo v0.6.0
+	github.com/fsamin/go-repo v0.6.1
 	github.com/fsamin/go-shredder v0.0.0-20180118184739-b2488aedb5be
 	github.com/fujiwara/shapeio v0.0.0-20170602072123-c073257dd745
 	github.com/go-gorp/gorp v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsamin/go-dump v1.0.9 h1:3MAneAJLnGfKTJtFEAdgrD+QqqK2Hwj7EJUQMQZcDls=
 github.com/fsamin/go-dump v1.0.9/go.mod h1:ZgKd2aOXAFFbbFuUgvQhu7mwTlI3d3qnTICMWdvAa9o=
-github.com/fsamin/go-repo v0.6.0 h1:gixZHtHBrg57/ZBiY4rHtYmCfKX6cp3EXCFwA0y61rE=
-github.com/fsamin/go-repo v0.6.0/go.mod h1:NolcuRMewkHXu4E0VFpNFksCDtYEl//X0pyvOmP0i2A=
+github.com/fsamin/go-repo v0.6.1 h1:BFjr/hpMLsySTDOCofLj9ax22rKqQ0YAXdPhwolXLpM=
+github.com/fsamin/go-repo v0.6.1/go.mod h1:NolcuRMewkHXu4E0VFpNFksCDtYEl//X0pyvOmP0i2A=
 github.com/fsamin/go-shredder v0.0.0-20180118184739-b2488aedb5be h1:UhjSvwE1gxUYfekK9BXZ/LL55we9Avg+2Pt0PIlMYCk=
 github.com/fsamin/go-shredder v0.0.0-20180118184739-b2488aedb5be/go.mod h1:kuiNcf1lKxl4isIY6bHxbBatpLD43c2RKWIV/AGlhXY=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=


### PR DESCRIPTION
1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
