### PR TITLE
feat(v2/ui/run): add systemerr tab to ui

### DIFF
--- a/ui/src/app/views/projectv2/run/run-test.component.ts
+++ b/ui/src/app/views/projectv2/run/run-test.component.ts
@@ -110,7 +110,7 @@ export class RunTestComponent implements OnInit, OnChanges, OnDestroy {
 			this.systemout = t?.systemout?.value
 		}
 		if (t?.systemerr?.value) {
-			this.systemout = t?.systemerr?.value
+			this.systemerr = t?.systemerr?.value
 		}
 
 		if (this.systemout != "") {

--- a/ui/src/app/views/projectv2/run/run-test.component.ts
+++ b/ui/src/app/views/projectv2/run/run-test.component.ts
@@ -29,6 +29,7 @@ export class RunTestComponent implements OnInit, OnChanges, OnDestroy {
 	testRaw: string;
 	outputError: string = "";
 	systemout: string = "";
+	systemerr: string = "";
 
 	constructor(
 		private _cd: ChangeDetectorRef,
@@ -108,11 +109,21 @@ export class RunTestComponent implements OnInit, OnChanges, OnDestroy {
 		if (t?.systemout?.value) {
 			this.systemout = t?.systemout?.value
 		}
+		if (t?.systemerr?.value) {
+			this.systemout = t?.systemerr?.value
+		}
 
 		if (this.systemout != "") {
 			this.tabs.unshift(<Tab>{
 				title: 'SystemOut',
 				key: 'systemout',
+				default: true
+			});
+		}
+		if (this.systemerr != "") {
+			this.tabs.unshift(<Tab>{
+				title: 'SystemErr',
+				key: 'systemerr',
 				default: true
 			});
 		}

--- a/ui/src/app/views/projectv2/run/run-test.html
+++ b/ui/src/app/views/projectv2/run/run-test.html
@@ -7,6 +7,10 @@
 	<nz-code-editor #editor [ngModel]="systemout" [nzEditorOption]="editorOptionRaw"
 		(nzEditorInitialized)="onEditorInit($event)" (dblclick)="$event.stopPropagation();"></nz-code-editor>
 </ng-container>
+<ng-container *ngIf="selectedTab && selectedTab.key === 'systemerr'">
+	<nz-code-editor #editor [ngModel]="systemerr" [nzEditorOption]="editorOptionRaw"
+		(nzEditorInitialized)="onEditorInit($event)" (dblclick)="$event.stopPropagation();"></nz-code-editor>
+</ng-container>
 <ng-container *ngIf="selectedTab && selectedTab.key === 'raw'">
 	<nz-code-editor #editor [ngModel]="testRaw" [nzEditorOption]="editorOption"
 		(nzEditorInitialized)="onEditorInit($event)" (dblclick)="$event.stopPropagation();"></nz-code-editor>


### PR DESCRIPTION
The v2 ui is missing the systemerr tab
![image](https://github.com/user-attachments/assets/1e0c16ae-f7c7-427c-913f-f7ef7bfb9812)


@ovh/cds
