### PR TITLE
feat(cdn): parallelize item purge with configurable worker pool

### DIFF
--- a/engine/cdn/storage/storageunit.go
+++ b/engine/cdn/storage/storageunit.go
@@ -53,6 +53,10 @@ func Init(ctx context.Context, m *gorpmapper.Mapper, store cache.Store, db *gorp
 		config.PurgeNbElements = 1000
 	}
 
+	if config.PurgeNbWorkers <= 0 {
+		config.PurgeNbWorkers = 10
+	}
+
 	if len(config.HashLocatorSalt) < 8 {
 		return nil, sdk.WithStack(fmt.Errorf("invalid CDN configuration. HashLocatorSalt is too short"))
 	}

--- a/engine/cdn/storage/storageunit_purge.go
+++ b/engine/cdn/storage/storageunit_purge.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rockbears/log"
 
@@ -26,64 +27,86 @@ func (x *RunningStorageUnits) Purge(ctx context.Context, s Interface) error {
 	}
 
 	if len(unitItems) > 0 {
-		log.Info(ctx, "cdn:purge:%s: %d unit item to delete", s.Name(), len(unitItems))
+		log.Info(ctx, "cdn:purge:%s: %d unit item to delete with %d workers", s.Name(), len(unitItems), x.config.PurgeNbWorkers)
 	}
 
+	// Fan-out: distribute items to workers via a channel
+	ch := make(chan sdk.CDNItemUnit, len(unitItems))
 	for _, ui := range unitItems {
-		ctx = context.WithValue(ctx, FieldAPIRef, ui.Item.APIRefHash)
-		ctx = context.WithValue(ctx, FieldSize, ui.Item.Size)
-
-		exists, err := s.ItemExists(ctx, x.m, x.db, *ui.Item)
-		if err != nil {
-			log.Error(ctx, "error on ItemExists: err:%s", err)
-			continue
-		}
-
-		if exists {
-			var hasItemUnit bool
-			if _, hasLocator := s.(StorageUnitWithLocator); hasLocator {
-				var err error
-				hasItemUnit, err = x.GetItemUnitByLocatorByUnit(ui.Locator, s.ID(), ui.Type)
-				if err != nil {
-					return err
-				}
-			}
-
-			if hasItemUnit {
-				log.Info(ctx, "item %s will not be deleted from %s", ui.ID, s.Name())
-			} else {
-				if err := s.Remove(ctx, ui); err != nil {
-					if sdk.ErrorIs(err, sdk.ErrNotFound) {
-						log.Info(ctx, "Item %s has already been deleted from %s", ui.ItemID, s.Name())
-						continue
-					}
-					ctx = sdk.ContextWithStacktrace(ctx, err)
-					log.Error(ctx, "unable to remove item %s on %s: %v", ui.ID, s.Name(), err)
-					continue
-				}
-				log.Info(ctx, "item %s deleted on %s", ui.ID, s.Name())
-			}
-		}
-
-		tx, err := x.db.Begin()
-		if err != nil {
-			return sdk.WithStack(err)
-		}
-
-		if err := DeleteItemUnit(x.m, tx, &ui); err != nil {
-			ctx = sdk.ContextWithStacktrace(ctx, err)
-			log.Error(ctx, "unable to delete item unit %s: %v", ui.ID, err)
-			_ = tx.Rollback() // nolint
-			continue
-		}
-
-		if err := tx.Commit(); err != nil {
-			_ = tx.Rollback() // nolint
-			return sdk.WithStack(err)
-		}
-
-		log.Info(ctx, "item %s deleted on %s", ui.ID, s.Name())
+		ch <- ui
 	}
+	close(ch)
+
+	var wg sync.WaitGroup
+	for i := 0; i < x.config.PurgeNbWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ui := range ch {
+				x.purgeItem(ctx, s, ui)
+			}
+		}()
+	}
+	wg.Wait()
 
 	return nil
+}
+
+func (x *RunningStorageUnits) purgeItem(ctx context.Context, s Interface, ui sdk.CDNItemUnit) {
+	ctx = context.WithValue(ctx, FieldAPIRef, ui.Item.APIRefHash)
+	ctx = context.WithValue(ctx, FieldSize, ui.Item.Size)
+
+	exists, err := s.ItemExists(ctx, x.m, x.db, *ui.Item)
+	if err != nil {
+		log.Error(ctx, "error on ItemExists: err:%s", err)
+		return
+	}
+
+	if exists {
+		var hasItemUnit bool
+		if _, hasLocator := s.(StorageUnitWithLocator); hasLocator {
+			var err error
+			hasItemUnit, err = x.GetItemUnitByLocatorByUnit(ui.Locator, s.ID(), ui.Type)
+			if err != nil {
+				log.Error(ctx, "unable to check item unit locator %s: %v", ui.ID, err)
+				return
+			}
+		}
+
+		if hasItemUnit {
+			log.Info(ctx, "item %s will not be deleted from %s", ui.ID, s.Name())
+		} else {
+			if err := s.Remove(ctx, ui); err != nil {
+				if sdk.ErrorIs(err, sdk.ErrNotFound) {
+					log.Info(ctx, "Item %s has already been deleted from %s", ui.ItemID, s.Name())
+				} else {
+					ctx = sdk.ContextWithStacktrace(ctx, err)
+					log.Error(ctx, "unable to remove item %s on %s: %v", ui.ID, s.Name(), err)
+				}
+				return
+			}
+			log.Info(ctx, "item %s deleted on %s", ui.ID, s.Name())
+		}
+	}
+
+	tx, err := x.db.Begin()
+	if err != nil {
+		log.Error(ctx, "unable to begin transaction for item unit %s: %v", ui.ID, err)
+		return
+	}
+
+	if err := DeleteItemUnit(x.m, tx, &ui); err != nil {
+		ctx = sdk.ContextWithStacktrace(ctx, err)
+		log.Error(ctx, "unable to delete item unit %s: %v", ui.ID, err)
+		_ = tx.Rollback() // nolint
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback() // nolint
+		log.Error(ctx, "unable to commit transaction for item unit %s: %v", ui.ID, err)
+		return
+	}
+
+	log.Info(ctx, "item unit %s deleted on %s", ui.ID, s.Name())
 }

--- a/engine/cdn/storage/types.go
+++ b/engine/cdn/storage/types.go
@@ -154,6 +154,7 @@ type Configuration struct {
 	SyncNbElements  int64                           `toml:"syncNbElements" default:"100" json:"syncNbElements" comment:"nb items to synchronize from the buffer"`
 	PurgeSeconds    int                             `toml:"purgeSeconds" default:"5" json:"purgeSeconds" comment:"each n seconds, all storage backends will have to start to delete storage unit item with deleted flag"`
 	PurgeNbElements int                             `toml:"purgeNbElements" default:"1000" json:"purgeNbElements" comment:"nb items to delete in each purge loop"`
+	PurgeNbWorkers  int                             `toml:"purgeNbWorkers" default:"10" json:"purgeNbWorkers" comment:"nb parallel workers to process purge items within each storage unit"`
 }
 
 type BufferConfiguration struct {


### PR DESCRIPTION
Add PurgeNbWorkers configuration parameter (default: 10) to control the number of parallel goroutines processing item deletions within each storage unit purge cycle.

Previously, items were purged sequentially in a for loop, making the process slow for large batches due to I/O-bound operations (storage exists checks, removals, DB transactions). Now items are distributed to workers via a channel for concurrent processing.

@ovh/cds
