### PR TITLE
feat(contrib/vscode-cds): add Workflow Explorer panel with run controls

### DIFF
--- a/contrib/vscode-cds/package.json
+++ b/contrib/vscode-cds/package.json
@@ -22,6 +22,23 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "vscode-cds-explorer",
+          "title": "CDS",
+          "icon": "assets/images/cds.svg"
+        }
+      ]
+    },
+    "views": {
+      "vscode-cds-explorer": [
+        {
+          "id": "vscode-cds-workflows",
+          "name": "Workflow Explorer"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "vscode-cds.clearCache",
@@ -43,6 +60,42 @@
         "title": "Preview the CDS workflow",
         "category": "CDS",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "vscode-cds.refreshWorkflowView",
+        "title": "Refresh",
+        "category": "CDS",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "vscode-cds.triggerWorkflow",
+        "title": "Trigger Workflow Run",
+        "category": "CDS",
+        "icon": "$(play)"
+      },
+      {
+        "command": "vscode-cds.stopRun",
+        "title": "Stop Run",
+        "category": "CDS",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "vscode-cds.restartRun",
+        "title": "Restart Run",
+        "category": "CDS",
+        "icon": "$(debug-restart)"
+      },
+      {
+        "command": "vscode-cds.viewRunLogs",
+        "title": "Download Run Logs",
+        "category": "CDS",
+        "icon": "$(output)"
+      },
+      {
+        "command": "vscode-cds.refreshRuns",
+        "title": "Refresh Runs",
+        "category": "CDS",
+        "icon": "$(sync)"
       }
     ],
     "configuration": {
@@ -73,6 +126,40 @@
           "when": "isCDSWorkflowFile",
           "alt": "vscode-cds.previewWorkflow",
           "group": "navigation"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "vscode-cds.refreshWorkflowView",
+          "when": "view == vscode-cds-workflows",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "vscode-cds.triggerWorkflow",
+          "when": "view == vscode-cds-workflows && viewItem =~ /cdsRepoWorkspace|cdsRepoCds|cdsWorkflow/",
+          "group": "inline@1"
+        },
+        {
+          "command": "vscode-cds.stopRun",
+          "when": "view == vscode-cds-workflows && viewItem == cdsRunBuilding",
+          "group": "inline@1"
+        },
+        {
+          "command": "vscode-cds.restartRun",
+          "when": "view == vscode-cds-workflows && viewItem =~ /cdsRunFailed|cdsRunDone/",
+          "group": "inline@2"
+        },
+        {
+          "command": "vscode-cds.viewRunLogs",
+          "when": "view == vscode-cds-workflows && viewItem =~ /cdsRun/",
+          "group": "inline@3"
+        },
+        {
+          "command": "vscode-cds.refreshRuns",
+          "when": "view == vscode-cds-workflows && viewItem == cdsWorkflow",
+          "group": "inline@4"
         }
       ]
     },

--- a/contrib/vscode-cds/src/cdsService.ts
+++ b/contrib/vscode-cds/src/cdsService.ts
@@ -1,0 +1,296 @@
+import * as cp from "child_process";
+
+export interface CdsRepository {
+  id: string;
+  repoName: string;
+  vcsName: string;
+  projectKey: string;
+}
+
+export interface CdsWorkflowRun {
+  id: string;
+  runNumber: number;
+  status: string;
+  started: string;
+  workflowName: string;
+  projectKey: string;
+  username?: string;
+}
+
+const EXEC_TIMEOUT = 30_000;
+
+function run(cmd: string, cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    cp.exec(
+      cmd,
+      { cwd, timeout: EXEC_TIMEOUT, env: { ...process.env } },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error((stderr || err.message).trim()));
+        } else {
+          resolve(stdout.trim());
+        }
+      },
+    );
+  });
+}
+
+/** Parse ASCII table rows from cdsctl (only data lines starting with |). */
+export function parseTable(output: string): Record<string, string>[] {
+  const lines = output.split("\n");
+  // Find header line (first | line)
+  const dataLines = lines.filter((l) => /^\|/.test(l));
+  if (dataLines.length < 2) {
+    return [];
+  }
+  const headers = dataLines[0]
+    .split("|")
+    .map((h) =>
+      h
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_-]/g, ""),
+    )
+    .filter(Boolean);
+  const rows: Record<string, string>[] = [];
+  for (let i = 1; i < dataLines.length; i++) {
+    const cols = dataLines[i]
+      .split("|")
+      .map((c) => c.trim())
+      .filter(Boolean);
+    // Skip continuation lines (only one non-empty cell)
+    if (cols.length < 2) {
+      continue;
+    }
+    const row: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      row[h] = cols[idx] ?? "";
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+export function parseJson<T>(output: string): T[] {
+  try {
+    const parsed = JSON.parse(output);
+    return Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Parse a flat run record as returned by cdsctl --format json */
+function flatRunToWorkflowRun(
+  r: Record<string, string>,
+  defaults: { projKey: string; workflowName?: string },
+): CdsWorkflowRun {
+  return {
+    id: r["id"] ?? "",
+    runNumber: parseInt(r["run_number"] ?? r["runnumber"] ?? "0", 10),
+    status: r["status"] ?? "",
+    started: r["started"] ?? r["start"] ?? r["last_modified"] ?? "",
+    workflowName:
+      r["workflow_name"] ?? r["workflowname"] ?? defaults.workflowName ?? "",
+    projectKey: r["project_key"] ?? r["projectkey"] ?? defaults.projKey,
+    username: r["username"] ?? "",
+  };
+}
+
+export class CdsService {
+  /** Returns all project keys available in the current cdsctl context. */
+  async getProjectKeys(cwd?: string): Promise<string[]> {
+    try {
+      const out = await run("cdsctl project list --quiet", cwd);
+      return out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * List all CDS v2 repositories across all project keys.
+   */
+  async listRepositories(cwd?: string): Promise<CdsRepository[]> {
+    const projectKeys = await this.getProjectKeys(cwd);
+    const results: CdsRepository[] = [];
+    for (const projKey of projectKeys) {
+      try {
+        // Try JSON first, fall back to table
+        let repos: Array<{ id: string; vcsName: string; repoName: string }> =
+          [];
+        try {
+          const out = await run(
+            `cdsctl experimental project repository list ${projKey} --format json`,
+            cwd,
+          );
+          const parsed = parseJson<Record<string, string>>(out);
+          repos = parsed.map((r) => ({
+            id: r["id"] ?? "",
+            vcsName: r["vcsName"] ?? r["vcsname"] ?? r["vcs_name"] ?? "",
+            repoName: r["repoName"] ?? r["reponame"] ?? r["repo_name"] ?? "",
+          }));
+        } catch {
+          const out = await run(
+            `cdsctl experimental project repository list ${projKey}`,
+            cwd,
+          );
+          repos = parseTable(out).map((r) => ({
+            id: r["id"] ?? "",
+            vcsName: r["vcsname"] ?? "",
+            repoName: r["reponame"] ?? "",
+          }));
+        }
+        for (const r of repos) {
+          if (r.repoName) {
+            results.push({
+              id: r.id,
+              repoName: r.repoName,
+              vcsName: r.vcsName,
+              projectKey: projKey,
+            });
+          }
+        }
+      } catch {
+        // continue to next project key
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Get run history for a specific v2 workflow.
+   * Uses UUID for repoId to avoid shell quoting issues with slash-names.
+   */
+  async getWorkflowHistory(
+    projKey: string,
+    vcsName: string,
+    repoId: string,
+    workflowName: string,
+    limit = 15,
+    cwd?: string,
+  ): Promise<CdsWorkflowRun[]> {
+    const base = `cdsctl experimental workflow history ${projKey} ${vcsName} ${repoId} ${workflowName}`;
+    try {
+      const out = await run(`${base} --format json`, cwd);
+      const items = parseJson<Record<string, string>>(out);
+      return items
+        .slice(0, limit)
+        .map((r) => flatRunToWorkflowRun(r, { projKey, workflowName }));
+    } catch {
+      try {
+        const out = await run(base, cwd);
+        // table fallback
+        return parseTable(out)
+          .slice(0, limit)
+          .map((r) => ({
+            id: r["id"] ?? "",
+            runNumber: parseInt(r["runnumber"] ?? r["run number"] ?? "0", 10),
+            status: r["status"] ?? "",
+            started: r["started"] ?? "",
+            workflowName,
+            projectKey: projKey,
+            username: r["username"] ?? "",
+          }));
+      } catch {
+        return [];
+      }
+    }
+  }
+
+  /**
+   * List workflow names that have runs in a given repo by calling history for
+   * every workflow discovered from a lightweight workflow search.
+   * Returns unique workflow names scoped to a specific repository.
+   * Step 1: collect all candidate names project-wide.
+   * Step 2: verify each candidate belongs to this repo via --workflow vcs/repo/name filter.
+   */
+  async discoverRepoWorkflowNames(
+    projKey: string,
+    vcsName: string,
+    repoName: string,
+    cwd?: string,
+  ): Promise<string[]> {
+    // Step 1: collect candidate names across the whole project
+    let candidates: string[] = [];
+    try {
+      const out = await run(
+        `cdsctl experimental workflow search --project ${projKey} --limit 200 --format json`,
+        cwd,
+      );
+      const items = parseJson<Record<string, string>>(out);
+      const names = new Set<string>();
+      for (const r of items) {
+        const n = r["workflow_name"] ?? r["workflowname"] ?? "";
+        if (n) {
+          names.add(n);
+        }
+      }
+      candidates = [...names];
+    } catch {
+      return [];
+    }
+
+    // Step 2: verify each candidate belongs to this specific repo using the
+    // --workflow <vcs>/<repo>/<name> scoped filter (returns empty if not in repo)
+    const verified: string[] = [];
+    await Promise.all(
+      candidates.map(async (name) => {
+        try {
+          const out = await run(
+            `cdsctl experimental workflow search --project ${projKey} --workflow "${vcsName}/${repoName}/${name}" --limit 1 --format json`,
+            cwd,
+          );
+          const items = parseJson<Record<string, string>>(out);
+          if (items.length > 0) {
+            verified.push(name);
+          }
+        } catch {
+          // workflow not in this repo — skip
+        }
+      }),
+    );
+    return verified;
+  }
+
+  /** Build the cdsctl command to trigger a v2 workflow run (run in a terminal). */
+  buildTriggerV2Command(
+    projKey: string,
+    vcsName: string,
+    repoId: string,
+    workflowName: string,
+    branch?: string,
+    tag?: string,
+  ): string {
+    let cmd = `cdsctl experimental workflow run ${projKey} ${vcsName} ${repoId} ${workflowName}`;
+    if (branch) {
+      cmd += ` --branch ${branch}`;
+    }
+    if (tag) {
+      cmd += ` --tag ${tag}`;
+    }
+    return cmd;
+  }
+
+  /** Stop a running v2 workflow run. */
+  async stopRun(projKey: string, runId: string, cwd?: string): Promise<void> {
+    await run(`cdsctl experimental workflow stop ${projKey} ${runId}`, cwd);
+  }
+
+  /** Restart failed/stopped jobs in a v2 workflow run. */
+  async restartRun(
+    projKey: string,
+    runId: string,
+    cwd?: string,
+  ): Promise<void> {
+    await run(`cdsctl experimental workflow restart ${projKey} ${runId}`, cwd);
+  }
+
+  /** Build the command to download run logs (run in a terminal). */
+  buildLogsCommand(projKey: string, runId: string): string {
+    return `cdsctl experimental workflow logs download ${projKey} ${runId}`;
+  }
+}

--- a/contrib/vscode-cds/src/extension.ts
+++ b/contrib/vscode-cds/src/extension.ts
@@ -1,3 +1,4 @@
+import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -18,6 +19,8 @@ import { onGitRepositoryChanged, updateGitRepository } from './events/git-reposi
 import { PreviewWorkflowCommand } from './commands/preview-workflow';
 import { isCDSActionFile, isCDSWorkerModelFile, isCDSWorkflowFile } from './cds/file_utils';
 import { ClearCacheCommand } from './commands/clear-cache';
+import { WorkflowViewProvider, WorkflowItem, RunItem, RepoItem } from './workflowViewProvider';
+import { CdsService } from './cdsService';
 
 const CDS_SCHEMA = 'cds';
 
@@ -99,6 +102,114 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // init the vscode context
     updateVscodeContext(vscode.window.activeTextEditor);
+
+    // ── Workflow Explorer ────────────────────────────────────────────────────
+    const svc = new CdsService();
+    const workflowViewProvider = new WorkflowViewProvider(
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ''
+    );
+
+    vscode.window.registerTreeDataProvider('vscode-cds-workflows', workflowViewProvider);
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeWorkspaceFolders(() => workflowViewProvider.refresh())
+    );
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.refreshWorkflowView', () => {
+        workflowViewProvider.refresh();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.triggerWorkflow', async (item?: WorkflowItem | RepoItem) => {
+        let projKey: string | undefined;
+        let vcsName: string | undefined;
+        let repoId: string | undefined;
+        let workflowName: string | undefined;
+        let repoRoot: string | undefined;
+
+        if (item instanceof WorkflowItem && item.repo.cdsRepo) {
+            projKey = item.repo.cdsRepo.projectKey;
+            vcsName = item.repo.cdsRepo.vcsName;
+            repoId = item.repo.cdsRepo.id;
+            workflowName = item.cdsWorkflowName;
+            repoRoot = item.repo.repoRoot;
+        } else if (item instanceof RepoItem && item.cdsRepo) {
+            projKey = item.cdsRepo.projectKey;
+            vcsName = item.cdsRepo.vcsName;
+            repoId = item.cdsRepo.id;
+            repoRoot = item.repoRoot;
+            workflowName = await vscode.window.showInputBox({
+                title: 'Workflow name',
+                prompt: 'Enter the CDS v2 workflow name (filename without .yaml)',
+            });
+            if (!workflowName) { return; }
+        }
+
+        if (!projKey || !vcsName || !repoId || !workflowName) {
+            vscode.window.showErrorMessage('No CDS repository data associated with this item.');
+            return;
+        }
+
+        const branch = await vscode.window.showInputBox({
+            title: 'Branch',
+            prompt: 'Branch to run on (leave empty for default)',
+            value: await currentGitBranch(repoRoot),
+        });
+        if (branch === undefined) { return; }
+
+        const cmd = svc.buildTriggerV2Command(projKey, vcsName, repoId, workflowName, branch || undefined);
+        const terminal = vscode.window.createTerminal({ name: `CDS run: ${workflowName}`, cwd: repoRoot });
+        terminal.show();
+        terminal.sendText(cmd);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.stopRun', async (item?: RunItem) => {
+        if (!item?.run.id) { vscode.window.showErrorMessage('No run selected.'); return; }
+        const confirmed = await vscode.window.showWarningMessage(
+            `Stop run #${item.run.runNumber} of ${item.run.workflowName}?`, { modal: true }, 'Stop'
+        );
+        if (confirmed !== 'Stop') { return; }
+        try {
+            await svc.stopRun(item.run.projectKey, item.run.id, item.workflow.repo.repoRoot);
+            vscode.window.showInformationMessage(`Run #${item.run.runNumber} stopped.`);
+            workflowViewProvider.refreshRuns(item.workflow);
+        } catch (e) {
+            vscode.window.showErrorMessage(`Failed to stop run: ${(e as Error).message}`);
+        }
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.restartRun', async (item?: RunItem) => {
+        if (!item?.run.id) { vscode.window.showErrorMessage('No run selected.'); return; }
+        try {
+            await svc.restartRun(item.run.projectKey, item.run.id, item.workflow.repo.repoRoot);
+            vscode.window.showInformationMessage(`Run #${item.run.runNumber} restarted.`);
+            workflowViewProvider.refreshRuns(item.workflow);
+        } catch (e) {
+            vscode.window.showErrorMessage(`Failed to restart run: ${(e as Error).message}`);
+        }
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.viewRunLogs', async (item?: RunItem) => {
+        if (!item?.run.id) { vscode.window.showErrorMessage('No run selected.'); return; }
+        const cmd = svc.buildLogsCommand(item.run.projectKey, item.run.id);
+        const terminal = vscode.window.createTerminal({
+            name: `CDS logs: #${item.run.runNumber} ${item.run.workflowName}`,
+            cwd: item.workflow.repo.repoRoot,
+        });
+        terminal.show();
+        terminal.sendText(cmd);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('vscode-cds.refreshRuns', (item?: WorkflowItem) => {
+        if (item) { workflowViewProvider.refreshRuns(item); }
+    }));
+}
+
+async function currentGitBranch(cwd?: string): Promise<string> {
+    return new Promise((resolve) => {
+        cp.exec('git rev-parse --abbrev-ref HEAD', { cwd }, (_err, stdout) => {
+            resolve(stdout.trim() || '');
+        });
+    });
 }
 
 async function updateSchema(context: Context) {

--- a/contrib/vscode-cds/src/workflowViewProvider.ts
+++ b/contrib/vscode-cds/src/workflowViewProvider.ts
@@ -1,0 +1,352 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { CdsService, CdsRepository, CdsWorkflowRun } from "./cdsService";
+
+// ─── Tree item classes ───────────────────────────────────────────────────────
+
+export class RepoItem extends vscode.TreeItem {
+  readonly kind = "repo" as const;
+  constructor(
+    public readonly displayName: string,
+    public readonly cdsDir: string | undefined,
+    public readonly repoRoot: string | undefined,
+    public readonly cdsRepo: CdsRepository | undefined,
+  ) {
+    super(displayName, vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = `repo:${cdsRepo?.id ?? repoRoot ?? displayName}`;
+    this.description = cdsRepo
+      ? `${cdsRepo.repoName}  •  ${cdsRepo.vcsName}`
+      : cdsDir
+        ? "local only"
+        : undefined;
+    this.tooltip = cdsRepo
+      ? `${cdsRepo.repoName} (${cdsRepo.vcsName})\nProject: ${cdsRepo.projectKey}`
+      : (repoRoot ?? displayName);
+    this.iconPath = new vscode.ThemeIcon(
+      cdsRepo && cdsDir ? "repo-forked" : cdsRepo ? "cloud" : "folder-opened",
+    );
+    this.contextValue =
+      cdsRepo && cdsDir
+        ? "cdsRepoWorkspace"
+        : cdsRepo
+          ? "cdsRepoCds"
+          : "cdsRepoLocal";
+  }
+}
+
+export class WorkflowItem extends vscode.TreeItem {
+  readonly kind = "workflow" as const;
+  constructor(
+    public readonly displayLabel: string,
+    public readonly cdsWorkflowName: string,
+    public readonly filePath: string | undefined,
+    public readonly repo: RepoItem,
+  ) {
+    super(displayLabel, vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = `wf:${repo.id}:${cdsWorkflowName}`;
+    this.description = filePath
+      ? path.relative(repo.repoRoot ?? "", filePath)
+      : undefined;
+    this.tooltip = filePath ?? cdsWorkflowName;
+    this.iconPath = new vscode.ThemeIcon(
+      filePath ? "file-code" : "symbol-event",
+    );
+    this.contextValue = repo.cdsRepo ? "cdsWorkflow" : "cdsWorkflowLocal";
+    if (filePath) {
+      this.command = {
+        command: "vscode.open",
+        title: "Open Workflow File",
+        arguments: [vscode.Uri.file(filePath)],
+      };
+    }
+  }
+}
+
+const STATUS_ICONS: Record<string, string> = {
+  success: "pass-filled",
+  fail: "error",
+  failed: "error",
+  building: "sync~spin",
+  pending: "clock",
+  waiting: "clock",
+  skipped: "circle-slash",
+  stopped: "circle-slash",
+  cancelled: "circle-slash",
+};
+
+function statusIcon(status: string): vscode.ThemeIcon {
+  const lc = status.toLowerCase();
+  return new vscode.ThemeIcon(STATUS_ICONS[lc] ?? "circle-outline");
+}
+
+function runContextValue(status: string): string {
+  const lc = status.toLowerCase();
+  if (lc === "building" || lc === "pending" || lc === "waiting") {
+    return "cdsRunBuilding";
+  }
+  if (lc === "fail" || lc === "failed") {
+    return "cdsRunFailed";
+  }
+  if (lc === "success") {
+    return "cdsRunSuccess";
+  }
+  return "cdsRunDone";
+}
+
+function relativeTime(iso: string): string {
+  if (!iso) {
+    return "";
+  }
+  const diff = Date.now() - new Date(iso).getTime();
+  if (isNaN(diff)) {
+    return iso;
+  }
+  const s = Math.floor(diff / 1000);
+  if (s < 60) {
+    return `${s}s ago`;
+  }
+  const m = Math.floor(s / 60);
+  if (m < 60) {
+    return `${m}m ago`;
+  }
+  const h = Math.floor(m / 60);
+  if (h < 24) {
+    return `${h}h ago`;
+  }
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export class RunItem extends vscode.TreeItem {
+  readonly kind = "run" as const;
+  constructor(
+    public readonly run: CdsWorkflowRun,
+    public readonly workflow: WorkflowItem,
+  ) {
+    const ago = run.started ? `  ${relativeTime(run.started)}` : "";
+    super(`#${run.runNumber}${ago}`, vscode.TreeItemCollapsibleState.None);
+    this.id = `run:${run.id || run.runNumber}:${run.workflowName}`;
+    this.description = run.status;
+    this.tooltip = [
+      `Run #${run.runNumber}`,
+      `Status: ${run.status}`,
+      run.username ? `By: ${run.username}` : "",
+      run.started ? `Started: ${run.started}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    this.iconPath = statusIcon(run.status);
+    this.contextValue = runContextValue(run.status);
+  }
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+type TreeNode = RepoItem | WorkflowItem | RunItem;
+
+export class WorkflowViewProvider implements vscode.TreeDataProvider<TreeNode> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+    TreeNode | undefined | null | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private readonly svc = new CdsService();
+
+  // Promise-based caches — undefined = not started yet
+  private repoPromise: Promise<RepoItem[]> | undefined;
+  private workflowPromises = new Map<string, Promise<WorkflowItem[]>>();
+  private runPromises = new Map<string, Promise<RunItem[]>>();
+
+  // Workflow names discovered per CDS repo (projectKey:repoId -> Set<workflowName>)
+  private discoveredWorkflows = new Map<string, Promise<string[]>>();
+
+  constructor(_workspaceRoot: string) {
+    /* initial load on first getChildren */
+  }
+
+  getTreeItem(element: TreeNode): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: TreeNode): vscode.ProviderResult<TreeNode[]> {
+    if (!element) {
+      if (!this.repoPromise) {
+        this.repoPromise = this.buildRepoList();
+      }
+      return this.repoPromise;
+    }
+    if (element instanceof RepoItem) {
+      if (!this.workflowPromises.has(element.id!)) {
+        this.workflowPromises.set(element.id!, this.buildWorkflowList(element));
+      }
+      return this.workflowPromises.get(element.id!)!;
+    }
+    if (element instanceof WorkflowItem) {
+      if (!this.runPromises.has(element.id!)) {
+        this.runPromises.set(element.id!, this.buildRunList(element));
+      }
+      return this.runPromises.get(element.id!)!;
+    }
+    return [];
+  }
+
+  refresh(): void {
+    this.repoPromise = undefined;
+    this.workflowPromises.clear();
+    this.runPromises.clear();
+    this.discoveredWorkflows.clear();
+    this._onDidChangeTreeData.fire();
+  }
+
+  /** Refresh only a single workflow's run list (after stop / restart). */
+  refreshRuns(wf: WorkflowItem): void {
+    this.runPromises.delete(wf.id!);
+    this._onDidChangeTreeData.fire(wf);
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private async buildRepoList(): Promise<RepoItem[]> {
+    // 1. Scan workspace folders for .cds directories
+    const cdsDirs: Array<{ cdsDir: string; repoRoot: string }> = [];
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      for (const d of this.findCdsDirs(folder.uri.fsPath)) {
+        cdsDirs.push({ cdsDir: d, repoRoot: path.dirname(d) });
+      }
+    }
+
+    // 2. Get all CDS repos from cdsctl (v2)
+    const cdsRepos = await this.svc.listRepositories();
+
+    // 4. Match workspace dirs to CDS repos by basename
+    const matchedIds = new Set<string>();
+    const workspaceItems: RepoItem[] = [];
+    for (const { cdsDir, repoRoot } of cdsDirs) {
+      const dirName = path.basename(repoRoot);
+      const cdsRepo = cdsRepos.find(
+        (r) => r.repoName === dirName || r.repoName.endsWith("/" + dirName),
+      );
+      if (cdsRepo) {
+        matchedIds.add(cdsRepo.id);
+      }
+      workspaceItems.push(new RepoItem(dirName, cdsDir, repoRoot, cdsRepo));
+    }
+    // Matched workspace repos first
+    workspaceItems.sort((a, b) =>
+      !!a.cdsRepo === !!b.cdsRepo ? 0 : a.cdsRepo ? -1 : 1,
+    );
+
+    // 5. CDS repos not found in workspace
+    const cdsOnlyItems = cdsRepos
+      .filter((r) => !matchedIds.has(r.id))
+      .map((r) => new RepoItem(r.repoName, undefined, undefined, r));
+
+    return [...workspaceItems, ...cdsOnlyItems];
+  }
+
+  private async buildWorkflowList(repo: RepoItem): Promise<WorkflowItem[]> {
+    const workflows: WorkflowItem[] = [];
+    const seen = new Set<string>();
+
+    // Local .cds/ YAML files take priority
+    if (repo.cdsDir) {
+      for (const filePath of this.scanYamlFiles(repo.cdsDir)) {
+        const wfName = path.basename(filePath).replace(/\.(yaml|yml)$/, "");
+        if (!seen.has(wfName)) {
+          seen.add(wfName);
+          workflows.push(
+            new WorkflowItem(path.basename(filePath), wfName, filePath, repo),
+          );
+        }
+      }
+    }
+
+    // For CDS-only repos (not in workspace): discover workflows scoped to this
+    // specific repo. Workspace repos use local YAML files as the source of truth.
+    if (repo.cdsRepo && !repo.cdsDir) {
+      const { projectKey, vcsName, repoName, id: repoId } = repo.cdsRepo;
+      const cacheKey = `${projectKey}:${repoId}`;
+      if (!this.discoveredWorkflows.has(cacheKey)) {
+        this.discoveredWorkflows.set(
+          cacheKey,
+          this.svc.discoverRepoWorkflowNames(projectKey, vcsName, repoName),
+        );
+      }
+      const names = await this.discoveredWorkflows.get(cacheKey)!;
+      for (const name of names) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          workflows.push(new WorkflowItem(name, name, undefined, repo));
+        }
+      }
+    }
+
+    return workflows;
+  }
+
+  private async buildRunList(wf: WorkflowItem): Promise<RunItem[]> {
+    if (!wf.repo.cdsRepo) {
+      return [];
+    }
+    const { projectKey, vcsName, id: repoId, repoName } = wf.repo.cdsRepo;
+
+    // Use the repo UUID to avoid shell-quoting issues with slash-names
+    const runs = await this.svc.getWorkflowHistory(
+      projectKey,
+      vcsName,
+      repoId,
+      wf.cdsWorkflowName,
+      15,
+      wf.repo.repoRoot,
+    );
+
+    return runs.map((r) => new RunItem(r, wf));
+  }
+
+  private findCdsDirs(dir: string, depth = 0): string[] {
+    if (depth > 3) {
+      return [];
+    }
+    const found: string[] = [];
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const full = path.join(dir, entry.name);
+        if (entry.name === ".cds") {
+          found.push(full);
+        } else if (
+          !entry.name.startsWith(".") &&
+          entry.name !== "node_modules"
+        ) {
+          found.push(...this.findCdsDirs(full, depth + 1));
+        }
+      }
+    } catch {
+      /* skip unreadable dirs */
+    }
+    return found;
+  }
+
+  private scanYamlFiles(dir: string): string[] {
+    const results: string[] = [];
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          results.push(...this.scanYamlFiles(full));
+        } else if (
+          entry.isFile() &&
+          !entry.name.startsWith(".") &&
+          (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))
+        ) {
+          results.push(full);
+        }
+      }
+    } catch {
+      /* skip */
+    }
+    return results;
+  }
+}


### PR DESCRIPTION

### Description

Adds a **Workflow Explorer** sidebar panel to the CDS VS Code extension.

The panel surfaces a live tree of all your CDS repositories, their workflows and recent run history, directly in the editor — no browser tab-switching, no copy-pasting run IDs.

**Tree structure:** Projects → Repos → Workflows → Run history

**Features:**
- Workspace repos (those with a `.cds/` folder open in VS Code) are automatically matched to their CDS counterpart and shown first, with priority over CDS-only repos
- Trigger a workflow run — prompts for branch, pre-fills the current git branch
- Stop a running job
- Restart failed/stopped jobs
- Download run logs (opens a named terminal)
- Per-workflow and full-tree refresh buttons

**Implementation:**
- `src/cdsService.ts` — all `cdsctl` CLI interactions (repo list, run history, trigger / stop / restart / logs). No direct HTTP — delegates entirely to `cdsctl` so the user's existing context, MFA tokens and permissions apply automatically.
- `src/workflowViewProvider.ts` — `TreeDataProvider` with promise-based caching. Workspace repos are matched by repo basename. CDS-only repos use a two-step workflow discovery (project-wide candidates, then per-repo verification via `--workflow vcs/repo/name`).
- `src/extension.ts` — registers the tree view and new commands under the existing `vscode-cds.*` namespace.
- package.json — adds `viewsContainers`, `views`, 6 new commands and inline toolbar menu contributions.

### Related issues

None — this is a new feature. If there is an existing issue tracking a workflow explorer or run management UI, happy to link it.

### Tests

The new code is entirely driven by `cdsctl` subprocess calls and VS Code tree view API. There is no standalone unit-testable logic beyond what is already covered by the existing test infrastructure. Manual testing was done against a live CDS v2 instance (`cdsctl experimental` API). If the project adopts integration tests for VS Code extension views I'm happy to contribute them in a follow-up.

### Mentions

@ovh/cds

    Signed-off-by: Morgan Guichard morgan.guichard@epitech.eu