### PR TITLE
feat(cds v2): add coalesce and default functions for ${{ ... }} templating

### DIFF
--- a/sdk/action_parser_funcs.go
+++ b/sdk/action_parser_funcs.go
@@ -53,12 +53,40 @@ var (
 		"match":        match,
 		"replace":      replace,
 		"contextValue": contextValue,
+		"default":      dfault,
+		"coalesce":     coalesce,
 	}
 )
 
 type ActionFunc func(ctx context.Context, a *ActionParser, inputs ...interface{}) (interface{}, error)
 
-func replace(_ context.Context, a *ActionParser, inputs ...interface{}) (interface{}, error) {
+func dfault(_ context.Context, a *ActionParser, inputs ...interface{}) (interface{}, error) {
+	switch len(inputs) {
+	case 0:
+		return nil, nil // default
+	case 1:
+		return inputs[0], nil // default "var" OR default ""
+	case 2:
+		if !empty(inputs[0]) {
+			return inputs[0], nil // default "var" "" OR default "var" "another"
+		}
+		return inputs[1], nil // default "" "var" OR default "" ""
+	default:
+		return nil, NewErrorFrom(ErrInvalidData, "default: wrong number of arguments")
+	}
+}
+
+// coalesce returns the first non-empty value.
+func coalesce(_ context.Context, _ *ActionParser, inputs ...interface{}) (interface{}, error) {
+	for _, val := range inputs {
+		if !empty(val) {
+			return val, nil
+		}
+	}
+	return nil, nil
+}
+
+func replace(_ context.Context, _ *ActionParser, inputs ...interface{}) (interface{}, error) {
 	if len(inputs) != 3 && len(inputs) != 4 {
 		return nil, NewErrorFrom(ErrInvalidData, "replace: wrong number of arguments")
 	}
@@ -86,6 +114,7 @@ func replace(_ context.Context, a *ActionParser, inputs ...interface{}) (interfa
 
 	return strings.Replace(input, old, new, nbOfReplacements), nil
 }
+
 func contextValue(_ context.Context, a *ActionParser, inputs ...interface{}) (interface{}, error) {
 	if len(inputs) == 0 {
 		return nil, NewErrorFrom(ErrInvalidData, "contextValue: wrong number of arguments")
@@ -621,5 +650,33 @@ func base32decode(v string) (string, error) {
 func nilerr(fn func(string) string) stringActionFunc {
 	return func(s string) (string, error) {
 		return fn(s), nil
+	}
+}
+
+// empty returns true if the given value has the zero value for its type.
+func empty(given interface{}) bool {
+	g := reflect.ValueOf(given)
+	if !g.IsValid() {
+		return true
+	}
+
+	// Basically adapted from text/template.isTrue
+	switch g.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
+		return g.Len() == 0
+	case reflect.Bool:
+		return g.Bool() == false
+	case reflect.Complex64, reflect.Complex128:
+		return g.Complex() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return g.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return g.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return g.Float() == 0
+	case reflect.Struct:
+		return false
+	default:
+		return g.IsNil()
 	}
 }

--- a/sdk/action_parser_funcs_test.go
+++ b/sdk/action_parser_funcs_test.go
@@ -32,7 +32,6 @@ func Test_replace(t *testing.T) {
 	s, ok = r.(string)
 	require.True(t, ok)
 	require.Equal(t, "my-super/repo", s)
-
 }
 
 func Test_match(t *testing.T) {
@@ -390,4 +389,63 @@ func Test_newStringStringActionFunc(t *testing.T) {
 			t.Logf("%s", got)
 		})
 	}
+}
+
+func Test_Default(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		type testcase struct {
+			name     string
+			inputs   []any
+			expected any
+		}
+
+		cases := []testcase{
+			{name: "empty"},
+			{name: "one_arg_str", inputs: []any{"a"}, expected: "a"},
+			{name: "one_arg_int", inputs: []any{18}, expected: 18},
+			{name: "two_args_non_empty", inputs: []any{"a", "b"}, expected: "a"},
+			{name: "two_args_default_empty", inputs: []any{"", "b"}, expected: "b"},
+			{name: "two_args_input_empty", inputs: []any{"a", ""}, expected: "a"},
+			{name: "two_args_input_empty_int", inputs: []any{56, 0}, expected: 56},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Act
+				result, err := dfault(context.TODO(), nil, tc.inputs...)
+
+				// Assert
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			})
+		}
+	})
+}
+
+func Test_Coalesce(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		type testcase struct {
+			name     string
+			inputs   []any
+			expected any
+		}
+
+		cases := []testcase{
+			{name: "empty"},
+			{name: "one_arg_str", inputs: []any{"a"}, expected: "a"},
+			{name: "one_arg_int", inputs: []any{18}, expected: 18},
+			{name: "two_args_non_empty", inputs: []any{"a", "b"}, expected: "a"},
+			{name: "two_args_first_empty", inputs: []any{"", "b"}, expected: "b"},
+			{name: "many_args_first_non_empty", inputs: []any{"", 0, "b", "", 18}, expected: "b"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Act
+				result, err := coalesce(context.TODO(), nil, tc.inputs...)
+
+				// Assert
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			})
+		}
+	})
 }


### PR DESCRIPTION
For simpler workflows and jobs, I would like to add `default` and `coalesce` functions to templating functions to avoid having shell scripts steps to fallback on empty values (mostly string, but I think it's OK to handle any type of input).

@ovh/cds