### PR TITLE
feat(hatchery/vsphere): multi-network and deprovisioning

### DIFF
--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -34,6 +34,7 @@ The hatchery implements the `hatchery.InterfaceWithModels` interface and support
 | `vsphere.go` | `VSphereClient` interface and govmomi SDK wrapper implementation |
 | `init.go` | Hatchery initialization, govmomi client creation, background goroutines setup |
 | `ip.go` | IP address management (allocation, reservation, availability) |
+| `networks.go` | Multi-network initialization (parses networks config, builds IP pools per network) |
 | `monitoring.go` | Prometheus metrics: vSphere resource consumption at per-worker, hatchery, and pool levels |
 
 ## 3. Configuration
@@ -52,10 +53,11 @@ The hatchery is configured via `HatcheryConfiguration`, serialized as TOML.
 | `datastoreString` | `string` | — | No | vSphere datastore name (uses default if empty) |
 | `networkString` | `string` | — | No | vSphere network name (uses default if empty) |
 | `cardName` | `string` | `e1000` | No | Virtual ethernet card type |
-| `iprange` | `string` | — | No | IP range for static IP assignment (format: `a.a.a.a/b,c.c.c.c/e`) |
-| `gateway` | `string` | — | No | Gateway IP for spawned workers |
+| `iprange` | `string` | — | No | **Deprecated**: use `networks` instead. IP range for static IP assignment (format: `a.a.a.a/b,c.c.c.c/e`) |
+| `gateway` | `string` | — | No | **Deprecated**: use `networks` instead. Gateway IP for spawned workers |
 | `dns` | `string` | — | No | DNS server IP |
-| `subnetMask` | `string` | `255.255.255.0` | No | Subnet mask |
+| `subnetMask` | `string` | `255.255.255.0` | No | **Deprecated**: use `networks` instead. Subnet mask |
+| `networks` | `[]NetworkConfig` | — | No | List of network configurations (see section 3.1.2) |
 | `workerTTL` | `int` | `120` | No | Worker time-to-live in minutes |
 | `workerRegistrationTTL` | `int` | `10` | No | Worker registration timeout in minutes |
 | `workerProvisioningInterval` | `int` | `120` (2 min) | No | Provisioning loop interval in seconds |
@@ -63,6 +65,21 @@ The hatchery is configured via `HatcheryConfiguration`, serialized as TOML.
 | `workerProvisioning` | `[]WorkerProvisioningConfig` | — | No | List of models to pre-provision |
 | `guestCredentials` | `[]GuestCredential` | — | No | Guest OS credentials per model |
 | `defaultWorkerModelsV2` | `[]DefaultWorkerModelsV2` | — | No | Default V2 models for V1 jobs (binary matching) |
+
+### 3.1.2 Networks Configuration
+
+The `networks` field allows configuring multiple IP ranges, each with its own gateway and subnet mask.
+When a VM is spawned, the hatchery picks the first available IP across all configured networks and
+applies the corresponding gateway and subnet mask.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `iprange` | `string` | — | IP range in CIDR notation (format: `a.a.a.a/b,c.c.c.c/e`) |
+| `gateway` | `string` | — | Gateway IP for this network |
+| `subnetMask` | `string` | `255.255.255.0` | Subnet mask for this network |
+
+If `networks` is set, the legacy `iprange`, `gateway`, and `subnetMask` fields are ignored.
+If `networks` is empty and the legacy `iprange` is set, it is treated as a single-entry networks list.
 
 ### 3.1.1 Common Provision Configuration
 
@@ -278,11 +295,12 @@ Pre-provisioning creates idle VMs ahead of time so that job assignment is faster
 
 1. Lock the provisioning cache
 2. List all VMs prefixed with `provision-v2`, count per VMware model path
-3. For each model in `WorkerProvisioning` config with a `ModelVMWare`:
+3. **Deprovisioning**: for each model with more provisioned VMs than configured (or models removed from config), mark excess VMs for deletion
+4. For each model in `WorkerProvisioning` config with a `ModelVMWare`:
    - Calculate deficit: `config.Number - currentCount`
    - Queue provisioning tasks for the deficit
-4. Execute up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
-5. Each provisioning operation:
+5. Execute up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
+6. Each provisioning operation:
    - Generates a worker name: `provision-v2-<random>`
    - Adds name to `cacheProvisioning.pending`
    - Calls `ProvisionWorkerV2()`: clone → wait for IP → shutdown
@@ -291,10 +309,11 @@ Pre-provisioning creates idle VMs ahead of time so that job assignment is faster
 #### 6.3.2 V1 Provisioning (`provisioningV1`)
 
 1. Same counting logic as V2 but with `provision-v1` prefix and `WorkerModelPath`
-2. Additionally fetches the model from the CDS API to verify it doesn't need registration
-3. Distributes models in a round-robin provision queue
-4. Executes up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
-5. Each provisioning operation:
+2. **Deprovisioning**: same as V2 — excess VMs are marked for deletion when config count is decreased or model is removed
+3. Additionally fetches the model from the CDS API to verify it doesn't need registration
+4. Distributes models in a round-robin provision queue
+5. Executes up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
+6. Each provisioning operation:
    - Generates a worker name: `provision-v1-<random>`
    - Calls `ProvisionWorkerV1()`: clone → wait for IP → shutdown
 

--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -28,8 +28,9 @@ The hatchery implements the `hatchery.InterfaceWithModels` interface and support
 | File | Responsibility |
 |------|----------------|
 | `types.go` | Configuration structs and `HatcheryVSphere` struct definition |
-| `hatchery.go` | Hatchery lifecycle (init, config, CanSpawn), worker cleanup, provisioning loops |
-| `spawn.go` | VM spawning logic, template creation (V1), provisioning, worker bootstrap |
+| `hatchery.go` | Hatchery lifecycle (init, config, CanSpawn), worker cleanup, provisioning scheduler |
+| `spawn.go` | VM spawning logic, template creation (V1), provisioning clone, worker bootstrap |
+| `provision_cleanup.go` | Provisioning worker pool, task execution, reconciliation, `finishProvisioning` |
 | `client.go` | VM listing/filtering, clone spec preparation, guest operations |
 | `vsphere.go` | `VSphereClient` interface and govmomi SDK wrapper implementation |
 | `init.go` | Hatchery initialization, govmomi client creation, background goroutines setup |
@@ -221,7 +222,8 @@ On startup (`InitHatchery`), the hatchery:
 3. Instantiates the `VSphereClient` wrapper bound to the configured datacenter
 4. Parses the IP range (if configured) into a list of available IP addresses
 5. Starts background goroutines:
-   - **Provisioning loop** (if `workerProvisioning` is configured): runs every `workerProvisioningInterval` seconds, executes `provisioningV2()` then `provisioningV1()`
+   - **Provisioning worker pool** (if `workerProvisioning` is configured): `WorkerProvisioningPoolSize` long-lived workers that pull tasks from a shared channel
+   - **Provisioning scheduler** (if `workerProvisioning` is configured): runs every `workerProvisioningInterval` seconds, computes deficit, submits tasks to the pool, waits for batch completion
    - **Kill awol servers loop**: runs every 2 minutes, removes stale/expired VMs
    - **Kill disabled workers loop**: runs every 2 minutes, removes disabled workers
 
@@ -296,14 +298,15 @@ Pre-provisioning creates idle VMs ahead of time so that job assignment is faster
 1. Lock the provisioning cache
 2. List all VMs prefixed with `provision-v2`, count per VMware model path
 3. **Deprovisioning**: for each model with more provisioned VMs than configured (or models removed from config), mark excess VMs for deletion
-4. For each model in `WorkerProvisioning` config with a `ModelVMWare`:
+4. **Reconciliation**: submit "finish" tasks for orphaned VMs (see §6.3.4)
+5. For each model in `WorkerProvisioning` config with a `ModelVMWare`:
    - Calculate deficit: `config.Number - currentCount`
-   - Queue provisioning tasks for the deficit
-5. Execute up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
-6. Each provisioning operation:
+   - Submit "clone" tasks to the provisioning pool for the deficit
+6. Wait for the entire batch (reconciliation + new clones) to complete
+7. Each task executed by a pool worker:
    - Generates a worker name: `provision-v2-<random>`
    - Adds name to `cacheProvisioning.pending`
-   - Calls `ProvisionWorkerV2()`: clone → wait for IP → shutdown
+   - Calls `ProvisionWorkerV2()` (clone only), then `finishProvisioning()` (wait IP → shutdown)
    - Removes name from pending cache
 
 #### 6.3.2 V1 Provisioning (`provisioningV1`)
@@ -311,11 +314,12 @@ Pre-provisioning creates idle VMs ahead of time so that job assignment is faster
 1. Same counting logic as V2 but with `provision-v1` prefix and `WorkerModelPath`
 2. **Deprovisioning**: same as V2 — excess VMs are marked for deletion when config count is decreased or model is removed
 3. Additionally fetches the model from the CDS API to verify it doesn't need registration
-4. Distributes models in a round-robin provision queue
-5. Executes up to `WorkerProvisioningPoolSize` concurrent provisioning goroutines
-6. Each provisioning operation:
+4. **Reconciliation**: submit "finish" tasks for orphaned VMs (see §6.3.4)
+5. Distributes models in a round-robin provision queue and submits "clone" tasks
+6. Wait for the entire batch to complete
+7. Each task executed by a pool worker:
    - Generates a worker name: `provision-v1-<random>`
-   - Calls `ProvisionWorkerV1()`: clone → wait for IP → shutdown
+   - Calls `ProvisionWorkerV1()` (clone only), then `finishProvisioning()` (wait IP → shutdown)
 
 #### 6.3.3 Provisioned VM Lifecycle
 
@@ -324,7 +328,7 @@ A provisioned VM follows this lifecycle:
 ```
 Template ──clone──► Provisioned VM (powered on)
                     │
-                    ├── Wait for IP
+                    ├── Wait for IP (3 min timeout)
                     ├── Shutdown (stays in powered-off state)
                     │
                     └── On job assignment (FindProvisionnedWorker):
@@ -333,6 +337,35 @@ Template ──clone──► Provisioned VM (powered on)
                         ├── Wait for IP
                         └── Launch worker script
 ```
+
+#### 6.3.4 Provisioning State Reconciliation
+
+The `cacheProvisioning.pending` list is in-memory only. If the hatchery restarts while a VM is
+being provisioned (between clone and shutdown), that VM becomes orphaned: it stays powered on
+indefinitely and is never picked up by `FindProvisionnedWorker` (which requires a
+`VmPoweredOffEvent`).
+
+To handle this, each provisioning tick calls `reconcileProvisionedVMs()` which reconstructs the
+pending state by scanning all VMs:
+
+1. List all powered-on VMs with `provision-` prefix, `Provisioning: true` annotation, and
+   matching `HatcheryName`
+2. Skip VMs already in `cacheProvisioning.pending` (actively being provisioned this run)
+3. For each orphaned VM, re-inject it into the provisioning pipeline:
+   - Add the VM name to `cacheProvisioning.pending`
+   - Submit a "finish" task to the provisioning worker pool
+   - The pool worker runs `finishProvisioning`: `WaitForVirtualMachineIP` → `ShutdownVirtualMachine`
+   - If the VM already has an IP, `WaitForVirtualMachineIP` returns immediately and the VM is
+     shut down — completing its provisioning
+   - If the VM has no IP, the 3-minute timeout applies. On timeout, the VM is marked for deletion
+   - On completion (success or failure), the VM is removed from `cacheProvisioning.pending`
+
+Since reconciliation tasks are part of the same batch as new clone tasks, the scheduler waits
+for all work to complete before the next tick re-evaluates. This prevents double-counting and
+ensures a consistent snapshot between ticks.
+
+This mechanism also covers VMs where `ShutdownVirtualMachine` failed during normal operation
+(not just restarts), since the provisioning scheduler periodically re-runs reconciliation.
 
 #### 6.3.4 Finding a Provisioned Worker (`FindProvisionnedWorker`)
 
@@ -445,9 +478,10 @@ The `MaxWorker` limit and the vSphere-specific `WorkerProvisioning` (pre-provisi
   **do not count** against `MaxWorker`.
 - When a provisioned VM is assigned to a job, it is renamed (e.g. `provision-v2-xxx` →
   `worker-abc`). From that point, it **counts** against `MaxWorker`.
-- The `WorkerProvisioningPoolSize` config controls how many provisioning operations run in
-  parallel in the vSphere provisioning loop, but this is separate from
-  `MaxConcurrentProvisioning` which governs the common framework's capacity check.
+- The `WorkerProvisioningPoolSize` config controls how many persistent workers handle
+  provisioning tasks (clone + finish). The provisioning scheduler submits all tasks to the pool
+  and waits for the batch to complete. This is separate from `MaxConcurrentProvisioning` which
+  governs the common framework's capacity check.
 - There is **no global coordination** between the provisioning pool and `MaxWorker`. It is the
   operator's responsibility to ensure that `WorkerProvisioning[].Number` (total pre-provisioned
   VMs) plus expected active workers stays within the infrastructure's capacity.
@@ -555,7 +589,7 @@ template-defined network settings.
 For each VM with a CDS annotation belonging to this hatchery:
 
 1. **Marked for deletion**: Delete immediately
-2. **Provisioned VMs** (`provision-` prefix): Skip (managed by provisioning loop)
+2. **Provisioned VMs** (`provision-` prefix): Skip (managed by provisioning loop reconciliation, see §6.3.4)
 3. **Model templates** (`Model: true`): Skip (never delete)
 4. **Event analysis**: Load VM events (`VmStartingEvent`, `VmPoweredOffEvent`, `VmRenamedEvent`)
    - Filter out events related to provisioning (`provision-` in message)

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -281,36 +281,35 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 	}
 
 	if len(h.availableIPAddresses) > 0 {
-		var err error
-		ip, err := h.findAvailableIP(ctx)
+		ipRes, err := h.findAvailableIP(ctx)
 		if err != nil {
 			return nil, err
 		}
-		log.Debug(ctx, "Found %s as available IP", ip)
+		log.Debug(ctx, "Found %s as available IP (gw=%s, mask=%s)", ipRes.ip, ipRes.gateway, ipRes.subnetMask)
 		// Once we found an IP Address, we have to reserve this IP in local memory
 		// because the IP address won't be used directly on the server
-		if err := h.reserveIPAddress(ctx, ip); err != nil {
+		if err := h.reserveIPAddress(ctx, ipRes.ip); err != nil {
 			return nil, err
 		}
 
 		customSpec.NicSettingMap = []types.CustomizationAdapterMapping{
 			{
 				Adapter: types.CustomizationIPSettings{
-					Ip:         &types.CustomizationFixedIp{IpAddress: ip},
-					SubnetMask: h.Config.SubnetMask,
+					Ip:         &types.CustomizationFixedIp{IpAddress: ipRes.ip},
+					SubnetMask: ipRes.subnetMask,
 				},
 			},
 		}
-		if h.Config.Gateway != "" {
-			customSpec.NicSettingMap[0].Adapter.Gateway = []string{h.Config.Gateway}
+		if ipRes.gateway != "" {
+			customSpec.NicSettingMap[0].Adapter.Gateway = []string{ipRes.gateway}
 		}
 		if h.Config.DNS != "" {
 			customSpec.GlobalIPSettings = types.CustomizationGlobalIPSettings{DnsServerList: []string{h.Config.DNS}}
 		}
 
-		annot.IPAddress = ip
+		annot.IPAddress = ipRes.ip
 
-		log.Debug(ctx, "IP: %s; Gateway: %v; DNS: %v", ip, customSpec.NicSettingMap[0].Adapter.Gateway, customSpec.GlobalIPSettings.DnsServerList)
+		log.Debug(ctx, "IP: %s; Gateway: %v; DNS: %v", ipRes.ip, customSpec.NicSettingMap[0].Adapter.Gateway, customSpec.GlobalIPSettings.DnsServerList)
 	}
 
 	annotStr, err := json.Marshal(annot)

--- a/engine/hatchery/vsphere/client_test.go
+++ b/engine/hatchery/vsphere/client_test.go
@@ -237,6 +237,16 @@ func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{
+		{
+			config: NetworkConfig{
+				IPRange:    "192.168.0.0/24",
+				Gateway:    "192.168.0.254",
+				SubnetMask: "255.255.255.0",
+			},
+			ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+		},
+	}
 	h.reservedIPAddresses = []string{"192.168.0.1", "192.168.0.2"}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -150,6 +150,12 @@ func (h *HatcheryVSphere) CheckConfiguration(cfg interface{}) error {
 		if netCfg.IPRange == "" {
 			return sdk.WithStack(fmt.Errorf("networks[%d]: iprange is required", i))
 		}
+		if netCfg.Gateway == "" {
+			return sdk.WithStack(fmt.Errorf("networks[%d]: gateway is required", i))
+		}
+		if netCfg.SubnetMask == "" {
+			return sdk.WithStack(fmt.Errorf("networks[%d]: subnetMask is required", i))
+		}
 		_, err := sdk.IPinRanges(context.Background(), netCfg.IPRange)
 		if err != nil {
 			return sdk.WithStack(fmt.Errorf("networks[%d] ip-range error: %v", i, err))

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -145,6 +145,16 @@ func (h *HatcheryVSphere) CheckConfiguration(cfg interface{}) error {
 			return sdk.WithStack(fmt.Errorf("flag or environment variable ip-range error: %v", err))
 		}
 	}
+
+	for i, netCfg := range hconfig.Networks {
+		if netCfg.IPRange == "" {
+			return sdk.WithStack(fmt.Errorf("networks[%d]: iprange is required", i))
+		}
+		_, err := sdk.IPinRanges(context.Background(), netCfg.IPRange)
+		if err != nil {
+			return sdk.WithStack(fmt.Errorf("networks[%d] ip-range error: %v", i, err))
+		}
+	}
 	return nil
 }
 
@@ -769,6 +779,7 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 
 	// Count exiting provisionned machine for each vmware model
 	mapAlreadyProvisionned := make(map[string]int)
+	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
 	machines := h.getVirtualMachines(ctx)
 	for _, machine := range machines {
 		if !strings.HasPrefix(machine.Name, "provision-v2") {
@@ -783,9 +794,31 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 		}
 		if annot.Provisioning {
 			mapAlreadyProvisionned[annot.VMwareModelPath] = mapAlreadyProvisionned[annot.VMwareModelPath] + 1
+			mapProvisionedMachines[annot.VMwareModelPath] = append(mapProvisionedMachines[annot.VMwareModelPath], machine)
 		}
 	}
 	h.cacheProvisioning.mu.Unlock()
+
+	// Build a map of configured provisioning counts
+	configuredCounts := make(map[string]int)
+	for i := range h.Config.WorkerProvisioning {
+		modelVMware := h.Config.WorkerProvisioning[i].ModelVMWare
+		if modelVMware != "" {
+			configuredCounts[modelVMware] = h.Config.WorkerProvisioning[i].Number
+		}
+	}
+
+	// Remove excess provisioned VMs when config is decreased or model removed
+	for modelPath, provisionedMachines := range mapProvisionedMachines {
+		desired := configuredCounts[modelPath]
+		excess := len(provisionedMachines) - desired
+		if excess > 0 {
+			log.Info(ctx, "model vmware %q deprovisioning: removing %d excess (have %d, want %d)", modelPath, excess, len(provisionedMachines), desired)
+			for i := 0; i < excess; i++ {
+				h.markToDelete(ctx, provisionedMachines[i].Name)
+			}
+		}
+	}
 
 	var toProvisionVMWareModelNames []string
 	for i := range h.Config.WorkerProvisioning {
@@ -798,7 +831,7 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 		log.Info(ctx, "model vmware %q provisioning: %d/%d", modelVMware, mapAlreadyProvisionned[modelVMware], number)
 
 		nbToProvision := int(number) - mapAlreadyProvisionned[modelVMware]
-		if nbToProvision == 0 {
+		if nbToProvision <= 0 {
 			continue
 		}
 		for i = 1; i <= nbToProvision; i++ {
@@ -847,6 +880,7 @@ func (h *HatcheryVSphere) provisioningV1(ctx context.Context) {
 
 	// Count exiting provisionned machine for each model
 	mapAlreadyProvisionned := make(map[string]int)
+	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
 	machines := h.getVirtualMachines(ctx)
 	for _, machine := range machines {
 		if !strings.HasPrefix(machine.Name, "provision-v1") {
@@ -861,9 +895,31 @@ func (h *HatcheryVSphere) provisioningV1(ctx context.Context) {
 		}
 		if annot.Provisioning {
 			mapAlreadyProvisionned[annot.WorkerModelPath] = mapAlreadyProvisionned[annot.WorkerModelPath] + 1
+			mapProvisionedMachines[annot.WorkerModelPath] = append(mapProvisionedMachines[annot.WorkerModelPath], machine)
 		}
 	}
 	h.cacheProvisioning.mu.Unlock()
+
+	// Build a map of configured provisioning counts
+	configuredCounts := make(map[string]int)
+	for i := range h.Config.WorkerProvisioning {
+		modelPath := h.Config.WorkerProvisioning[i].ModelPath
+		if modelPath != "" {
+			configuredCounts[modelPath] = h.Config.WorkerProvisioning[i].Number
+		}
+	}
+
+	// Remove excess provisioned VMs when config is decreased or model removed
+	for modelPath, provisionedMachines := range mapProvisionedMachines {
+		desired := configuredCounts[modelPath]
+		excess := len(provisionedMachines) - desired
+		if excess > 0 {
+			log.Info(ctx, "model %q deprovisioning: removing %d excess (have %d, want %d)", modelPath, excess, len(provisionedMachines), desired)
+			for i := 0; i < excess; i++ {
+				h.markToDelete(ctx, provisionedMachines[i].Name)
+			}
+		}
+	}
 
 	// Count provision to create for each model
 	mapToProvision := make(map[string]int)

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ovh/cds/sdk/cdsclient"
 	"github.com/ovh/cds/sdk/hatchery"
 	cdslog "github.com/ovh/cds/sdk/log"
-	"github.com/ovh/cds/sdk/namesgenerator"
 	"github.com/ovh/cds/sdk/telemetry"
 )
 
@@ -783,7 +782,10 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 	h.cacheProvisioning.mu.Lock()
 
-	// Count exiting provisionned machine for each vmware model
+	// Count exiting provisionned machine for each vmware model.
+	// This counts ALL VMs with Provisioning annotation regardless of power state,
+	// so orphaned VMs (powered on, stuck) are included in the count. This ensures
+	// that reconciled VMs don't cause additional clones in the deficit calculation.
 	mapAlreadyProvisionned := make(map[string]int)
 	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
 	machines := h.getVirtualMachines(ctx)
@@ -826,7 +828,13 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 		}
 	}
 
-	var toProvisionVMWareModelNames []string
+	// Batch: reconcile orphaned VMs + provision new ones
+	var batch sync.WaitGroup
+
+	// Reconcile stuck provisioned VMs (powered on but not in pending cache)
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
+
+	// Compute deficit and submit clone tasks
 	for i := range h.Config.WorkerProvisioning {
 		modelVMware := h.Config.WorkerProvisioning[i].ModelVMWare
 		number := h.Config.WorkerProvisioning[i].Number
@@ -837,54 +845,25 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 		log.Info(ctx, "model vmware %q provisioning: %d/%d", modelVMware, mapAlreadyProvisionned[modelVMware], number)
 
 		nbToProvision := int(number) - mapAlreadyProvisionned[modelVMware]
-		if nbToProvision <= 0 {
-			continue
-		}
-		for i = 1; i <= nbToProvision; i++ {
-			toProvisionVMWareModelNames = append(toProvisionVMWareModelNames, modelVMware)
-		}
-	}
-
-	if len(toProvisionVMWareModelNames) == 0 {
-		return
-	}
-
-	poolSize := h.Config.WorkerProvisioningPoolSize
-	if poolSize == 0 {
-		poolSize = 1
-	}
-
-	// Provision workers
-	wg := new(sync.WaitGroup)
-	for i := 0; i < len(toProvisionVMWareModelNames) && i < poolSize; i++ {
-		wg.Add(1)
-		go func(modelVMware string) {
-			defer wg.Done()
-
-			workerName := namesgenerator.GenerateWorkerName("provision-v2")
-
-			h.cacheProvisioning.mu.Lock()
-			h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, workerName)
-			h.cacheProvisioning.mu.Unlock()
-
-			if err := h.ProvisionWorkerV2(ctx, modelVMware, workerName); err != nil {
-				ctx = log.ContextWithStackTrace(ctx, err)
-				log.Error(ctx, "unable to provision vmware worker v2 %q model %q: %v", workerName, modelVMware, err)
-				h.markToDelete(ctx, workerName)
+		for j := 0; j < nbToProvision; j++ {
+			batch.Add(1)
+			h.provisioningPool.tasks <- provisionTask{
+				cloneV2: modelVMware,
+				wg:      &batch,
 			}
-
-			h.cacheProvisioning.mu.Lock()
-			h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, workerName)
-			h.cacheProvisioning.mu.Unlock()
-		}(toProvisionVMWareModelNames[i])
+		}
 	}
-	wg.Wait()
+
+	batch.Wait()
 }
 
 func (h *HatcheryVSphere) provisioningV1(ctx context.Context) {
 	h.cacheProvisioning.mu.Lock()
 
-	// Count exiting provisionned machine for each model
+	// Count exiting provisionned machine for each model.
+	// This counts ALL VMs with Provisioning annotation regardless of power state,
+	// so orphaned VMs (powered on, stuck) are included in the count. This ensures
+	// that reconciled VMs don't cause additional clones in the deficit calculation.
 	mapAlreadyProvisionned := make(map[string]int)
 	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
 	machines := h.getVirtualMachines(ctx)
@@ -964,15 +943,17 @@ func (h *HatcheryVSphere) provisioningV1(ctx context.Context) {
 		}
 	}
 
-	// Distribute models in provision queue
-	countModelToProvision := len(mapToProvision)
-	if countModelToProvision == 0 {
+	if len(mapToProvision) == 0 {
 		return
 	}
-	poolSize := h.Config.WorkerProvisioningPoolSize
-	if poolSize == 0 {
-		poolSize = 1
-	}
+
+	// Batch: reconcile orphaned VMs + provision new ones
+	var batch sync.WaitGroup
+
+	// Reconcile stuck provisioned VMs (powered on but not in pending cache)
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v1", &batch)
+
+	// Distribute models in provision queue (round-robin) and submit tasks
 	var provisionQueue []string
 	for len(mapToProvision) > 0 {
 		for i := range h.Config.WorkerProvisioning {
@@ -990,30 +971,14 @@ func (h *HatcheryVSphere) provisioningV1(ctx context.Context) {
 		}
 	}
 
-	// Provision workers
-	wg := new(sync.WaitGroup)
-	for i := 0; i < len(provisionQueue) && i < poolSize; i++ {
-		modelPath := provisionQueue[i]
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			workerName := namesgenerator.GenerateWorkerName("provision-v1")
-
-			h.cacheProvisioning.mu.Lock()
-			h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, workerName)
-			h.cacheProvisioning.mu.Unlock()
-
-			if err := h.ProvisionWorkerV1(ctx, mapModels[modelPath], workerName); err != nil {
-				ctx = log.ContextWithStackTrace(ctx, err)
-				log.Error(ctx, "unable to provision vmware worker v1 %q model %q: %v", workerName, mapModels[modelPath], err)
-				h.markToDelete(ctx, workerName)
-			}
-
-			h.cacheProvisioning.mu.Lock()
-			h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, workerName)
-			h.cacheProvisioning.mu.Unlock()
-		}()
+	for _, modelPath := range provisionQueue {
+		model := mapModels[modelPath]
+		batch.Add(1)
+		h.provisioningPool.tasks <- provisionTask{
+			cloneV1: &model,
+			wg:      &batch,
+		}
 	}
-	wg.Wait()
+
+	batch.Wait()
 }

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -561,7 +561,10 @@ func TestHatcheryVSphere_provisioning_v1_do_nothing(t *testing.T) {
 		},
 	)
 
-	h.provisioningV1(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+	h.provisioningV1(ctx)
 }
 
 func TestHatcheryVSphere_provisioning_v2_do_nothing(t *testing.T) {
@@ -613,7 +616,10 @@ func TestHatcheryVSphere_provisioning_v2_do_nothing(t *testing.T) {
 		},
 	)
 
-	h.provisioningV2(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+	h.provisioningV2(ctx)
 }
 
 func TestHatcheryVSphere_provisioning_v1_start_one(t *testing.T) {
@@ -769,6 +775,14 @@ func TestHatcheryVSphere_provisioning_v1_start_one(t *testing.T) {
 		},
 	)
 
+	// finishProvisioning loads the VM by name, then waits for IP and shuts down
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, name string) (*object.VirtualMachine, error) {
+			assert.True(t, strings.HasPrefix(name, "provision-"))
+			return &workerVM, nil
+		},
+	)
+
 	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), &workerVM, gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vm *object.VirtualMachine, _ *string, _ string) error {
 			return nil
@@ -781,7 +795,10 @@ func TestHatcheryVSphere_provisioning_v1_start_one(t *testing.T) {
 		},
 	)
 
-	h.provisioningV1(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+	h.provisioningV1(ctx)
 }
 
 func TestHatcheryVSphere_GetDetaultModelV2Name(t *testing.T) {
@@ -868,7 +885,10 @@ func TestHatcheryVSphere_provisioning_v2_deprovision_excess(t *testing.T) {
 		},
 	).AnyTimes()
 
-	h.provisioningV2(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+	h.provisioningV2(ctx)
 
 	// 2 excess VMs should be marked for deletion (3 exist - 1 configured = 2 excess)
 	h.cacheToDelete.mu.Lock()
@@ -920,7 +940,10 @@ func TestHatcheryVSphere_provisioning_v2_deprovision_removed_model(t *testing.T)
 		},
 	).AnyTimes()
 
-	h.provisioningV2(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+	h.provisioningV2(ctx)
 
 	// Both VMs should be marked for deletion since model is removed from config
 	h.cacheToDelete.mu.Lock()

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -659,6 +659,10 @@ func TestHatcheryVSphere_provisioning_v1_start_one(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
@@ -810,4 +814,116 @@ func TestHatcheryVSphere_GetDetaultModelV2Name(t *testing.T) {
 
 	got = h.GetDetaultModelV2Name(context.TODO(), []sdk.Requirement{{Name: "foo", Value: "bar", Type: sdk.BinaryRequirement}})
 	require.Equal(t, "", got)
+}
+
+func TestHatcheryVSphere_provisioning_v2_deprovision_excess(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cdsclient := mock_cdsclient.NewMockInterface(ctrl)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+		Common: hatchery.Common{
+			Common: service.Common{
+				GoRoutines: sdk.NewGoRoutines(context.Background()),
+				Client:     cdsclient,
+			},
+		},
+		Config: HatcheryConfiguration{
+			WorkerProvisioning: []WorkerProvisioningConfig{
+				{
+					ModelVMWare: "the-model",
+					Number:      1, // decreased from 3 to 1
+				},
+			},
+		},
+	}
+
+	// 3 provisioned VMs exist, but config says only 1
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker-1"},
+					Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"model": false, "vmware_model_path": "the-model", "provisioning": true}`},
+					Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+				},
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker-2"},
+					Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"model": false, "vmware_model_path": "the-model", "provisioning": true}`},
+					Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+				},
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker-3"},
+					Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"model": false, "vmware_model_path": "the-model", "provisioning": true}`},
+					Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+				},
+			}, nil
+		},
+	).AnyTimes()
+
+	h.provisioningV2(context.Background())
+
+	// 2 excess VMs should be marked for deletion (3 exist - 1 configured = 2 excess)
+	h.cacheToDelete.mu.Lock()
+	defer h.cacheToDelete.mu.Unlock()
+	assert.Len(t, h.cacheToDelete.list, 2)
+	assert.Contains(t, h.cacheToDelete.list, "provision-v2-worker-1")
+	assert.Contains(t, h.cacheToDelete.list, "provision-v2-worker-2")
+}
+
+func TestHatcheryVSphere_provisioning_v2_deprovision_removed_model(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cdsclient := mock_cdsclient.NewMockInterface(ctrl)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+		Common: hatchery.Common{
+			Common: service.Common{
+				GoRoutines: sdk.NewGoRoutines(context.Background()),
+				Client:     cdsclient,
+			},
+		},
+		Config: HatcheryConfiguration{
+			// No models configured - all should be removed
+			WorkerProvisioning: []WorkerProvisioningConfig{},
+		},
+	}
+
+	// 2 provisioned VMs exist for a model that's no longer in config
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker-1"},
+					Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"model": false, "vmware_model_path": "removed-model", "provisioning": true}`},
+					Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+				},
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker-2"},
+					Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"model": false, "vmware_model_path": "removed-model", "provisioning": true}`},
+					Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+				},
+			}, nil
+		},
+	).AnyTimes()
+
+	h.provisioningV2(context.Background())
+
+	// Both VMs should be marked for deletion since model is removed from config
+	h.cacheToDelete.mu.Lock()
+	defer h.cacheToDelete.mu.Unlock()
+	assert.Len(t, h.cacheToDelete.list, 2)
 }

--- a/engine/hatchery/vsphere/init.go
+++ b/engine/hatchery/vsphere/init.go
@@ -31,11 +31,8 @@ func (h *HatcheryVSphere) InitHatchery(ctx context.Context) error {
 		return fmt.Errorf("unable to init vsphere metrics: %v", err)
 	}
 
-	if h.Config.IPRange != "" {
-		h.availableIPAddresses, err = sdk.IPinRanges(ctx, h.Config.IPRange)
-		if err != nil {
-			return err
-		}
+	if err := h.initNetworks(ctx); err != nil {
+		return err
 	}
 
 	killAwolServersTick := time.NewTicker(2 * time.Minute)

--- a/engine/hatchery/vsphere/init.go
+++ b/engine/hatchery/vsphere/init.go
@@ -41,6 +41,9 @@ func (h *HatcheryVSphere) InitHatchery(ctx context.Context) error {
 	if len(h.Config.WorkerProvisioning) > 0 {
 		log.Debug(ctx, "provisioning is enabled")
 
+		// Start the provisioning worker pool
+		h.startProvisioningPool(ctx)
+
 		provisioningInterval := 2 * time.Minute
 		if h.Config.WorkerProvisioningInterval > 0 {
 			provisioningInterval = time.Duration(h.Config.WorkerProvisioningInterval) * time.Second

--- a/engine/hatchery/vsphere/ip.go
+++ b/engine/hatchery/vsphere/ip.go
@@ -8,8 +8,9 @@ import (
 	"github.com/ovh/cds/sdk"
 )
 
-// For each IPs in the range, look for the first free ones
-func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (string, error) {
+// findAvailableIP looks for the first free IP across all configured networks
+// and returns the IP along with its associated network configuration.
+func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error) {
 	h.IpAddressesMutex.Lock()
 	defer h.IpAddressesMutex.Unlock()
 
@@ -38,15 +39,21 @@ func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (string, error) {
 		}
 	}
 
-	for _, ip := range h.availableIPAddresses {
-		_, isUsed := usedIPAddresses[ip]
-		isReserved := sdk.IsInArray(ip, h.reservedIPAddresses)
-		if !isUsed && !isReserved {
-			return ip, nil
+	for _, network := range h.availableNetworks {
+		for _, ip := range network.ipAddresses {
+			_, isUsed := usedIPAddresses[ip]
+			isReserved := sdk.IsInArray(ip, h.reservedIPAddresses)
+			if !isUsed && !isReserved {
+				return ipResult{
+					ip:         ip,
+					gateway:    network.config.Gateway,
+					subnetMask: network.config.SubnetMask,
+				}, nil
+			}
 		}
 	}
 
-	return "", sdk.WithStack(errors.New("no IP address available"))
+	return ipResult{}, sdk.WithStack(errors.New("no IP address available"))
 }
 
 func (h *HatcheryVSphere) reserveIPAddress(ctx context.Context, ip string) error {

--- a/engine/hatchery/vsphere/networks.go
+++ b/engine/hatchery/vsphere/networks.go
@@ -1,0 +1,55 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rockbears/log"
+
+	"github.com/ovh/cds/sdk"
+)
+
+// initNetworks builds the list of available networks from configuration.
+// It supports both the new Networks config and the legacy single IPRange/Gateway/SubnetMask fields.
+func (h *HatcheryVSphere) initNetworks(ctx context.Context) error {
+	h.availableNetworks = nil
+	h.availableIPAddresses = nil
+
+	// Build the effective list of network configs.
+	// New-style Networks takes precedence; if empty, fall back to legacy fields.
+	networks := h.Config.Networks
+	if len(networks) == 0 && h.Config.IPRange != "" {
+		networks = []NetworkConfig{
+			{
+				IPRange:    h.Config.IPRange,
+				Gateway:    h.Config.Gateway,
+				SubnetMask: h.Config.SubnetMask,
+			},
+		}
+	}
+
+	for i, netCfg := range networks {
+		if netCfg.IPRange == "" {
+			continue
+		}
+		if netCfg.SubnetMask == "" {
+			netCfg.SubnetMask = "255.255.255.0"
+		}
+
+		ips, err := sdk.IPinRanges(ctx, netCfg.IPRange)
+		if err != nil {
+			return fmt.Errorf("networks[%d] ip-range error: %v", i, err)
+		}
+
+		h.availableNetworks = append(h.availableNetworks, availableNetwork{
+			config:      netCfg,
+			ipAddresses: ips,
+		})
+		h.availableIPAddresses = append(h.availableIPAddresses, ips...)
+
+		log.Info(ctx, "network[%d]: %d IPs from %s (gw=%s, mask=%s)",
+			i, len(ips), netCfg.IPRange, netCfg.Gateway, netCfg.SubnetMask)
+	}
+
+	return nil
+}

--- a/engine/hatchery/vsphere/networks.go
+++ b/engine/hatchery/vsphere/networks.go
@@ -32,8 +32,11 @@ func (h *HatcheryVSphere) initNetworks(ctx context.Context) error {
 		if netCfg.IPRange == "" {
 			continue
 		}
+		if netCfg.Gateway == "" {
+			return fmt.Errorf("networks[%d]: gateway is required", i)
+		}
 		if netCfg.SubnetMask == "" {
-			netCfg.SubnetMask = "255.255.255.0"
+			return fmt.Errorf("networks[%d]: subnetMask is required", i)
 		}
 
 		ips, err := sdk.IPinRanges(ctx, netCfg.IPRange)
@@ -46,9 +49,15 @@ func (h *HatcheryVSphere) initNetworks(ctx context.Context) error {
 			ipAddresses: ips,
 		})
 		h.availableIPAddresses = append(h.availableIPAddresses, ips...)
+	}
 
-		log.Info(ctx, "network[%d]: %d IPs from %s (gw=%s, mask=%s)",
-			i, len(ips), netCfg.IPRange, netCfg.Gateway, netCfg.SubnetMask)
+	if len(h.availableNetworks) > 0 {
+		totalIPs := len(h.availableIPAddresses)
+		log.Info(ctx, "network configuration: %d network(s), %d total IPs available", len(h.availableNetworks), totalIPs)
+		for i, net := range h.availableNetworks {
+			log.Info(ctx, "  network[%d] gw=%s: %d IPs (mask=%s)",
+				i, net.config.Gateway, len(net.ipAddresses), net.config.SubnetMask)
+		}
 	}
 
 	return nil

--- a/engine/hatchery/vsphere/networks_test.go
+++ b/engine/hatchery/vsphere/networks_test.go
@@ -1,0 +1,288 @@
+package vsphere
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rockbears/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHatcheryVSphere_findAvailableIP_MultipleNetworks(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+	}
+
+	// Configure two networks with different gateways and subnets
+	h.availableIPAddresses = []string{
+		"10.0.1.1", "10.0.1.2", "10.0.1.3",
+		"10.0.2.1", "10.0.2.2", "10.0.2.3",
+	}
+	h.availableNetworks = []availableNetwork{
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.1.0/29",
+				Gateway:    "10.0.1.254",
+				SubnetMask: "255.255.255.0",
+			},
+			ipAddresses: []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"},
+		},
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.2.0/29",
+				Gateway:    "10.0.2.254",
+				SubnetMask: "255.255.248.0",
+			},
+			ipAddresses: []string{"10.0.2.1", "10.0.2.2", "10.0.2.3"},
+		},
+	}
+
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{}, nil
+		},
+	).AnyTimes()
+
+	ctx := context.Background()
+
+	// First available IP should come from the first network
+	result, err := h.findAvailableIP(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.1.1", result.ip)
+	assert.Equal(t, "10.0.1.254", result.gateway)
+	assert.Equal(t, "255.255.255.0", result.subnetMask)
+}
+
+func TestHatcheryVSphere_findAvailableIP_FallsToSecondNetwork(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+	}
+
+	// First network is fully reserved, second has availability
+	h.availableIPAddresses = []string{
+		"10.0.1.1", "10.0.1.2",
+		"10.0.2.1", "10.0.2.2",
+	}
+	h.availableNetworks = []availableNetwork{
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.1.0/30",
+				Gateway:    "10.0.1.254",
+				SubnetMask: "255.255.255.0",
+			},
+			ipAddresses: []string{"10.0.1.1", "10.0.1.2"},
+		},
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.2.0/30",
+				Gateway:    "10.0.2.254",
+				SubnetMask: "255.255.248.0",
+			},
+			ipAddresses: []string{"10.0.2.1", "10.0.2.2"},
+		},
+	}
+	// Reserve all IPs from first network
+	h.reservedIPAddresses = []string{"10.0.1.1", "10.0.1.2"}
+
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{}, nil
+		},
+	).AnyTimes()
+
+	ctx := context.Background()
+
+	// Should fall to second network
+	result, err := h.findAvailableIP(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.2.1", result.ip)
+	assert.Equal(t, "10.0.2.254", result.gateway)
+	assert.Equal(t, "255.255.248.0", result.subnetMask)
+}
+
+func TestHatcheryVSphere_prepareCloneSpec_MultiNetwork(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+	}
+	h.Config.VSphereNetworkString = "vbox-net"
+	h.Config.VSphereCardName = "ethernet-card"
+	h.Config.VSphereDatastoreString = "datastore"
+	h.Config.DNS = "8.8.8.8"
+
+	// First network exhausted (IPs used by VMs), second network has availability
+	h.availableIPAddresses = []string{
+		"10.0.1.1",
+		"10.0.2.1", "10.0.2.2",
+	}
+	h.availableNetworks = []availableNetwork{
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.1.0/30",
+				Gateway:    "10.0.1.254",
+				SubnetMask: "255.255.255.0",
+			},
+			ipAddresses: []string{"10.0.1.1"},
+		},
+		{
+			config: NetworkConfig{
+				IPRange:    "10.0.2.0/30",
+				Gateway:    "10.0.2.254",
+				SubnetMask: "255.255.248.0",
+			},
+			ipAddresses: []string{"10.0.2.1", "10.0.2.2"},
+		},
+	}
+
+	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine) (object.VirtualDeviceList, error) {
+			card := types.VirtualEthernetCard{}
+			return object.VirtualDeviceList{&card}, nil
+		},
+	)
+
+	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").DoAndReturn(
+		func(ctx context.Context, s string) (object.NetworkReference, error) {
+			return &object.Network{}, nil
+		},
+	)
+
+	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, card *types.VirtualEthernetCard, ethernetCardName string, network object.NetworkReference) error {
+			return nil
+		},
+	)
+
+	c.EXPECT().LoadResourcePool(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) (*object.ResourcePool, error) {
+			return &object.ResourcePool{}, nil
+		},
+	)
+
+	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").DoAndReturn(
+		func(ctx context.Context, name string) (*object.Datastore, error) {
+			return &object.Datastore{}, nil
+		},
+	)
+
+	// Simulate 10.0.1.1 already in use by a VM
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{
+				{
+					Summary: types.VirtualMachineSummary{
+						Config: types.VirtualMachineConfigSummary{Template: false},
+					},
+					Guest: &types.GuestInfo{
+						Net: []types.GuestNicInfo{
+							{IpAddress: []string{"10.0.1.1"}},
+						},
+					},
+				},
+			}, nil
+		},
+	).AnyTimes()
+
+	ctx := context.Background()
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cloneSpec)
+
+	// Should use IP from second network since first is exhausted
+	assert.Equal(t, "10.0.2.1", cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp).IpAddress)
+	// Gateway and subnet from second network
+	assert.Equal(t, "10.0.2.254", cloneSpec.Customization.NicSettingMap[0].Adapter.Gateway[0])
+	assert.Equal(t, "255.255.248.0", cloneSpec.Customization.NicSettingMap[0].Adapter.SubnetMask)
+	// DNS still global
+	assert.Equal(t, "8.8.8.8", cloneSpec.Customization.GlobalIPSettings.DnsServerList[0])
+}
+
+func TestHatcheryVSphere_initNetworks_LegacyConfig(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := HatcheryVSphere{}
+	h.Config.IPRange = "192.168.1.0/30"
+	h.Config.Gateway = "192.168.1.254"
+	h.Config.SubnetMask = "255.255.255.0"
+
+	ctx := context.Background()
+	err := h.initNetworks(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, h.availableNetworks, 1)
+	assert.Equal(t, "192.168.1.254", h.availableNetworks[0].config.Gateway)
+	assert.Equal(t, "255.255.255.0", h.availableNetworks[0].config.SubnetMask)
+	assert.True(t, len(h.availableNetworks[0].ipAddresses) > 0)
+	assert.Equal(t, h.availableNetworks[0].ipAddresses, h.availableIPAddresses)
+}
+
+func TestHatcheryVSphere_initNetworks_NewConfig(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := HatcheryVSphere{}
+	h.Config.Networks = []NetworkConfig{
+		{
+			IPRange:    "10.0.1.0/30",
+			Gateway:    "10.0.1.1",
+			SubnetMask: "255.255.255.0",
+		},
+		{
+			IPRange:    "10.0.2.0/30",
+			Gateway:    "10.0.2.1",
+			SubnetMask: "255.255.248.0",
+		},
+	}
+
+	ctx := context.Background()
+	err := h.initNetworks(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, h.availableNetworks, 2)
+	assert.Equal(t, "10.0.1.1", h.availableNetworks[0].config.Gateway)
+	assert.Equal(t, "255.255.255.0", h.availableNetworks[0].config.SubnetMask)
+	assert.Equal(t, "10.0.2.1", h.availableNetworks[1].config.Gateway)
+	assert.Equal(t, "255.255.248.0", h.availableNetworks[1].config.SubnetMask)
+
+	// availableIPAddresses should contain IPs from both networks
+	totalIPs := len(h.availableNetworks[0].ipAddresses) + len(h.availableNetworks[1].ipAddresses)
+	assert.Equal(t, totalIPs, len(h.availableIPAddresses))
+}
+
+func TestHatcheryVSphere_initNetworks_NewConfigOverridesLegacy(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := HatcheryVSphere{}
+	// Set both legacy and new config - new should take precedence
+	h.Config.IPRange = "192.168.1.0/30"
+	h.Config.Gateway = "192.168.1.254"
+	h.Config.SubnetMask = "255.255.255.0"
+	h.Config.Networks = []NetworkConfig{
+		{
+			IPRange:    "10.0.1.0/30",
+			Gateway:    "10.0.1.1",
+			SubnetMask: "255.255.248.0",
+		},
+	}
+
+	ctx := context.Background()
+	err := h.initNetworks(ctx)
+	require.NoError(t, err)
+
+	// Networks config takes precedence over legacy
+	require.Len(t, h.availableNetworks, 1)
+	assert.Equal(t, "10.0.1.1", h.availableNetworks[0].config.Gateway)
+	assert.Equal(t, "255.255.248.0", h.availableNetworks[0].config.SubnetMask)
+}

--- a/engine/hatchery/vsphere/provision_cleanup.go
+++ b/engine/hatchery/vsphere/provision_cleanup.go
@@ -128,7 +128,7 @@ func (h *HatcheryVSphere) reconcileProvisionedVMs(ctx context.Context, machines 
 			continue
 		}
 
-		if machine.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
+		if machine.Summary.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
 			continue
 		}
 

--- a/engine/hatchery/vsphere/provision_cleanup.go
+++ b/engine/hatchery/vsphere/provision_cleanup.go
@@ -1,0 +1,196 @@
+package vsphere
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/rockbears/log"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/namesgenerator"
+)
+
+// provisionTask represents a unit of provisioning work submitted to the pool.
+type provisionTask struct {
+	// For "clone" tasks: clone a new VM then finish provisioning
+	cloneV1 *sdk.Model // non-nil for V1 clone tasks
+	cloneV2 string     // non-empty for V2 clone tasks (vmware model path)
+
+	// For "finish" tasks: the VM already exists, just wait IP + shutdown
+	finishVM string // non-nil for reconciled VMs (name of existing powered-on VM)
+
+	wg *sync.WaitGroup // shared per-batch WaitGroup, caller calls wg.Wait()
+}
+
+// provisioningPool manages a fixed set of long-lived worker goroutines that
+// execute provisioning tasks. Created at startup, shut down on context cancel.
+type provisioningPool struct {
+	tasks chan provisionTask
+}
+
+// startProvisioningPool launches the worker pool. Workers are long-lived and
+// pull tasks from the channel until the context is cancelled.
+func (h *HatcheryVSphere) startProvisioningPool(ctx context.Context) {
+	poolSize := h.Config.WorkerProvisioningPoolSize
+	if poolSize == 0 {
+		poolSize = 1
+	}
+
+	h.provisioningPool = &provisioningPool{
+		tasks: make(chan provisionTask, poolSize*2),
+	}
+
+	for i := 0; i < poolSize; i++ {
+		h.GoRoutines.Run(ctx, "hatchery-vsphere-provisioning-worker",
+			func(ctx context.Context) {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case task, ok := <-h.provisioningPool.tasks:
+						if !ok {
+							return
+						}
+						h.executeProvisionTask(ctx, task)
+					}
+				}
+			},
+		)
+	}
+}
+
+// executeProvisionTask runs a single provisioning task.
+func (h *HatcheryVSphere) executeProvisionTask(ctx context.Context, task provisionTask) {
+	defer task.wg.Done()
+
+	if task.finishVM != "" {
+		// Reconciled VM: just finish provisioning (wait IP + shutdown)
+		h.finishProvisioning(ctx, task.finishVM)
+		return
+	}
+
+	// Clone task: generate name, clone the VM, then finish provisioning
+	var workerName string
+	var err error
+
+	if task.cloneV2 != "" {
+		workerName = namesgenerator.GenerateWorkerName("provision-v2")
+
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, workerName)
+		h.cacheProvisioning.mu.Unlock()
+
+		err = h.ProvisionWorkerV2(ctx, task.cloneV2, workerName)
+		if err != nil {
+			ctx = log.ContextWithStackTrace(ctx, err)
+			log.Error(ctx, "unable to provision vmware worker v2 %q model %q: %v", workerName, task.cloneV2, err)
+		}
+	} else if task.cloneV1 != nil {
+		workerName = namesgenerator.GenerateWorkerName("provision-v1")
+
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, workerName)
+		h.cacheProvisioning.mu.Unlock()
+
+		err = h.ProvisionWorkerV1(ctx, *task.cloneV1, workerName)
+		if err != nil {
+			ctx = log.ContextWithStackTrace(ctx, err)
+			log.Error(ctx, "unable to provision vmware worker v1 %q model %q: %v", workerName, *task.cloneV1, err)
+		}
+	}
+
+	if err != nil {
+		h.markToDelete(ctx, workerName)
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, workerName)
+		h.cacheProvisioning.mu.Unlock()
+		return
+	}
+
+	// Clone succeeded — now wait for IP and shut down
+	h.finishProvisioning(ctx, workerName)
+}
+
+// reconcileProvisionedVMs detects provisioned VMs that are powered on but not
+// actively being provisioned (not in cacheProvisioning.pending). For each
+// orphaned VM it submits a "finish" task to the pool via the provided batch.
+func (h *HatcheryVSphere) reconcileProvisionedVMs(ctx context.Context, machines []mo.VirtualMachine, prefix string, batch *sync.WaitGroup) {
+	h.cacheProvisioning.mu.Lock()
+	pending := make([]string, len(h.cacheProvisioning.pending))
+	copy(pending, h.cacheProvisioning.pending)
+	h.cacheProvisioning.mu.Unlock()
+
+	for _, machine := range machines {
+		if !strings.HasPrefix(machine.Name, prefix) {
+			continue
+		}
+
+		if machine.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
+			continue
+		}
+
+		annot := getVirtualMachineCDSAnnotation(ctx, machine)
+		if annot == nil {
+			continue
+		}
+		if annot.HatcheryName != h.Name() {
+			continue
+		}
+		if !annot.Provisioning {
+			continue
+		}
+
+		if sdk.IsInArray(machine.Name, pending) {
+			continue
+		}
+
+		vmName := machine.Name
+		log.Info(ctx, "reconcileProvisionedVMs: resuming provisioning for VM %q", vmName)
+
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, vmName)
+		h.cacheProvisioning.mu.Unlock()
+
+		batch.Add(1)
+		h.provisioningPool.tasks <- provisionTask{
+			finishVM: vmName,
+			wg:       batch,
+		}
+	}
+}
+
+// finishProvisioning completes the provisioning of an already-cloned VM by
+// waiting for it to get an IP and then shutting it down. On failure the VM is
+// marked for deletion. In all cases the VM name is removed from
+// cacheProvisioning.pending when done.
+func (h *HatcheryVSphere) finishProvisioning(ctx context.Context, vmName string) {
+	defer func() {
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, vmName)
+		h.cacheProvisioning.mu.Unlock()
+	}()
+
+	vm, err := h.vSphereClient.LoadVirtualMachine(ctx, vmName)
+	if err != nil {
+		log.Error(ctx, "finishProvisioning: unable to load VM %q: %v", vmName, err)
+		h.markToDelete(ctx, vmName)
+		return
+	}
+
+	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, vm, nil, vmName); err != nil {
+		log.Warn(ctx, "finishProvisioning: VM %q failed to get IP, marking for deletion: %v", vmName, err)
+		h.markToDelete(ctx, vmName)
+		return
+	}
+
+	if err := h.vSphereClient.ShutdownVirtualMachine(ctx, vm); err != nil {
+		log.Warn(ctx, "finishProvisioning: unable to shutdown VM %q: %v", vmName, err)
+		h.markToDelete(ctx, vmName)
+		return
+	}
+
+	log.Info(ctx, "finishProvisioning: VM %q provisioning completed", vmName)
+}

--- a/engine/hatchery/vsphere/provision_cleanup_test.go
+++ b/engine/hatchery/vsphere/provision_cleanup_test.go
@@ -1,0 +1,142 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rockbears/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"go.uber.org/mock/gomock"
+)
+
+// setupTestPool creates a provisioning pool with a single worker for testing.
+func setupTestPool(ctx context.Context, h *HatcheryVSphere) {
+	h.provisioningPool = &provisioningPool{
+		tasks: make(chan provisionTask, 10),
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case task, ok := <-h.provisioningPool.tasks:
+				if !ok {
+					return
+				}
+				h.executeProvisionTask(ctx, task)
+			}
+		}
+	}()
+}
+
+func TestHatcheryVSphere_reconcileProvisionedVMs_completesProvisioning(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+
+	stuckCreatedAt := time.Now().Add(-15 * time.Minute)
+
+	machines := []mo.VirtualMachine{
+		{
+			// Powered on, provisioning annotation — should be reconciled
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-orphan"},
+			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Config: &types.VirtualMachineConfigInfo{
+				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
+			},
+		},
+		{
+			// Already powered off → ignored
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-ready"},
+			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+			Config: &types.VirtualMachineConfigInfo{
+				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
+			},
+		},
+		{
+			// In pending cache → ignored
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-pending"},
+			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Config: &types.VirtualMachineConfigInfo{
+				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
+			},
+		},
+	}
+
+	h.cacheProvisioning.pending = []string{"provision-v2-pending"}
+
+	// The worker will: LoadVirtualMachine → WaitForVirtualMachineIP → ShutdownVirtualMachine
+	vmObj := &object.VirtualMachine{}
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-orphan").Return(vmObj, nil)
+	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), vmObj, nil, "provision-v2-orphan").Return(nil)
+	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), vmObj).Return(nil)
+
+	var batch sync.WaitGroup
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
+	batch.Wait()
+
+	// VM should have been removed from pending after completion
+	h.cacheProvisioning.mu.Lock()
+	assert.NotContains(t, h.cacheProvisioning.pending, "provision-v2-orphan")
+	h.cacheProvisioning.mu.Unlock()
+
+	// No VMs should be marked for deletion — provisioning completed successfully
+	h.cacheToDelete.mu.Lock()
+	defer h.cacheToDelete.mu.Unlock()
+	assert.Empty(t, h.cacheToDelete.list)
+}
+
+func TestHatcheryVSphere_reconcileProvisionedVMs_deletesOnIPTimeout(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupTestPool(ctx, &h)
+
+	stuckCreatedAt := time.Now().Add(-15 * time.Minute)
+
+	machines := []mo.VirtualMachine{
+		{
+			// No IP, WaitForVirtualMachineIP will fail → marked for deletion
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-stuck"},
+			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Config: &types.VirtualMachineConfigInfo{
+				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
+			},
+		},
+	}
+
+	vmObj := &object.VirtualMachine{}
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-stuck").Return(vmObj, nil)
+	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), vmObj, nil, "provision-v2-stuck").Return(fmt.Errorf("context deadline exceeded"))
+
+	// markToDelete calls ListVirtualMachines
+	c.EXPECT().ListVirtualMachines(gomock.Any()).Return(machines, nil).AnyTimes()
+
+	var batch sync.WaitGroup
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
+	batch.Wait()
+
+	// The stuck VM should be marked for deletion
+	h.cacheToDelete.mu.Lock()
+	defer h.cacheToDelete.mu.Unlock()
+	assert.Equal(t, []string{"provision-v2-stuck"}, h.cacheToDelete.list)
+}

--- a/engine/hatchery/vsphere/provision_cleanup_test.go
+++ b/engine/hatchery/vsphere/provision_cleanup_test.go
@@ -53,7 +53,9 @@ func TestHatcheryVSphere_reconcileProvisionedVMs_completesProvisioning(t *testin
 		{
 			// Powered on, provisioning annotation — should be reconciled
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-orphan"},
-			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Summary: types.VirtualMachineSummary{
+				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			},
 			Config: &types.VirtualMachineConfigInfo{
 				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
 			},
@@ -61,7 +63,9 @@ func TestHatcheryVSphere_reconcileProvisionedVMs_completesProvisioning(t *testin
 		{
 			// Already powered off → ignored
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-ready"},
-			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+			Summary: types.VirtualMachineSummary{
+				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+			},
 			Config: &types.VirtualMachineConfigInfo{
 				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
 			},
@@ -69,7 +73,9 @@ func TestHatcheryVSphere_reconcileProvisionedVMs_completesProvisioning(t *testin
 		{
 			// In pending cache → ignored
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-pending"},
-			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Summary: types.VirtualMachineSummary{
+				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			},
 			Config: &types.VirtualMachineConfigInfo{
 				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
 			},
@@ -117,7 +123,9 @@ func TestHatcheryVSphere_reconcileProvisionedVMs_deletesOnIPTimeout(t *testing.T
 		{
 			// No IP, WaitForVirtualMachineIP will fail → marked for deletion
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-stuck"},
-			Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Summary: types.VirtualMachineSummary{
+				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			},
 			Config: &types.VirtualMachineConfigInfo{
 				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
 			},

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -513,7 +513,7 @@ func (h *HatcheryVSphere) ProvisionWorkerV1(ctx context.Context, m sdk.Model, wo
 		Created:                 time.Now(),
 	}
 
-	return h.provisionWorker(ctx, vmTemplate, annot, workerName)
+	return h.cloneProvisionedWorker(ctx, vmTemplate, annot, workerName)
 }
 
 func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel string, workerName string) error {
@@ -531,10 +531,13 @@ func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel str
 		Created:         time.Now(),
 	}
 
-	return h.provisionWorker(ctx, vmTemplate, annot, workerName)
+	return h.cloneProvisionedWorker(ctx, vmTemplate, annot, workerName)
 }
 
-func (h *HatcheryVSphere) provisionWorker(ctx context.Context, vmTemplate *object.VirtualMachine, annot annotation, workerName string) (err error) {
+// cloneProvisionedWorker clones a VM template for provisioning. After the clone
+// the VM is powered on but not yet shut down — the caller is responsible for
+// completing provisioning via finishProvisioning.
+func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate *object.VirtualMachine, annot annotation, workerName string) error {
 	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot, nil)
 	if err != nil {
 		return err
@@ -552,21 +555,9 @@ func (h *HatcheryVSphere) provisionWorker(ctx context.Context, vmTemplate *objec
 		return err
 	}
 
-	clonedVM, err := h.vSphereClient.NewVirtualMachine(ctx, cloneSpec, cloneRef, workerName)
-	if err != nil {
+	if _, err := h.vSphereClient.NewVirtualMachine(ctx, cloneSpec, cloneRef, workerName); err != nil {
 		return err
 	}
-
-	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, clonedVM, &annot.IPAddress, workerName); err != nil {
-		return err
-	}
-
-	// the provisionned workers are shutdown when they are created
-	if err := h.vSphereClient.ShutdownVirtualMachine(ctx, clonedVM); err != nil {
-		return err
-	}
-
-	log.Info(ctx, "vm %q has been provisionned", workerName)
 
 	return nil
 }

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -1114,18 +1114,6 @@ func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {
 		},
 	)
 
-	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), &workerVM, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine, _ *string, _ string) error {
-			return nil
-		},
-	)
-
-	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &workerVM).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) error {
-			return nil
-		},
-	)
-
 	err := h.ProvisionWorkerV1(ctx, validModel, "provisionned-worker")
 	require.NoError(t, err)
 }

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -42,6 +42,10 @@ func TestHatcheryVSphere_createVirtualMachineTemplate(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
@@ -386,6 +390,10 @@ func TestHatcheryVSphere_SpawnWorkerv1(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
@@ -577,6 +585,10 @@ func TestHatcheryVSphere_SpawnWorkerv2(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
@@ -776,6 +788,10 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
@@ -982,6 +998,10 @@ func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
 	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}}
 	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -103,6 +103,7 @@ type HatcheryVSphere struct {
 	availableIPAddresses []string // flat list kept for backward-compat checks (e.g. CanSpawn)
 	availableNetworks    []availableNetwork
 	reservedIPAddresses  []string
+	provisioningPool     *provisioningPool
 	cachePendingJobID    struct {
 		mu   sync.Mutex
 		list []string

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -17,22 +17,32 @@ type HatcheryConfiguration struct {
 	VSphereDatastoreString              string                     `mapstructure:"datastoreString" toml:"datastoreString" default:"" commented:"false" comment:"VSphere Datastore" json:"datastoreString"`
 	VSphereNetworkString                string                     `mapstructure:"networkString" toml:"networkString" default:"" commented:"false" comment:"VShpere Network" json:"networkString"`
 	VSphereCardName                     string                     `mapstructure:"cardName" toml:"cardName" default:"e1000" commented:"false" comment:"Name of the virtual ethernet card" json:"cardName"`
-	IPRange                             string                     `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"Optional. IP Range for spawned workers. \n Format: a.a.a.a/b,c.c.c.c/e \n Hatchery will use an IP from this range to create Virtual Machine (Fixed IP Attribute).\nIf not set, you have to set it in your worker model template" json:"iprange,omitempty"`
-	Gateway                             string                     `mapstructure:"gateway" toml:"gateway" default:"" commented:"false" comment:"Optional. Gateway IP for spawned workers." json:"gateway,omitempty"`
-	DNS                                 string                     `mapstructure:"dns" toml:"dns" default:"" commented:"false" comment:"Optional. DNS IP" json:"dns,omitempty"`
-	SubnetMask                          string                     `mapstructure:"subnetMask" toml:"subnetMask" default:"255.255.255.0" commented:"false" comment:"Subnet Mask" json:"subnetMask"`
-	WorkerTTL                           int                        `mapstructure:"workerTTL" toml:"workerTTL" default:"120" commented:"false" comment:"Worker TTL (minutes)" json:"workerTTL"`
-	WorkerRegistrationTTL               int                        `mapstructure:"workerRegistrationTTL" toml:"workerRegistrationTTL" commented:"false" comment:"Worker Registration TTL (minutes)" json:"workerRegistrationTTL"`
-	WorkerProvisioningInterval          int                        `mapstructure:"workerProvisioningInterval" toml:"workerProvisioningInterval" commented:"true" comment:"Worker Provisioning interval (seconds)" json:"workerProvisioningInterval"`
-	WorkerProvisioningPoolSize          int                        `mapstructure:"workerProvisioningPoolSize" toml:"workerProvisioningPoolSize" commented:"true" comment:"Worker Provisioning pool size" json:"workerProvisioningPoolSize"`
-	WorkerProvisioning                  []WorkerProvisioningConfig `mapstructure:"workerProvisioning" toml:"workerProvisioning" commented:"true" comment:"Worker Provisioning per model name" json:"workerProvisioning"`
-	GuestCredentials                    []GuestCredential          `mapstructure:"guestCredentials" toml:"guestCredentials" commented:"true" comment:"List of Guest credentials" json:"-"`
-	DefaultWorkerModelsV2               []DefaultWorkerModelsV2    `mapstructure:"defaultWorkerModelsV2" toml:"defaultWorkerModelsV2" commented:"true" comment:"List of default worker models v2 for declared binaries - used by workflow v1" json:"-"`
-	MaxCPUs                             int                        `mapstructure:"maxCpus" toml:"maxCpus" default:"0" commented:"true" comment:"Optional. Maximum total vCPUs this hatchery may allocate. 0 means no static CPU limit (Resource Pool limits still apply)." json:"maxCpus"`
-	MaxMemoryMB                         int                        `mapstructure:"maxMemoryMB" toml:"maxMemoryMB" default:"0" commented:"true" comment:"Optional. Maximum total RAM (MB) this hatchery may allocate. 0 means no static memory limit (Resource Pool limits still apply)." json:"maxMemoryMB"`
-	Flavors                             []VSphereFlavorConfig      `mapstructure:"flavors" toml:"flavors" commented:"true" comment:"Optional. VM flavors for CPU/RAM sizing. List of available flavors." json:"flavors,omitempty"`
-	DefaultFlavor                       string                     `mapstructure:"defaultFlavor" toml:"defaultFlavor" default:"" commented:"true" comment:"Optional. Default flavor to use when no flavor is specified in worker model or job requirements." json:"defaultFlavor,omitempty"`
-	CountSmallerFlavorToKeep            int                        `mapstructure:"countSmallerFlavorToKeep" toml:"countSmallerFlavorToKeep" default:"0" commented:"true" comment:"Optional. Reserve capacity for N smaller flavor workers when spawning large flavors. 0 disables starvation prevention." json:"countSmallerFlavorToKeep"`
+	// Deprecated: Use Networks instead. Kept for backward compatibility.
+	IPRange    string `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"Deprecated: use [[networks]] instead. Optional. IP Range for spawned workers. \n Format: a.a.a.a/b,c.c.c.c/e \n Hatchery will use an IP from this range to create Virtual Machine (Fixed IP Attribute).\nIf not set, you have to set it in your worker model template" json:"iprange,omitempty"`
+	Gateway    string `mapstructure:"gateway" toml:"gateway" default:"" commented:"false" comment:"Deprecated: use [[networks]] instead. Optional. Gateway IP for spawned workers." json:"gateway,omitempty"`
+	DNS        string `mapstructure:"dns" toml:"dns" default:"" commented:"false" comment:"Optional. DNS IP" json:"dns,omitempty"`
+	SubnetMask string `mapstructure:"subnetMask" toml:"subnetMask" default:"255.255.255.0" commented:"false" comment:"Deprecated: use [[networks]] instead. Subnet Mask" json:"subnetMask"`
+	// Networks defines multiple IP ranges, each associated with its own gateway and subnet mask.
+	Networks                   []NetworkConfig            `mapstructure:"networks" toml:"networks" commented:"true" comment:"Optional. List of network configurations. Each entry defines an IP range with its associated gateway and subnet mask." json:"networks,omitempty"`
+	WorkerTTL                  int                        `mapstructure:"workerTTL" toml:"workerTTL" default:"120" commented:"false" comment:"Worker TTL (minutes)" json:"workerTTL"`
+	WorkerRegistrationTTL      int                        `mapstructure:"workerRegistrationTTL" toml:"workerRegistrationTTL" commented:"false" comment:"Worker Registration TTL (minutes)" json:"workerRegistrationTTL"`
+	WorkerProvisioningInterval int                        `mapstructure:"workerProvisioningInterval" toml:"workerProvisioningInterval" commented:"true" comment:"Worker Provisioning interval (seconds)" json:"workerProvisioningInterval"`
+	WorkerProvisioningPoolSize int                        `mapstructure:"workerProvisioningPoolSize" toml:"workerProvisioningPoolSize" commented:"true" comment:"Worker Provisioning pool size" json:"workerProvisioningPoolSize"`
+	WorkerProvisioning         []WorkerProvisioningConfig `mapstructure:"workerProvisioning" toml:"workerProvisioning" commented:"true" comment:"Worker Provisioning per model name" json:"workerProvisioning"`
+	GuestCredentials           []GuestCredential          `mapstructure:"guestCredentials" toml:"guestCredentials" commented:"true" comment:"List of Guest credentials" json:"-"`
+	DefaultWorkerModelsV2      []DefaultWorkerModelsV2    `mapstructure:"defaultWorkerModelsV2" toml:"defaultWorkerModelsV2" commented:"true" comment:"List of default worker models v2 for declared binaries - used by workflow v1" json:"-"`
+	MaxCPUs                    int                        `mapstructure:"maxCpus" toml:"maxCpus" default:"0" commented:"true" comment:"Optional. Maximum total vCPUs this hatchery may allocate. 0 means no static CPU limit (Resource Pool limits still apply)." json:"maxCpus"`
+	MaxMemoryMB                int                        `mapstructure:"maxMemoryMB" toml:"maxMemoryMB" default:"0" commented:"true" comment:"Optional. Maximum total RAM (MB) this hatchery may allocate. 0 means no static memory limit (Resource Pool limits still apply)." json:"maxMemoryMB"`
+	Flavors                    []VSphereFlavorConfig      `mapstructure:"flavors" toml:"flavors" commented:"true" comment:"Optional. VM flavors for CPU/RAM sizing. List of available flavors." json:"flavors,omitempty"`
+	DefaultFlavor              string                     `mapstructure:"defaultFlavor" toml:"defaultFlavor" default:"" commented:"true" comment:"Optional. Default flavor to use when no flavor is specified in worker model or job requirements." json:"defaultFlavor,omitempty"`
+	CountSmallerFlavorToKeep   int                        `mapstructure:"countSmallerFlavorToKeep" toml:"countSmallerFlavorToKeep" default:"0" commented:"true" comment:"Optional. Reserve capacity for N smaller flavor workers when spawning large flavors. 0 disables starvation prevention." json:"countSmallerFlavorToKeep"`
+}
+
+// NetworkConfig defines a network with an IP range, gateway and subnet mask.
+type NetworkConfig struct {
+	IPRange    string `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"IP Range in CIDR notation. Format: a.a.a.a/b,c.c.c.c/e" json:"iprange"`
+	Gateway    string `mapstructure:"gateway" toml:"gateway" default:"" commented:"false" comment:"Gateway IP for this network" json:"gateway"`
+	SubnetMask string `mapstructure:"subnetMask" toml:"subnetMask" default:"255.255.255.0" commented:"false" comment:"Subnet mask for this network" json:"subnetMask"`
 }
 
 // VSphereFlavorConfig defines CPU and RAM resources for a flavor
@@ -70,6 +80,19 @@ type DefaultWorkerModelsV2 struct {
 	Binaries      []string `mapstructure:"binaries" toml:"binaries" default:"" commented:"true" comment:"If one binary is matching this list, the default model associated is used." json:"binaries"`
 }
 
+// availableNetwork holds an IP range with its associated network configuration.
+type availableNetwork struct {
+	config      NetworkConfig
+	ipAddresses []string
+}
+
+// ipResult is returned by findAvailableIP with the IP and its network context.
+type ipResult struct {
+	ip         string
+	gateway    string
+	subnetMask string
+}
+
 // HatcheryVSphere spawns vm
 type HatcheryVSphere struct {
 	hatcheryCommon.Common
@@ -77,7 +100,8 @@ type HatcheryVSphere struct {
 	vSphereClient        VSphereClient
 	metrics              vsphereMetrics
 	IpAddressesMutex     sync.Mutex
-	availableIPAddresses []string
+	availableIPAddresses []string // flat list kept for backward-compat checks (e.g. CanSpawn)
+	availableNetworks    []availableNetwork
 	reservedIPAddresses  []string
 	cachePendingJobID    struct {
 		mu   sync.Mutex

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -42,7 +42,7 @@ type HatcheryConfiguration struct {
 type NetworkConfig struct {
 	IPRange    string `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"IP Range in CIDR notation. Format: a.a.a.a/b,c.c.c.c/e" json:"iprange"`
 	Gateway    string `mapstructure:"gateway" toml:"gateway" default:"" commented:"false" comment:"Gateway IP for this network" json:"gateway"`
-	SubnetMask string `mapstructure:"subnetMask" toml:"subnetMask" default:"255.255.255.0" commented:"false" comment:"Subnet mask for this network" json:"subnetMask"`
+	SubnetMask string `mapstructure:"subnetMask" toml:"subnetMask" default:"" commented:"false" comment:"Subnet mask for this network" json:"subnetMask"`
 }
 
 // VSphereFlavorConfig defines CPU and RAM resources for a flavor


### PR DESCRIPTION
Add Networks config for multiple IP ranges with per-network gateway and subnet mask. When an IP is allocated, the correct gateway/subnet for that network is applied to the VM. Legacy single iprange/gateway/subnetMask fields remain supported for backward compatibility.

Add deprovisioning logic: when provisioning count is decreased or a model is removed, excess VMs are marked for deletion.

Add tests for multi-network allocation, fallback, and deprovisioning behavior.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
