### PR TITLE
feat(hatchery/vsphere): only spawn workers from provisioned VMs

### DIFF
--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -231,34 +231,33 @@ On startup (`InitHatchery`), the hatchery:
 
 ### 6.2 Spawning a Worker
 
+Workers are **only** started from pre-provisioned VMs: there is no fallback cloning the
+template at spawn time. `CanSpawn` only accepts a job when a provisioned VM is available
+for the model, and `SpawnWorker` fails if none can be claimed (e.g. when another job claimed
+it in the meantime — the job is then rescheduled).
+
 The main spawn flow (`SpawnWorker`) proceeds as follows:
 
 ```
 SpawnWorker(spawnArgs)
 │
-├── 1. Resolve template VM
-│   └── Load the V2 template by spec.Image name (must already exist)
+├── 1. Claim a pre-provisioned VM (FindProvisionnedWorker)
+│   └── None available: FAIL (job will be rescheduled)
 │
-├── 2. Try to find a pre-provisioned VM
-│   ├── Found: rename → reconfigure (flavor) → start → wait for IP
-│   │         → pre-start script → launch worker script → DONE
-│   └── Not found: continue to fresh clone
-│
-├── 3. Fresh clone path
-│   ├── Build annotation
-│   ├── prepareCloneSpec() → clone specification (network, IP, datastore)
-│   ├── Clone template VM into datacenter folder
-│   ├── If flavor: reconfigure (CPU/RAM/disk) → power on
+├── 2. Start the claimed VM
+│   ├── If flavor: reconfigure (CPU/RAM/disk) while powered off
+│   ├── Rename to the worker name → start → wait for IP
 │   ├── Wait for guest operations readiness
 │   ├── Execute pre-start script (if configured)
 │   └── Launch worker script via guest operations → DONE
 │
-└── 4. Error handling: shutdown + mark for deletion on any failure
+└── 3. Error handling: shutdown + mark for deletion on any failure
 ```
 
 #### 6.2.1 Clone Specification (`prepareCloneSpec`)
 
-The clone specification defines how the VM is created:
+The clone specification defines how a provisioned VM is created (used by the provisioning
+scheduler, see §6.3):
 
 - **Network**: Loads the first ethernet card from the template's devices, reconfigures it with the
   configured card type and network backing
@@ -268,12 +267,12 @@ The clone specification defines how the VM is created:
 - **Customization**: Linux prep with auto-generated hostname. If IP range is configured, assigns
   a static IP with subnet mask, gateway, and DNS
 - **Annotation**: Serializes the `annotation` struct as JSON into `VirtualMachineConfigSpec.Annotation`
-- **Power On**: `PowerOn: true` when no flavor is needed (VM boots immediately). `PowerOn: false`
-  when a flavor is provided (the caller must reconfigure and start the VM explicitly)
+- **Power On**: `PowerOn: true`, the VM boots immediately to complete its provisioning
 - **VM Tools**: Configured to run after power on
 
 **Important**: CPU, RAM, and disk size are **not** specified in the clone spec. All hardware
-reconfiguration (CPU, RAM, disk) is handled by `reconfigureVM` on the powered-off clone.
+reconfiguration (CPU, RAM, disk) is handled by `reconfigureVM` on the powered-off provisioned
+VM when it is claimed by `SpawnWorker`.
 
 #### 6.2.2 Worker Script Launch (`launchScriptWorker`)
 
@@ -530,7 +529,12 @@ Before spawning, the hatchery checks:
 3. **Empty Cmd**: Returns `false` if the model has no command defined
 4. **Duplicate job check**: Ensures no existing VM annotation references the same `JobID`
 5. **Pending job check**: Ensures the job ID is not in the local `cachePendingJobID`
-6. **IP availability**: If IP range is configured, verifies at least one IP is available
+6. **Provisioned worker availability** (`hasAvailableProvisionedWorker`): a provisioned VM
+   matching the model must be ready to be claimed (powered off, not pending/used/marked for
+   deletion). Workers are only started from provisioned VMs, and a provisioned VM already
+   holds its own IP (reserved at clone time) — so no free-IP check is performed: it would
+   wrongly refuse to spawn when the whole IP range is held by provisioned machines, which is
+   the nominal situation.
 
 ### 6.6 Resource Allocation (`CanAllocateResources`)
 
@@ -941,12 +945,9 @@ The hatchery supports **flavors** for flexible CPU, RAM, and disk sizing without
 
 ## 13.1 Overview
 
-Flavors map abstract size names (e.g., `small`, `medium`, `large`) to explicit CPU, RAM, and disk values. When a worker is spawned with a flavor:
+Flavors map abstract size names (e.g., `small`, `medium`, `large`) to explicit CPU, RAM, and disk values. When a worker is spawned with a flavor, the claimed pre-provisioned VM is reconfigured (while still powered off) to match the flavor before power-on.
 
-- **For pre-provisioned VMs**: The VM is reconfigured (while powered off) to match the flavor before power-on
-- **For fresh clones**: The VM is cloned powered off, then reconfigured via `reconfigureVM`, then powered on
-
-In both cases, `reconfigureVM` is the single entry point for all hardware configuration (CPU, RAM, disk). This consolidation ensures consistent behavior regardless of the spawn path.
+`reconfigureVM` is the single entry point for all hardware configuration (CPU, RAM, disk).
 
 ## 13.2 Configuration
 
@@ -1087,23 +1088,9 @@ Pre-start script (e.g. filesystem resize) runs inside guest
 Worker starts with 8 vCPUs, 16GB RAM, 100GB disk
 ```
 
-For fresh clones with a flavor, the same `reconfigureVM` function is used:
-
-```
-Template ──clone (powered off)──► New VM (template resources)
-  ↓
-reconfigureVM(vm, "large")  →  VM reconfigured (powered off)
-  ↓
-Power on VM
-  ↓
-Pre-start script runs inside guest
-  ↓
-Worker starts
-```
-
 ## 13.7 Backward Compatibility
 
-- If `flavors` map is empty/not configured → no resizing occurs, VMs inherit template resources and are cloned powered on (legacy behavior)
+- If `flavors` map is empty/not configured → no resizing occurs, VMs inherit template resources (legacy behavior)
 - If worker model has no flavor and no `defaultFlavor` configured → template resources used
 - If `diskSizeGB` is `0` or unset → disk is not resized, template disk size is inherited
 - Resource counting (Section 12) reads actual VM hardware → automatically handles resized VMs

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -240,7 +240,7 @@ func (h *HatcheryVSphere) deleteServer(ctx context.Context, s mo.VirtualMachine)
 }
 
 // prepareCloneSpec create a basic configuration in order to create a vm
-func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.VirtualMachine, annot *annotation, flavor *VSphereFlavorConfig) (*types.VirtualMachineCloneSpec, error) {
+func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.VirtualMachine, annot *annotation) (*types.VirtualMachineCloneSpec, error) {
 	devices, err := h.vSphereClient.LoadVirtualMachineDevices(ctx, vm)
 	if err != nil {
 		return nil, err
@@ -337,7 +337,7 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 
 	cloneSpec := &types.VirtualMachineCloneSpec{
 		Location: relocateSpec,
-		PowerOn:  flavor == nil, // When a flavor is set, clone powered off then reconfigureVM handles CPU/RAM/disk
+		PowerOn:  true,
 		Template: false,
 		Config: &types.VirtualMachineConfigSpec{
 			RepConfig: &types.ReplicationConfigSpec{

--- a/engine/hatchery/vsphere/client_test.go
+++ b/engine/hatchery/vsphere/client_test.go
@@ -306,7 +306,7 @@ func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 	).AnyTimes()
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, nil)
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 

--- a/engine/hatchery/vsphere/flavor_test.go
+++ b/engine/hatchery/vsphere/flavor_test.go
@@ -13,51 +13,7 @@ import (
 	"github.com/ovh/cds/engine/hatchery/vsphere/mock_vsphere"
 )
 
-func TestPrepareCloneSpecWithFlavor(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockClient := mock_vsphere.NewMockVSphereClient(ctrl)
-	h := &HatcheryVSphere{
-		vSphereClient:        mockClient,
-		availableIPAddresses: []string{},
-		Config: HatcheryConfiguration{
-			VSphereNetworkString:   "VM Network",
-			VSphereDatastoreString: "datastore1",
-			VSphereCardName:        "e1000",
-		},
-	}
-
-	// Mock expectations
-	mockClient.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).Return(
-		[]types.BaseVirtualDevice{
-			&types.VirtualE1000{
-				VirtualEthernetCard: types.VirtualEthernetCard{
-					VirtualDevice: types.VirtualDevice{},
-				},
-			},
-		}, nil)
-	mockClient.EXPECT().LoadNetwork(gomock.Any(), "VM Network").Return(&object.Network{}, nil)
-	mockClient.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "e1000", gomock.Any()).Return(nil)
-	mockClient.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
-	mockClient.EXPECT().LoadDatastore(gomock.Any(), "datastore1").Return(&object.Datastore{}, nil)
-
-	flavor := &VSphereFlavorConfig{
-		CPUs:     8,
-		MemoryMB: 16384,
-	}
-
-	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, flavor)
-	require.NoError(t, err)
-	require.NotNil(t, cloneSpec)
-
-	// When a flavor is provided, the VM should be cloned powered off
-	// (reconfigureVM handles CPU/RAM/disk on the powered-off clone)
-	assert.False(t, cloneSpec.PowerOn)
-}
-
-func TestPrepareCloneSpecWithoutFlavor(t *testing.T) {
+func TestPrepareCloneSpec(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -87,11 +43,12 @@ func TestPrepareCloneSpecWithoutFlavor(t *testing.T) {
 	mockClient.EXPECT().LoadDatastore(gomock.Any(), "datastore1").Return(&object.Datastore{}, nil)
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, nil)
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 
-	// Without a flavor, the VM should be cloned powered on
+	// Provisioned clones always boot right away (flavors are applied later by
+	// reconfigureVM, when a powered-off provision is claimed by SpawnWorker)
 	assert.True(t, cloneSpec.PowerOn)
 }
 

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -210,11 +210,14 @@ func (h *HatcheryVSphere) CanSpawn(ctx context.Context, model sdk.WorkerStarterW
 		}
 	}
 
-	// Check if there is one ip available
-	if len(h.availableIPAddresses) > 0 {
-		if _, err := h.findAvailableIP(ctx); err != nil {
-			return false
-		}
+	// Workers are only started from pre-provisioned VMs (which already hold
+	// their own IP, reserved at clone time): check that one is available for
+	// this model instead of checking for a free IP. Checking for a free IP
+	// here would wrongly refuse to spawn when the whole IP range is held by
+	// provisioned machines, which is the nominal situation.
+	if !h.hasAvailableProvisionedWorker(ctx, model) {
+		log.Debug(ctx, "can't spawn worker for job %s: no provisioned worker available for model %q", jobID, model.GetName())
+		return false
 	}
 
 	return true

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -55,7 +55,32 @@ func TestHatcheryVSphere_CanSpawnv2(t *testing.T) {
 		Type: sdk.WorkerModelTypeVSphere,
 	}
 	starter := func() sdk.WorkerStarterWorkerModel {
-		return sdk.WorkerStarterWorkerModel{ModelV2: &validModel, Cmd: "cmd"}
+		return sdk.WorkerStarterWorkerModel{
+			ModelV2: &validModel,
+			Cmd:     "cmd",
+			VSphereSpec: sdk.V2WorkerModelVSphereSpec{
+				Image: "the-model",
+			},
+		}
+	}
+
+	// A provisioned VM ready to be claimed for the model: powered off,
+	// provisioning annotation matching the VMware model path.
+	readyProvision := mo.VirtualMachine{
+		ManagedEntity: mo.ManagedEntity{
+			Name: "provision-v2-worker",
+		},
+		Summary: types.VirtualMachineSummary{
+			Config: types.VirtualMachineConfigSummary{
+				Template: false,
+			},
+			Runtime: types.VirtualMachineRuntimeInfo{
+				PowerState: types.VirtualMachinePowerStatePoweredOff,
+			},
+		},
+		Config: &types.VirtualMachineConfigInfo{
+			Annotation: `{"provisioning": true, "vmware_model_path": "the-model"}`,
+		},
 	}
 
 	can := h.CanSpawn(ctx, starter(), "1", []sdk.Requirement{{Type: sdk.ServiceRequirement}})
@@ -82,12 +107,14 @@ func TestHatcheryVSphere_CanSpawnv2(t *testing.T) {
 					Annotation: `{"job_id": "1"}`,
 				},
 			},
+			readyProvision,
 		}, nil
 	})
 
 	can = h.CanSpawn(ctx, starter(), "1", []sdk.Requirement{})
 	assert.False(t, can, "it should return False, because there is a worker for the same job")
 
+	// duplicate-job check + provisioned-worker check both list the VMs
 	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
 		return []mo.VirtualMachine{
 			{
@@ -103,17 +130,28 @@ func TestHatcheryVSphere_CanSpawnv2(t *testing.T) {
 					Annotation: `{"job_id": "2"}`,
 				},
 			},
+			readyProvision,
 		}, nil
-	})
+	}).Times(2)
 
 	can = h.CanSpawn(ctx, starter(), "1", []sdk.Requirement{})
-	assert.True(t, can, "it should return True")
+	assert.True(t, can, "it should return True, a provisioned worker is available for the model")
 
+	// a powered-on provision is not ready to be claimed
+	startingProvision := readyProvision
+	startingProvision.Summary.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
+		return []mo.VirtualMachine{startingProvision}, nil
+	}).Times(2)
+	can = h.CanSpawn(ctx, starter(), "1", []sdk.Requirement{})
+	assert.False(t, can, "it should return False, the provisioned worker is not powered off yet")
+
+	// without any provisioned VM for the model, it can't spawn
 	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
 		return []mo.VirtualMachine{}, nil
 	}).AnyTimes()
 	can = h.CanSpawn(ctx, starter(), "0", []sdk.Requirement{})
-	assert.True(t, can, "it should return True")
+	assert.False(t, can, "it should return False, no provisioned worker is available for the model")
 
 	h.cachePendingJobID.list = append(h.cachePendingJobID.list, "666")
 	can = h.CanSpawn(ctx, starter(), "666", []sdk.Requirement{})

--- a/engine/hatchery/vsphere/networks_test.go
+++ b/engine/hatchery/vsphere/networks_test.go
@@ -197,7 +197,7 @@ func TestHatcheryVSphere_prepareCloneSpec_MultiNetwork(t *testing.T) {
 	).AnyTimes()
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, nil)
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/rockbears/log"
-	"github.com/rockbears/yaml"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
@@ -56,20 +56,8 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 	h.cachePendingJobID.list = append(h.cachePendingJobID.list, spawnArgs.JobID)
 	h.cachePendingJobID.mu.Unlock()
 
-	// ascode v2: the template must exist into vsphere
-	// the template name is the image name in the worker model yml file
 	if spawnArgs.Model.ModelV2 == nil {
 		return sdk.WithStack(fmt.Errorf("worker model v1 is no longer supported on vSphere"))
-	}
-
-	var vsphereSpec sdk.V2WorkerModelVSphereSpec
-	if err := yaml.Unmarshal(spawnArgs.Model.ModelV2.Spec, &vsphereSpec); err != nil {
-		return sdk.WrapError(err, "cannot Unmarshal virtual machine spec")
-	}
-
-	var vmTemplate *object.VirtualMachine
-	if vmTemplate, err = h.vSphereClient.LoadVirtualMachine(ctx, vsphereSpec.Image); err != nil {
-		return sdk.WrapError(err, "cannot find virtual machine template with name %s", vsphereSpec.Image)
 	}
 
 	// Amendment C: Resolve flavor before spawning
@@ -104,125 +92,75 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 		}
 	}
 
-	// Try to reuse a provisioned worker (it already holds its own IP)
-	{
-		provisionnedVMWorker, err := h.FindProvisionnedWorker(ctx, spawnArgs.Model)
-		if err != nil {
-			return err
-		}
+	// Workers are only started from pre-provisioned VMs: claim one. There is
+	// no fallback cloning the template directly, CanSpawn only accepts a job
+	// when a provisioned VM is available for the model.
+	provisionnedVMWorker, err := h.FindProvisionnedWorker(ctx, spawnArgs.Model)
+	if err != nil {
+		return err
+	}
+	if provisionnedVMWorker == nil {
+		return sdk.WithStack(fmt.Errorf("no provisioned worker available for model %q", spawnArgs.Model.GetName()))
+	}
 
-		if provisionnedVMWorker != nil {
-			log.Info(ctx, "starting worker %q with provisionned machine %q", spawnArgs.Model.GetName(), provisionnedVMWorker.Name())
+	log.Info(ctx, "starting worker %q with provisionned machine %q", spawnArgs.Model.GetName(), provisionnedVMWorker.Name())
 
-			// Amendment C: Reconfigure VM to flavor before starting (if flavor requested)
-			if flavor != nil {
-				log.Info(ctx, "reconfiguring provisioned VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
-				if err := h.reconfigureVM(ctx, provisionnedVMWorker, flavor); err != nil {
-					h.cacheProvisioning.mu.Lock()
-					h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-					h.cacheProvisioning.mu.Unlock()
-					return sdk.WrapError(err, "unable to reconfigure VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
-				}
-			}
-
-			if err := h.vSphereClient.RenameVirtualMachine(ctx, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
-				h.cacheProvisioning.mu.Lock()
-				h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-				h.cacheProvisioning.mu.Unlock()
-				return sdk.WrapError(err, "unable to rename VM %q", provisionnedVMWorker.Name())
-			}
-
-			time.Sleep(2 * time.Second)
-
-			if err := h.vSphereClient.StartVirtualMachine(ctx, provisionnedVMWorker); err != nil {
-				h.cacheProvisioning.mu.Lock()
-				h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-				h.cacheProvisioning.mu.Unlock()
-
-				_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
-				h.markToDelete(ctx, provisionnedVMWorker.Name())
-				return sdk.WrapError(err, "unable to start VM %q", spawnArgs.WorkerName)
-			}
-
-			// wait for the right IP, probably keep track of the IP address in the server annotations
-			// to avoid having two provisionned VM with the same IP address
-			// so we if to peek a random IP address by considering already provisionned IP addresses
-			moProvisionnedVMWorker, err := h.getVirtualMachineByName(ctx, provisionnedVMWorker.Name())
-			if err != nil {
-				return sdk.WrapError(err, "unable to find VM %q", spawnArgs.WorkerName)
-			}
-			annot := getVirtualMachineCDSAnnotation(ctx, *moProvisionnedVMWorker)
-
-			if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, provisionnedVMWorker, &annot.IPAddress, spawnArgs.WorkerName); err != nil {
-				h.cacheProvisioning.mu.Lock()
-				h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-				h.cacheProvisioning.mu.Unlock()
-
-				_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
-				h.markToDelete(ctx, provisionnedVMWorker.Name())
-				return sdk.WrapError(err, "unable to get VM %q IP Address", spawnArgs.WorkerName)
-			}
-
-			errLaunch := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName)
-
+	// Amendment C: Reconfigure VM to flavor before starting (if flavor requested)
+	if flavor != nil {
+		log.Info(ctx, "reconfiguring provisioned VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
+		if err := h.reconfigureVM(ctx, provisionnedVMWorker, flavor); err != nil {
 			h.cacheProvisioning.mu.Lock()
 			h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
 			h.cacheProvisioning.mu.Unlock()
-
-			return errLaunch
+			return sdk.WrapError(err, "unable to reconfigure VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
 		}
 	}
 
-	// No provisioned VM available: create fresh clone with flavor applied
-	annot := annotation{
-		HatcheryName:    h.Name(),
-		WorkerName:      spawnArgs.WorkerName,
-		WorkerModelPath: spawnArgs.Model.GetFullPath(),
-		VMwareModelPath: vmTemplate.Name(),
-		Created:         time.Now(),
-		JobID:           spawnArgs.JobID,
+	if err := h.vSphereClient.RenameVirtualMachine(ctx, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
+		h.cacheProvisioning.mu.Unlock()
+		return sdk.WrapError(err, "unable to rename VM %q", provisionnedVMWorker.Name())
 	}
 
-	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot, flavor)
+	time.Sleep(2 * time.Second)
+
+	if err := h.vSphereClient.StartVirtualMachine(ctx, provisionnedVMWorker); err != nil {
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
+		h.cacheProvisioning.mu.Unlock()
+
+		_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
+		h.markToDelete(ctx, provisionnedVMWorker.Name())
+		return sdk.WrapError(err, "unable to start VM %q", spawnArgs.WorkerName)
+	}
+
+	// wait for the right IP, probably keep track of the IP address in the server annotations
+	// to avoid having two provisionned VM with the same IP address
+	// so we if to peek a random IP address by considering already provisionned IP addresses
+	moProvisionnedVMWorker, err := h.getVirtualMachineByName(ctx, provisionnedVMWorker.Name())
 	if err != nil {
-		if sdk.Cause(err).Error() == "no IP address available" {
-			log.Warn(ctx, "unable to create worker: %v", err)
-			return nil
-		}
-		return err
+		return sdk.WrapError(err, "unable to find VM %q", spawnArgs.WorkerName)
+	}
+	annot := getVirtualMachineCDSAnnotation(ctx, *moProvisionnedVMWorker)
+
+	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, provisionnedVMWorker, &annot.IPAddress, spawnArgs.WorkerName); err != nil {
+		h.cacheProvisioning.mu.Lock()
+		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
+		h.cacheProvisioning.mu.Unlock()
+
+		_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
+		h.markToDelete(ctx, provisionnedVMWorker.Name())
+		return sdk.WrapError(err, "unable to get VM %q IP Address", spawnArgs.WorkerName)
 	}
 
-	folder, err := h.vSphereClient.LoadFolder(ctx)
-	if err != nil {
-		return err
-	}
+	errLaunch := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName)
 
-	log.Info(ctx, "Create vm to execute worker %q, cloneSpec: %+v", spawnArgs.WorkerName, *cloneSpec)
-	defer log.Info(ctx, "Terminate to create vm for worker %s", spawnArgs.WorkerName)
+	h.cacheProvisioning.mu.Lock()
+	h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
+	h.cacheProvisioning.mu.Unlock()
 
-	cloneRef, err := h.vSphereClient.CloneVirtualMachine(ctx, vmTemplate, folder, spawnArgs.WorkerName, cloneSpec)
-	if err != nil {
-		return err
-	}
-
-	vmWorker, err := h.vSphereClient.NewVirtualMachine(ctx, cloneSpec, cloneRef, spawnArgs.WorkerName)
-	if err != nil {
-		return err
-	}
-
-	// When a flavor is set the VM was cloned powered off — reconfigure then start
-	if flavor != nil {
-		if err := h.reconfigureVM(ctx, vmWorker, flavor); err != nil {
-			h.markToDelete(ctx, spawnArgs.WorkerName)
-			return sdk.WrapError(err, "unable to reconfigure fresh clone %q", spawnArgs.WorkerName)
-		}
-		if err := h.vSphereClient.StartVirtualMachine(ctx, vmWorker); err != nil {
-			h.markToDelete(ctx, spawnArgs.WorkerName)
-			return sdk.WrapError(err, "unable to start fresh clone %q", spawnArgs.WorkerName)
-		}
-	}
-
-	return h.launchScriptWorker(ctx, spawnArgs, vmWorker, spawnArgs.WorkerName)
+	return errLaunch
 }
 
 func (h *HatcheryVSphere) checkVirtualMachineIsReady(ctx context.Context, model sdk.WorkerStarterWorkerModel, vm *object.VirtualMachine, vmName string) error {
@@ -395,7 +333,7 @@ func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel str
 // the VM is powered on but not yet shut down — the caller is responsible for
 // completing provisioning via finishProvisioning.
 func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate *object.VirtualMachine, annot annotation, workerName string) error {
-	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot, nil)
+	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot)
 	if err != nil {
 		return err
 	}
@@ -417,6 +355,58 @@ func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate
 	}
 
 	return nil
+}
+
+// hasAvailableProvisionedWorker reports whether a provisioned VM matching the
+// given model is ready to be claimed by SpawnWorker. It mirrors the matching
+// logic of FindProvisionnedWorker but is read-only: it does not reserve the VM
+// (no mutation of cacheProvisioning.using) and avoids per-VM vSphere API calls,
+// so it is cheap enough to be called from CanSpawn.
+func (h *HatcheryVSphere) hasAvailableProvisionedWorker(ctx context.Context, model sdk.WorkerStarterWorkerModel) bool {
+	expectedModelPath := model.GetVSphereImage()
+
+	h.cacheProvisioning.mu.Lock()
+	pending := make([]string, len(h.cacheProvisioning.pending))
+	copy(pending, h.cacheProvisioning.pending)
+	using := make([]string, len(h.cacheProvisioning.using))
+	copy(using, h.cacheProvisioning.using)
+	h.cacheProvisioning.mu.Unlock()
+
+	h.cacheToDelete.mu.Lock()
+	toDelete := make([]string, len(h.cacheToDelete.list))
+	copy(toDelete, h.cacheToDelete.list)
+	h.cacheToDelete.mu.Unlock()
+
+	for _, machine := range h.getVirtualMachines(ctx) {
+		if !strings.HasPrefix(machine.Name, "provision-v2") {
+			continue
+		}
+
+		annot := getVirtualMachineCDSAnnotation(ctx, machine)
+		if annot == nil || !annot.Provisioning {
+			continue
+		}
+
+		if expectedModelPath != annot.VMwareModelPath {
+			continue
+		}
+
+		// A finished provision is powered off, waiting to be claimed. A
+		// powered-on one is either still being provisioned or already starting.
+		if machine.Summary.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
+			continue
+		}
+
+		if sdk.IsInArray(machine.Name, pending) ||
+			sdk.IsInArray(machine.Name, using) ||
+			sdk.IsInArray(machine.Name, toDelete) {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 func (h *HatcheryVSphere) FindProvisionnedWorker(ctx context.Context, model sdk.WorkerStarterWorkerModel) (*object.VirtualMachine, error) {

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -97,7 +97,9 @@ func TestHatcheryVSphere_launchScriptWorkerv2(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHatcheryVSphere_SpawnWorkerv2(t *testing.T) {
+// SpawnWorker must fail when no provisioned VM is available for the model:
+// there is no fallback cloning the template directly.
+func TestHatcheryVSphere_SpawnWorkerNoProvisionedWorker(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
 	c := NewVSphereClientTest(t)
@@ -114,43 +116,14 @@ func TestHatcheryVSphere_SpawnWorkerv2(t *testing.T) {
 		},
 	}
 
-	h.Config.VSphereNetworkString = "vbox-net"
-	h.Config.VSphereCardName = "ethernet-card"
-	h.Config.VSphereDatastoreString = "datastore"
-	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
-	h.availableNetworks = []availableNetwork{{
-		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
-		ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
-	}}
-	h.Config.Gateway = "192.168.0.254"
-	h.Config.DNS = "192.168.0.253"
-
 	var ctx = context.Background()
 
-	var validModel = sdk.Model{
-		Name: "cds-model-name",
-		Type: sdk.VSphere,
-		ModelVirtualMachine: sdk.ModelVirtualMachine{
-			Cmd:     "./worker",
-			Image:   "the-model",
-			PostCmd: "shutdown -h now",
-		},
-		Group: &sdk.Group{
-			Name: sdk.SharedInfraGroupName,
-		},
-	}
-
-	var vmTemplate = object.VirtualMachine{
-		Common: object.Common{
-			InventoryPath: "the-model",
-		},
-	}
-
+	// No provision-v2 VM exists, only the vSphere template
 	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
 		return []mo.VirtualMachine{
 			{
 				ManagedEntity: mo.ManagedEntity{
-					Name: validModel.Name,
+					Name: "the-model",
 				},
 				Summary: types.VirtualMachineSummary{
 					Config: types.VirtualMachineConfigSummary{
@@ -163,114 +136,6 @@ func TestHatcheryVSphere_SpawnWorkerv2(t *testing.T) {
 			},
 		}, nil
 	}).AnyTimes()
-
-	c.EXPECT().LoadVirtualMachine(gomock.Any(), "the-model").DoAndReturn(
-		func(ctx context.Context, name string) (*object.VirtualMachine, error) {
-			return &vmTemplate, nil
-		},
-	)
-
-	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) (object.VirtualDeviceList, error) {
-			card := types.VirtualEthernetCard{}
-			return object.VirtualDeviceList{
-				&card,
-			}, nil
-		},
-	)
-
-	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").DoAndReturn(
-		func(ctx context.Context, s string) (object.NetworkReference, error) {
-			return &object.Network{}, nil
-		},
-	)
-
-	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).DoAndReturn(
-		func(ctx context.Context, card *types.VirtualEthernetCard, ethernetCardName string, network object.NetworkReference) error {
-			return nil
-		},
-	)
-
-	c.EXPECT().LoadResourcePool(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) (*object.ResourcePool, error) {
-			return &object.ResourcePool{}, nil
-		},
-	)
-
-	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").DoAndReturn(
-		func(ctx context.Context, name string) (*object.Datastore, error) {
-			return &object.Datastore{}, nil
-		},
-	)
-
-	var folder object.Folder
-
-	c.EXPECT().LoadFolder(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) (*object.Folder, error) {
-			return &folder, nil
-		},
-	)
-
-	var workerRef types.ManagedObjectReference
-
-	c.EXPECT().CloneVirtualMachine(gomock.Any(), &vmTemplate, &folder, "worker-name", gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine, folder *object.Folder, name string, config *types.VirtualMachineCloneSpec) (*types.ManagedObjectReference, error) {
-			return &workerRef, nil
-		},
-	)
-
-	var workerVM object.VirtualMachine
-
-	c.EXPECT().NewVirtualMachine(gomock.Any(), gomock.Any(), &workerRef, gomock.Any()).DoAndReturn(
-		func(ctx context.Context, cloneSpec *types.VirtualMachineCloneSpec, ref *types.ManagedObjectReference, vmname string) (*object.VirtualMachine, error) {
-			assert.False(t, cloneSpec.Template)
-			assert.True(t, cloneSpec.PowerOn)
-			var givenAnnotation annotation
-			json.Unmarshal([]byte(cloneSpec.Config.Annotation), &givenAnnotation)
-			assert.Equal(t, "the-model", givenAnnotation.VMwareModelPath)
-			assert.False(t, givenAnnotation.Model)
-			assert.Equal(t, "192.168.0.1", (cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp).IpAddress))
-			return &workerVM, nil
-		},
-	)
-
-	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), &workerVM, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine, _ *string, _ string) error {
-			return nil
-		},
-	)
-
-	var procman = guest.ProcessManager{}
-
-	c.EXPECT().ProcessManager(gomock.Any(), &workerVM).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) (*guest.ProcessManager, error) {
-			return &procman, nil
-		},
-	).AnyTimes()
-
-	c.EXPECT().StartProgramInGuest(gomock.Any(), &procman, gomock.Any()).DoAndReturn(
-		func(ctx context.Context, procman *guest.ProcessManager, req *types.StartProgramInGuest) (*types.StartProgramInGuestResponse, error) {
-			assert.Equal(t, "/bin/echo", req.Spec.GetGuestProgramSpec().ProgramPath)
-			assert.Contains(t, req.Spec.GetGuestProgramSpec().Arguments, "-n ;env")
-			return &types.StartProgramInGuestResponse{}, nil
-		},
-	)
-
-	c.EXPECT().StartProgramInGuest(gomock.Any(), &procman, gomock.Any()).DoAndReturn(
-		func(ctx context.Context, procman *guest.ProcessManager, req *types.StartProgramInGuest) (*types.StartProgramInGuestResponse, error) {
-			assert.Equal(t, "/bin/echo", req.Spec.GetGuestProgramSpec().ProgramPath)
-			assert.Contains(t, req.Spec.GetGuestProgramSpec().Arguments, "-n ;\n")
-			assert.Contains(t, req.Spec.GetGuestProgramSpec().Arguments, "shutdown -h now")
-			var foundConfig bool
-			for _, env := range req.Spec.GetGuestProgramSpec().EnvVariables {
-				if strings.HasPrefix(env, "CDS_CONFIG=") {
-					foundConfig = true
-				}
-			}
-			assert.True(t, foundConfig, "CDS_CONFIG env variable should be set")
-			return &types.StartProgramInGuestResponse{}, nil
-		},
-	)
 
 	err := h.SpawnWorker(ctx, hatchery.SpawnArguments{
 		WorkerName:  "worker-name",
@@ -285,20 +150,16 @@ func TestHatcheryVSphere_SpawnWorkerv2(t *testing.T) {
 				Username: "user",
 				Password: "password",
 			},
+			Cmd:     "./worker",
 			PostCmd: "sudo shutdown -h now",
 		},
-		JobName: "job_name",
-		JobID:   "666",
-		Requirements: []sdk.Requirement{
-			{
-				Type:  sdk.ModelRequirement,
-				Value: validModel.Name,
-			},
-		},
+		JobName:      "job_name",
+		JobID:        "666",
 		RegisterOnly: false,
 		HatcheryName: "hatchery_name",
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no provisioned worker available")
 }
 
 func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
@@ -329,12 +190,6 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 	h.Config.DNS = "192.168.0.253"
 
 	var ctx = context.Background()
-
-	var vmTemplate = object.VirtualMachine{
-		Common: object.Common{
-			InventoryPath: "the-model",
-		},
-	}
 
 	var vmProvisionned = object.VirtualMachine{
 		Common: object.Common{
@@ -369,12 +224,6 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 			},
 		}, nil
 	}).Times(1)
-
-	c.EXPECT().LoadVirtualMachine(gomock.Any(), "the-model").DoAndReturn(
-		func(ctx context.Context, name string) (*object.VirtualMachine, error) {
-			return &vmTemplate, nil
-		},
-	)
 
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-worker").DoAndReturn(
 		func(ctx context.Context, name string) (*object.VirtualMachine, error) {


### PR DESCRIPTION
Workers are now only started from pre-provisioned VMs:

- SpawnWorker no longer falls back to cloning the vSphere template when no provisioned VM is available; it fails and the job is rescheduled.
- CanSpawn checks that a provisioned VM is ready to be claimed for the model (powered off, not pending/used/marked for deletion) instead of checking for a free IP. The free-IP check wrongly refused to spawn when the whole IP range was held by provisioned machines, which is the nominal situation: a provisioned VM already owns its IP, reserved at clone time.
- prepareCloneSpec loses its flavor parameter: clones are only created by the provisioning scheduler and always boot right away. Flavors are applied by reconfigureVM on the powered-off provisioned VM when it is claimed.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
