### PR TITLE
fix: Add retry on http status code 422 (Unprocessable Entity)

### DIFF
--- a/contrib/integrations/arsenal/arsenal.go
+++ b/contrib/integrations/arsenal/arsenal.go
@@ -129,7 +129,7 @@ func (ac *Client) Deploy(deployRequest *DeployRequest) (*DeployResponse, error) 
 		if statusCode == http.StatusOK {
 			return &deployResult, lastErr
 		}
-		if statusCode == http.StatusMethodNotAllowed {
+		if statusCode == http.StatusMethodNotAllowed || statusCode == http.StatusUnprocessableEntity {
 			lastErr = &RequestError{fmt.Sprintf("deploy request failed (HTTP status %d): %s", statusCode, rawBody)}
 			time.Sleep(100 * time.Millisecond)
 			continue


### PR DESCRIPTION
1. Description
Add retry on http status code 422 (Unprocessable Entity) when deploying on Arsenal
1. Related issues
The deploy fail if we got an http status 422 during deployment


@ovh/cds
