### PR TITLE
fix(hatchery/vsphere): reclaim orphaned worker VMs leaking IPs

### DIFF
--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -36,7 +36,7 @@ templates) is no longer supported.
 | `client.go` | VM listing/filtering, clone spec preparation, guest operations |
 | `vsphere.go` | `VSphereClient` interface and govmomi SDK wrapper implementation |
 | `init.go` | Hatchery initialization, govmomi client creation, background goroutines setup |
-| `ip.go` | IP address management (allocation, reservation, availability) |
+| `ip.go` | IP address management (name encode/parse, used-IP set, free-IP selection) |
 | `networks.go` | Multi-network initialization (parses networks config, builds IP pools per network) |
 | `monitoring.go` | Prometheus metrics: vSphere resource consumption at per-worker, hatchery, and pool levels |
 
@@ -347,18 +347,22 @@ launched but its VM is not yet listable, so a rapid retrigger never double-creat
 - Prevents models with larger counts from monopolizing the provisioning queue
 - Example: deficits A=3, B=1, C=2 → queue `[A, B, C, A, C, A]`
 
-**Step 3 — Cap by available IPs and launch clones:**
-- If IP ranges are configured, truncate the queue to the available-IP budget
-- **Reconciliation**: resume orphaned in-flight provisions (see §6.3.3)
-- For each model in the queue, launch a clone via `startProvisionClone()` — one goroutine per
-  provision, **no waiting for the batch**. Concurrency is bounded only by the deficit and IP budget;
-  set `WorkerProvisioningPoolSize > 0` to cap concurrent clones (a semaphore), or leave it `0` to
-  maximize parallelism.
+**Step 3 — Assign IPs and launch clones:**
+- **Reconciliation**: resume orphaned in-flight provisions (see §6.3.3).
+- When an IP range is configured, build the in-use IP set (`getUsedIPs` over the VM list + the IPs of
+  in-flight clones parsed from `pending` names). For each model in the queue, pick a distinct free IP
+  with `pickFreeIP` (adding it to the set so the next pick differs); stop when no IP remains — the IP
+  range is the budget (see §7.3).
+- Launch a clone per model via `startProvisionClone(model, name, ip)` — one goroutine, **no waiting
+  for the batch**. `WorkerProvisioningPoolSize > 0` caps concurrent clones (a semaphore); `0`
+  maximizes parallelism.
 
-Each clone goroutine:
-- Generates a worker name: `provision-v2-<random>`, recorded in `cacheProvisioning.pending` (with its model) **before** the goroutine starts
-- Calls `ProvisionWorkerV2()` (clone), then `finishProvisioning()` (wait IP → shutdown)
-- On any failure marks the VM for deletion; in all cases removes its name from `pending` when done
+Each clone:
+- Uses the caller-chosen name `provision-v2-ip-<dashed-ip>-<random>` (the IP-encoded lock, see §7.1;
+  DHCP mode uses a plain `provision-v2-<random>`), recorded in `cacheProvisioning.pending` **before**
+  the goroutine starts.
+- Calls `ProvisionWorkerV2()` (clone with that IP), then `finishProvisioning()` (wait IP → shutdown).
+- On any failure marks the VM for deletion; in all cases removes its name from `pending` when done.
 
 #### 6.3.2 Provisioned VM Lifecycle
 
@@ -596,61 +600,64 @@ For V1 jobs that need to run on a V2 model (`GetDetaultModelV2Name`):
 
 ### 7.1 IP Lifecycle
 
-When IP ranges are configured (via `networks` or legacy `iprange`), each VM is assigned a static
-IP at clone time through vSphere guest customization. This IP is:
+When IP ranges are configured (via `networks` or legacy `iprange`), each provision is assigned a
+static IP at clone time through vSphere guest customization. The IP is:
 
-1. **Allocated** during `prepareCloneSpec`: `findAvailableIP` picks the first free IP
-2. **Reserved** in local memory (`reservedIPAddresses`) with a 5-minute TTL to prevent races
-3. **Stored** in the VM annotation (`annot.IPAddress`) as part of the clone specification
-4. **Applied** by vSphere guest customization when the VM first boots
+1. **Chosen** by `provisioningV2` (the single provisioning goroutine) via `pickFreeIP`, which returns
+   the first IP not currently in use (see §7.2). Choosing in one goroutine means parallel clones can
+   never pick the same IP.
+2. **Locked by the VM name**: the provision is named `provision-v2-ip-<o1>-<o2>-<o3>-<o4>-<rand>`. The
+   cloning VM is listed in the vSphere inventory **with its name as soon as the clone starts** —
+   before its annotation is populated — so the IP is immediately visible as "in use" to every other
+   pass, and this lock survives a hatchery restart. There is no in-memory reservation and no timeout.
+3. **Stored** in the VM annotation (`annot.IPAddress`) as part of the clone spec — the compatibility
+   anchor (see §7.5), used by the spawn claim's `WaitForVirtualMachineIP`.
+4. **Applied** by vSphere guest customization when the VM first boots.
 
-The IP persists for the entire VM lifetime. When a provisioned VM is powered off and later
-restarted for a job, it comes back up with the **same IP** (baked into the guest OS via
-customization). The spawn flow verifies this by calling `WaitForVirtualMachineIP` with the
-expected IP from the annotation.
+The IP persists for the VM's lifetime: a provisioned VM powered off and later restarted for a job
+comes back with the **same IP** (baked into the guest via customization).
 
-### 7.2 IP Ownership and Counting
+### 7.2 IP Ownership and Counting (`getUsedIPs`)
 
-An IP is considered "in use" if it appears in **any** non-template VM, regardless of power state.
-The `getUsedIPs` function scans all VMs and collects IPs from two sources:
+An IP is "in use" if it appears in **any** non-template VM, from any of three sources:
 
-- **VM annotations** (`annot.IPAddress`): covers all VMs including powered-off provisioned VMs
-  and freshly cloned VMs where guest tools have not yet reported the IP
-- **Guest network info** (`Guest.Net[].IpAddress`): covers running VMs where the OS has the IP
-  active on an interface
+- **Provision name** (`provision-v2-ip-...`): covers a provision *during its clone*, before the
+  annotation exists, and after a restart (parsed straight from the live VM list).
+- **VM annotation** (`annot.IPAddress`): covers claimed workers (renamed away from the IP-encoded
+  name), old-style provisions created before this scheme, and any VM whose guest tools have not yet
+  reported the IP.
+- **Guest network info** (`Guest.Net[].IpAddress`): covers running VMs where the OS has the IP active.
 
-This means powered-off provisioned VMs **hold their IP** — they are counted as "in use" and
-prevent that IP from being allocated to another VM. This is correct because the same IP will be
-reused when the VM powers on for a job.
+Powered-off provisioned VMs therefore **hold their IP** (counted as in use), correctly preventing
+reallocation.
 
 ### 7.3 IP Budget in Provisioning
 
-The provisioning scheduler uses `countAvailableIPs` to determine how many new VMs can be cloned.
-Since powered-off provisioned VMs already hold IPs (via their annotations), they are naturally
-subtracted from the available pool. The IP budget only reflects IPs that are truly unassigned.
+`provisioningV2` builds the in-use set with `getUsedIPs` over the current VM list, plus the IPs of
+in-flight clones not yet listed (parsed from the `cacheProvisioning.pending` names), then picks a
+distinct free IP per clone with `pickFreeIP`, adding each pick to the set as it goes. When no free IP
+remains it stops launching clones — the IP range is the natural budget, no separate counter needed.
 
-### 7.4 Finding an Available IP (`findAvailableIP`)
+### 7.4 Why the name, not a reservation
 
-1. Acquire IP mutex
-2. List all VMs, collect used IPs via `getUsedIPs` (annotations + guest network)
-3. Clean up stale reservations for IPs that are now confirmed in guest network
-4. Return the first IP from the configured range that is neither used nor reserved
+The destination VM is not in the inventory until partway through the clone, and its annotation only
+appears when the clone completes — but its **name** is visible almost immediately. Encoding the IP in
+the name makes the IP lock readable from vSphere during the whole clone and across restarts, which an
+in-memory reservation (lost on restart, and needing a fragile TTL longer than the clone) could not
+provide. The annotation still carries the IP for backward/forward compatibility (§7.5).
 
-### 7.5 Reserving an IP (`reserveIPAddress`)
+### 7.5 Compatibility
 
-1. Check the IP is not already reserved
-2. Add to `reservedIPAddresses` list
-3. Start a goroutine that removes the reservation after 5 minutes (safety timeout)
-
-The reservation bridges the gap between `findAvailableIP` (which picks an IP) and the VM
-actually being created with that IP in its annotation. Without it, concurrent clones could
-pick the same IP.
+- **Old-style provisions** (named `provision-v2-<rand>`, no IP token): their IP is read from the
+  annotation, so they are counted and handled exactly as before — name parsing is purely additive.
+- **Rollback**: new provisions also store the IP in `annot.IPAddress` and keep the `provision-v2`
+  prefix, so a previous (reservation-based) binary handles them transparently.
 
 ### 7.6 IP-less Mode (DHCP)
 
-When no IP range is configured, no static IP assignment occurs. VMs rely on DHCP or
-template-defined network settings. In this mode, `countAvailableIPs` returns -1 (unlimited)
-and the provisioning scheduler does not cap tasks by IP budget.
+When no IP range is configured, no static IP is assigned and provisions keep the plain
+`provision-v2-<rand>` name. `pickFreeIP` is not consulted and provisioning is not IP-bounded; VMs
+rely on DHCP or template-defined network settings.
 
 ## 8. Cleanup and Garbage Collection
 
@@ -772,7 +779,6 @@ The hatchery maintains several in-memory caches protected by mutexes:
 | `cacheProvisioning.using` | `[]string` | Provisioned VM names being assigned to a job |
 | `cacheToDelete` | `[]string` | VM names marked for deletion by spawn logic |
 | `availableIPAddresses` | `[]string` | All IPs parsed from the configured range |
-| `reservedIPAddresses` | `[]string` | IPs temporarily reserved (5-minute TTL) |
 
 ## 11. Limitations
 
@@ -941,9 +947,10 @@ When an IP range is configured (`iprange`), these metrics track IP address pool 
 
 **Tags**: `service_name`, `service_type`
 
-An IP is considered "in use" if it appears in any VM's CDS annotation (`IPAddress` field) or in
-the VM's guest network info (`Guest.Net[].IpAddress`). These metrics are only emitted when
-`iprange` is configured (i.e. `availableIPAddresses` is non-empty).
+An IP is considered "in use" if it appears in a provision VM's IP-encoded name
+(`provision-v2-ip-...`), a VM's CDS annotation (`IPAddress` field), or the VM's guest network info
+(`Guest.Net[].IpAddress`) — see §7.2. These metrics are only emitted when `iprange` is configured
+(i.e. `availableIPAddresses` is non-empty).
 
 ### 14.7 Source Files
 

--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -198,20 +198,31 @@ This annotation is the primary mechanism for tracking VM state and ownership.
 
 ```go
 type annotation struct {
-    HatcheryName            string    // Name of the hatchery that created this VM
-    WorkerName              string    // CDS worker name assigned to this VM
-    Provisioning            bool      // True if VM is a pre-provisioned idle worker
-    VMwareModelPath         string    // VMware template name (V2)
-    WorkerModelLastModified string    // Unix timestamp of model last modification
-    Model                   bool      // True if VM is a model template (do not destroy)
-    Created                 time.Time // Creation timestamp
-    JobID                   string    // CDS job ID assigned to this worker
-    IPAddress               string    // Static IP assigned to this VM
+    HatcheryName    string    // Name of the hatchery that created this VM
+    WorkerName      string    // CDS worker name assigned to this VM
+    Provisioning    bool      // True while the VM is a pre-provisioned idle worker (cleared when claimed)
+    WorkerModelPath string    // CDS worker model path
+    VMwareModelPath string    // VMware template name (V2)
+    Model           bool      // True if VM is a model template (do not destroy)
+    Created         time.Time // Provision clone timestamp
+    WorkerStartTime time.Time // Time the VM was claimed for a job (turned into a worker)
+    JobID           string    // CDS job ID assigned to this worker
+    IPAddress       string    // Static IP assigned to this VM
 }
 ```
 
 All hatchery operations (cleanup, provisioning lookup, duplicate detection) rely on parsing these
 annotations from `VirtualMachine.Config.Annotation`.
+
+The annotation is set at clone time, and **updated in place** (via `ReconfigVM_Task`, the same
+mechanism used for flavor reconfiguration) when a provision is claimed for a job. Note the
+distinction between the two timestamps:
+
+- `Created` is the **provision clone time** — it can be arbitrarily old (a provision may sit
+  pooled for a long time), so it is not a reliable indicator of worker activity.
+- `WorkerStartTime` is stamped when the provision is **claimed and turned into a worker**. Being
+  persisted in the annotation, it survives a hatchery restart and never ages out like vSphere
+  events do. `killAwolServers` uses it to decide when a VM can be reclaimed (see §8.1).
 
 ## 6. Lifecycle
 
@@ -246,13 +257,22 @@ SpawnWorker(spawnArgs)
 │
 ├── 2. Start the claimed VM
 │   ├── If flavor: reconfigure (CPU/RAM/disk) while powered off
-│   ├── Rename to the worker name → start → wait for IP
-│   ├── Wait for guest operations readiness
-│   ├── Execute pre-start script (if configured)
+│   ├── Rename to the worker name
+│   ├── Stamp the annotation with WorkerStartTime (+ JobID, Provisioning=false)
+│   │   before power-on, preserving the reserved IP and VMware model path
+│   ├── Power on (bounded retry, tolerates a VM not yet startable after reconfigure)
+│   ├── Wait for the reserved IP
+│   ├── Wait for guest operations readiness, run the pre-start script (if any)
 │   └── Launch worker script via guest operations → DONE
 │
-└── 3. Error handling: shutdown + mark for deletion on any failure
+└── 3. Error handling: a single deferred teardown releases the provision from the
+       in-use cache and, on ANY failure above, shuts the VM down and marks it for
+       deletion — so a partially-configured worker is never left holding an IP.
 ```
+
+The `WorkerStartTime` stamp is written **before** power-on so that, even if the hatchery crashes
+mid-spawn (the deferred teardown would not run), the VM still carries a start time and is cleaned
+up by `killAwolServers` (see §8.1).
 
 #### 6.2.1 Clone Specification (`prepareCloneSpec`)
 
@@ -626,21 +646,43 @@ and the provisioning scheduler does not cap tasks by IP budget.
 
 ### 8.1 Kill Awol Servers (`killAwolServers`) — Every 2 minutes
 
+This routine relies on the `WorkerStartTime` annotation stamp (see §5) and the VM's **live power
+state**, not on vSphere events. Events were previously used to find a VM's start time, but they age
+out of vCenter's event retention; a VM whose start event had expired (or never existed, e.g. a spawn
+that crashed after rename) was then kept forever, accumulating powered-off VMs that each hold a
+reserved IP until the pool exhausts its IP range. Using the persisted start time avoids that.
+
 For each VM with a CDS annotation belonging to this hatchery:
 
 1. **Marked for deletion**: Delete immediately
-2. **Provisioned VMs** (`provision-` prefix): Skip (managed by provisioning loop reconciliation, see §6.3.3)
+2. **Provisioned VMs** (`provision-` prefix): Skip (still pooled, holding their reserved IP on
+   purpose; managed by provisioning loop reconciliation, see §6.3.3)
 3. **Model templates** (`Model: true`): Skip (never delete)
-4. **Event analysis**: Load VM events (`VmStartingEvent`, `VmPoweredOffEvent`, `VmRenamedEvent`)
-   - Filter out events related to provisioning (`provision-` in message)
-   - Find the most recent start, power-off, and rename events
-5. **Renamed but never started**: If `VmRenamedEvent` exists but no `VmStartingEvent`, and the
-   rename is older than `WorkerRegistrationTTL` → delete
-6. **No start event found**: Skip (VM not yet fully created)
-7. **Worker exists on API side**: Delete if `vmStartedTime + WorkerTTL` has expired
-8. **Worker does not exist on API side**:
-   - If `VmPoweredOffEvent` found (after start): Worker finished → delete
-   - If no power-off event: Worker still starting → delete if `vmStartedTime + WorkerRegistrationTTL` has expired
+4. **Determine the start time**: `WorkerStartTime` from the annotation, or — for VMs created before
+   this field existed (upgrade/transition) — the VM's vSphere `CreateDate` as a fallback. If neither
+   is available (should not happen), the VM is kept and a warning is logged.
+5. **Decide expiry** from the live power state:
+   - **Powered off**: a claimed worker is never restarted, so it has finished or failed. Delete once
+     `startTime + WorkerRegistrationTTL` has passed. The short grace frees the IP quickly while still
+     covering the brief rename→power-on window of an in-flight spawn (whose `WorkerStartTime` is "now").
+   - **Powered on and registered on the API**: running worker → delete if `startTime + WorkerTTL` has expired.
+   - **Powered on but not on the API**: still booting/registering → delete if `startTime + WorkerRegistrationTTL` has expired.
+
+#### Backward compatibility (VMs created before this change)
+
+No migration step is required — VMs that predate the `WorkerStartTime` stamp are handled
+transparently:
+
+- **Existing provisions** (`provision-` prefix, no `WorkerStartTime`): unaffected. They are still
+  skipped by `killAwolServers` (rule 2), and the first time the new code claims one it stamps the
+  annotation in place (`ReconfigVM_Task`), so it transitions to the new scheme automatically.
+- **Existing workers** (already claimed/renamed before the change, so no `WorkerStartTime`):
+  `killAwolServers` falls back to the VM's vSphere `CreateDate` (rule 4). This means they are still
+  evaluated and eventually cleaned up instead of being kept forever — including the orphaned
+  powered-off VMs this change was introduced to reclaim. Because `CreateDate` is the provision clone
+  time (older than the real start), such a legacy VM may be reaped slightly earlier than its
+  `WorkerStartTime`-based expiry would dictate; this only affects VMs spawned before the upgrade and
+  is a one-time transitional effect.
 
 ### 8.2 Kill Disabled Workers (`killDisabledWorkers`) — Every 2 minutes
 
@@ -672,6 +714,7 @@ type VSphereClient interface {
     GetVirtualMachinePowerState(ctx, vm) (VirtualMachinePowerState, error)
     NewVirtualMachine(ctx, cloneSpec, ref, vmName) (*object.VirtualMachine, error)
     RenameVirtualMachine(ctx, vm, newName) error
+    SetVirtualMachineAnnotation(ctx, vm, annotation) error
     WaitForVirtualMachineShutdown(ctx, vm) error
     WaitForVirtualMachineIP(ctx, vm, IPAddress, vmName) error
     LoadFolder(ctx) (*object.Folder, error)

--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -896,7 +896,12 @@ with matching `HatcheryName`). Includes workers and pre-provisioned VMs. Exclude
 | `cds/hatchery/vsphere/allocated_vcpus` | Gauge | vCPUs | Total vCPUs allocated by this hatchery's VMs |
 | `cds/hatchery/vsphere/allocated_memory_mb` | Gauge | MB | Total memory allocated by this hatchery's VMs |
 | `cds/hatchery/vsphere/vm_count` | Gauge | count | Total number of VMs managed by this hatchery (workers + provisioned) |
-| `cds/hatchery/vsphere/provisioned_vm_count` | Gauge | count | Number of pre-provisioned (idle) VMs |
+| `cds/hatchery/vsphere/worker_vm_count` | Gauge | count | VMs running as workers (claimed, no longer in the provision pool) |
+| `cds/hatchery/vsphere/provisioned_vm_count` | Gauge | count | Pre-provisioned VMs (sum of ready + starting + dying) |
+| `cds/hatchery/vsphere/provision_ready_count` | Gauge | count | Provisioned VMs powered off and ready to be claimed |
+| `cds/hatchery/vsphere/provision_starting_count` | Gauge | count | Provisioned VMs powered on, still being created/finished (not yet claimable) |
+| `cds/hatchery/vsphere/provision_dying_count` | Gauge | count | Provisioned VMs marked for deletion, not yet reaped |
+| `cds/hatchery/vsphere/provision_inflight_count` | Gauge | count | In-flight provision clones not yet visible in the inventory |
 | `cds/hatchery/vsphere/template_vcpus` | Gauge | vCPUs | Total vCPUs defined by template VMs (annotation `Model=true`) |
 | `cds/hatchery/vsphere/template_memory_mb` | Gauge | MB | Total memory defined by template VMs |
 | `cds/hatchery/vsphere/template_count` | Gauge | count | Number of template VMs managed by this hatchery |

--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -32,7 +32,7 @@ templates) is no longer supported.
 | `types.go` | Configuration structs and `HatcheryVSphere` struct definition |
 | `hatchery.go` | Hatchery lifecycle (init, config, CanSpawn), worker cleanup, provisioning scheduler |
 | `spawn.go` | VM spawning logic, provisioning clone, worker bootstrap |
-| `provision.go` | Provisioning worker pool, task execution, reconciliation, `finishProvisioning` |
+| `provision.go` | On-demand provisioning trigger, clone/finish goroutines, reconciliation, `finishProvisioning` |
 | `client.go` | VM listing/filtering, clone spec preparation, guest operations |
 | `vsphere.go` | `VSphereClient` interface and govmomi SDK wrapper implementation |
 | `init.go` | Hatchery initialization, govmomi client creation, background goroutines setup |
@@ -64,7 +64,7 @@ The hatchery is configured via `HatcheryConfiguration`, serialized as TOML.
 | `workerTTL` | `int` | `120` | No | Worker time-to-live in minutes |
 | `workerRegistrationTTL` | `int` | `10` | No | Worker registration timeout in minutes |
 | `workerProvisioningInterval` | `int` | `120` (2 min) | No | Provisioning loop interval in seconds |
-| `workerProvisioningPoolSize` | `int` | `1` | No | Max concurrent provisioning operations |
+| `workerProvisioningPoolSize` | `int` | `0` | No | Optional cap on concurrent provisioning clones. `0` = unbounded (clones run fully in parallel, bounded by the deficit and IP budget) |
 | `workerProvisioning` | `[]WorkerProvisioningConfig` | — | No | List of models to pre-provision |
 | `guestCredentials` | `[]GuestCredential` | — | No | **Deprecated**: use `models` instead. Guest OS credentials per model |
 | `models` | `[]ModelConfig` | — | No | Per-model configuration (credentials, pre-start script) |
@@ -235,9 +235,8 @@ On startup (`InitHatchery`), the hatchery:
 3. Instantiates the `VSphereClient` wrapper bound to the configured datacenter
 4. Parses the IP range (if configured) into a list of available IP addresses
 5. Starts background goroutines:
-   - **Provisioning worker pool** (if `workerProvisioning` is configured): `WorkerProvisioningPoolSize` long-lived workers that pull tasks from a shared channel
-   - **Provisioning scheduler** (if `workerProvisioning` is configured): runs every `workerProvisioningInterval` seconds, computes deficit, submits tasks to the pool, waits for batch completion
-   - **Kill awol servers loop**: runs every 2 minutes, removes stale/expired VMs
+   - **Provisioning loop** (if `workerProvisioning` is configured): runs `provisioningV2` every `workerProvisioningInterval` seconds **and** on demand via the signal channel; each run computes the deficit and launches clones fire-and-forget (§6.3.1). An optional semaphore (`WorkerProvisioningPoolSize > 0`) caps concurrent clones.
+   - **Kill awol servers loop**: runs every `killAwolServersInterval` seconds, removes stale/expired VMs
    - **Kill disabled workers loop**: runs every 2 minutes, removes disabled workers
 
 ### 6.2 Spawning a Worker
@@ -322,32 +321,44 @@ Pre-provisioning creates idle VMs ahead of time so that job assignment is faster
 
 #### 6.3.1 Provisioning (`provisioningV2`)
 
-Provisioning is keyed on the VMware template name (`provision-v2` VMs). The provisioning scheduler
-runs a three-step process:
+Provisioning is keyed on the VMware template name (`provision-v2` VMs). `provisioningV2` is the
+trigger handler: it runs on the provisioning ticker **and** on demand whenever a provision is
+consumed — `requestProvisioning()` is called after every spawn claim and after `killAwolServers` deletes
+anything (it does a non-blocking send on a size-1 signal channel, coalescing bursts into a single
+pending run). Each run is **fire-and-forget**: it computes what is missing, submits
+the clones as independent goroutines, and returns immediately so the trigger loop stays responsive.
 
-**Step 1 — Compute current state and deficit:**
-1. Lock the provisioning cache
-2. List all VMs prefixed with `provision-v2`, count per VMware model path (includes all power states to account for orphans)
-3. Build configured counts and compute deficit (`desired - existing`) for each model
-4. **Deprovisioning**: for each model with more provisioned VMs than configured (or models removed from config), mark excess VMs for deletion
+**Step 1 — Compute the deficit (vSphere is the source of truth):**
+1. List `provision-v2` VMs and count per VMware model path, **including all power states**:
+   - **READY** = powered off, `Provisioning: true` → a finished, claimable provision
+   - **STARTING** = powered on, `Provisioning: true` → a provision still being created
+2. Also count **in-flight clones not yet visible** in the inventory — entries in
+   `cacheProvisioning.pending` (name → model) whose VM does not yet appear in the list.
+3. `deficit(model) = configured Number − READY − STARTING − not-yet-listable pending`.
+4. **Deprovisioning**: for each model with more provisioned VMs than configured (or models removed
+   from config), mark excess VMs for deletion.
+
+Counting READY + STARTING from vSphere is what makes the deficit correct after a restart with an
+empty cache (see §6.3.3); `pending` only additionally covers the brief window where a clone has been
+launched but its VM is not yet listable, so a rapid retrigger never double-creates.
 
 **Step 2 — Interleave models using round-robin:**
 - Uses `roundRobinInterleave()` to produce a fair ordering where models are picked one task at a time in config order
 - Prevents models with larger counts from monopolizing the provisioning queue
 - Example: deficits A=3, B=1, C=2 → queue `[A, B, C, A, C, A]`
 
-**Step 3 — Cap by available IPs and enqueue tasks:**
-- If IP ranges are configured, compute available IP count
-- Truncate the queue to the IP budget (prevents submitting work that would fail at clone time)
-- **Reconciliation**: submit "finish" tasks for orphaned VMs (see §6.3.3)
-- Submit clone tasks from the queue to the provisioning pool
-- Wait for the entire batch (reconciliation + new clones) to complete
+**Step 3 — Cap by available IPs and launch clones:**
+- If IP ranges are configured, truncate the queue to the available-IP budget
+- **Reconciliation**: resume orphaned in-flight provisions (see §6.3.3)
+- For each model in the queue, launch a clone via `startProvisionClone()` — one goroutine per
+  provision, **no waiting for the batch**. Concurrency is bounded only by the deficit and IP budget;
+  set `WorkerProvisioningPoolSize > 0` to cap concurrent clones (a semaphore), or leave it `0` to
+  maximize parallelism.
 
-Each task executed by a pool worker:
-- Generates a worker name: `provision-v2-<random>`
-- Adds name to `cacheProvisioning.pending`
-- Calls `ProvisionWorkerV2()` (clone only), then `finishProvisioning()` (wait IP → shutdown)
-- Removes name from pending cache
+Each clone goroutine:
+- Generates a worker name: `provision-v2-<random>`, recorded in `cacheProvisioning.pending` (with its model) **before** the goroutine starts
+- Calls `ProvisionWorkerV2()` (clone), then `finishProvisioning()` (wait IP → shutdown)
+- On any failure marks the VM for deletion; in all cases removes its name from `pending` when done
 
 #### 6.3.2 Provisioned VM Lifecycle
 
@@ -368,29 +379,28 @@ Template ──clone──► Provisioned VM (powered on)
 
 #### 6.3.3 Provisioning State Reconciliation
 
-The `cacheProvisioning.pending` list is in-memory only. If the hatchery restarts while a VM is
-being provisioned (between clone and shutdown), that VM becomes orphaned: it stays powered on
-indefinitely and is never picked up by `FindProvisionnedWorker` (which requires a
-`VmPoweredOffEvent`).
+`cacheProvisioning.pending` is in-memory only and **must be safe to lose at any time** (restart or
+crash). Correctness never relies on it surviving: the deficit (§6.3.1) is computed from the vSphere
+VM list, which is the source of truth. On restart the cache is empty, but every real provision is
+still classifiable by power state — **READY** (powered off) vs **STARTING** (powered on) — so the
+deficit is reconstructed exactly and no duplicates are created.
 
-To handle this, each provisioning tick calls `reconcileProvisionedVMs()` which reconstructs the
-pending state by scanning all VMs:
+The open question on restart is what to do with the **STARTING** provisions (powered on, mid-creation
+when the old process died). The hatchery **reuses** them: each provisioning run calls
+`reconcileProvisionedVMs()` to resume their provisioning rather than discarding the in-progress clone:
 
-1. List all powered-on VMs with `provision-` prefix, `Provisioning: true` annotation, and
-   matching `HatcheryName`
-2. Skip VMs already in `cacheProvisioning.pending` (actively being provisioned this run)
-3. For each orphaned VM, re-inject it into the provisioning pipeline:
-   - Add the VM name to `cacheProvisioning.pending`
-   - Submit a "finish" task to the provisioning worker pool
-   - The pool worker runs `finishProvisioning`: `WaitForVirtualMachineIP` → `ShutdownVirtualMachine`
-   - If the VM already has an IP, `WaitForVirtualMachineIP` returns immediately and the VM is
-     shut down — completing its provisioning
-   - If the VM has no IP, the 3-minute timeout applies. On timeout, the VM is marked for deletion
-   - On completion (success or failure), the VM is removed from `cacheProvisioning.pending`
+1. List powered-on VMs with the `provision-` prefix, `Provisioning: true`, and matching `HatcheryName`
+2. Skip VMs already in `cacheProvisioning.pending` (already being handled this process)
+3. For each remaining orphan, resume it via `startProvisionFinish()` (a fire-and-forget goroutine):
+   - Record it in `cacheProvisioning.pending`
+   - Run `finishProvisioning`: `WaitForVirtualMachineIP` → `ShutdownVirtualMachine`
+   - If it already has its IP, this returns quickly and the VM is shut down → becomes READY
+   - If it never gets an IP, the IP-wait timeout fires and the VM is marked for deletion (and
+     recreated by a later deficit) — so a genuinely stuck provision is never reused forever
+   - On completion (success or failure) the VM is removed from `cacheProvisioning.pending`
 
-Since reconciliation tasks are part of the same batch as new clone tasks, the scheduler waits
-for all work to complete before the next tick re-evaluates. This prevents double-counting and
-ensures a consistent snapshot between ticks.
+Because the deficit counts STARTING provisions, the in-flight ones being reconciled are not also
+cloned fresh.
 
 This mechanism also covers VMs where `ShutdownVirtualMachine` failed during normal operation
 (not just restarts), since the provisioning scheduler periodically re-runs reconciliation.
@@ -506,11 +516,11 @@ The `MaxWorker` limit and the vSphere-specific `WorkerProvisioning` (pre-provisi
   **do not count** against `MaxWorker`.
 - When a provisioned VM is assigned to a job, it is renamed (e.g. `provision-v2-xxx` →
   `worker-abc`). From that point, it **counts** against `MaxWorker`.
-- The `WorkerProvisioningPoolSize` config controls how many persistent workers handle
-  provisioning tasks (clone + finish). The provisioning scheduler submits all tasks to the pool
-  and waits for the batch to complete. This is separate from `MaxConcurrentProvisioning` which
-  governs the common framework's capacity check.
-- There is **no global coordination** between the provisioning pool and `MaxWorker`. It is the
+- The `WorkerProvisioningPoolSize` config optionally caps how many provision clones run
+  concurrently (`0` = unbounded — clones run fully in parallel, bounded only by the deficit and IP
+  budget). This is separate from `MaxConcurrentProvisioning`, which governs the common framework's
+  capacity check.
+- There is **no global coordination** between provisioning and `MaxWorker`. It is the
   operator's responsibility to ensure that `WorkerProvisioning[].Number` (total pre-provisioned
   VMs) plus expected active workers stays within the infrastructure's capacity.
 
@@ -700,7 +710,9 @@ transparently:
 ## 9. vSphere Client Interface
 
 The hatchery interacts with vSphere through the `VSphereClient` interface, which wraps the
-govmomi SDK. All vSphere API calls use a 15-second request timeout.
+govmomi SDK. Most API calls use a 15-second request timeout; the long-running task waits — clone,
+power-off, destroy — use a `vmTaskTimeout` of 10 minutes so a stuck vCenter task fails (and is
+recovered) instead of hanging the caller forever.
 
 ```go
 type VSphereClient interface {
@@ -756,7 +768,7 @@ The hatchery maintains several in-memory caches protected by mutexes:
 | Cache | Type | Purpose |
 |-------|------|---------|
 | `cachePendingJobID` | `[]string` | Job IDs currently being spawned, prevents duplicates |
-| `cacheProvisioning.pending` | `[]string` | VM names currently being provisioned |
+| `cacheProvisioning.pending` | `map[string]string` | In-flight provisions (VM name → VMware model); accelerator only, safe to lose on restart |
 | `cacheProvisioning.using` | `[]string` | Provisioned VM names being assigned to a job |
 | `cacheToDelete` | `[]string` | VM names marked for deletion by spawn logic |
 | `availableIPAddresses` | `[]string` | All IPs parsed from the configured range |

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -332,6 +332,9 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 
 	annotStr, err := json.Marshal(annot)
 	if err != nil {
+		// The IP was reserved just above; release it since this clone spec will
+		// not be used.
+		h.releaseIPAddress(annot.IPAddress)
 		return nil, sdk.WrapError(err, "unable to marshal annotation")
 	}
 

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -239,8 +239,11 @@ func (h *HatcheryVSphere) deleteServer(ctx context.Context, s mo.VirtualMachine)
 	return nil
 }
 
-// prepareCloneSpec create a basic configuration in order to create a vm
-func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.VirtualMachine, annot *annotation) (*types.VirtualMachineCloneSpec, error) {
+// prepareCloneSpec create a basic configuration in order to create a vm. When ip
+// is non-nil the VM is given that static IP via guest customization and the IP is
+// recorded in the annotation (the compatibility anchor); the IP itself is chosen
+// by the caller (provisioningV2) so parallel clones never collide.
+func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.VirtualMachine, annot *annotation, ip *ipResult) (*types.VirtualMachineCloneSpec, error) {
 	devices, err := h.vSphereClient.LoadVirtualMachineDevices(ctx, vm)
 	if err != nil {
 		return nil, err
@@ -298,40 +301,33 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 		},
 	}
 
-	if len(h.availableIPAddresses) > 0 {
-		// findAvailableIP already reserves the returned IP atomically, so parallel
-		// provisioning clones never receive the same address.
-		ipRes, err := h.findAvailableIP(ctx)
-		if err != nil {
-			return nil, err
-		}
-		log.Debug(ctx, "Found %s as available IP (gw=%s, mask=%s)", ipRes.ip, ipRes.gateway, ipRes.subnetMask)
+	if ip != nil {
+		log.Debug(ctx, "assigning %s as IP (gw=%s, mask=%s)", ip.ip, ip.gateway, ip.subnetMask)
 
 		customSpec.NicSettingMap = []types.CustomizationAdapterMapping{
 			{
 				Adapter: types.CustomizationIPSettings{
-					Ip:         &types.CustomizationFixedIp{IpAddress: ipRes.ip},
-					SubnetMask: ipRes.subnetMask,
+					Ip:         &types.CustomizationFixedIp{IpAddress: ip.ip},
+					SubnetMask: ip.subnetMask,
 				},
 			},
 		}
-		if ipRes.gateway != "" {
-			customSpec.NicSettingMap[0].Adapter.Gateway = []string{ipRes.gateway}
+		if ip.gateway != "" {
+			customSpec.NicSettingMap[0].Adapter.Gateway = []string{ip.gateway}
 		}
 		if h.Config.DNS != "" {
 			customSpec.GlobalIPSettings = types.CustomizationGlobalIPSettings{DnsServerList: []string{h.Config.DNS}}
 		}
 
-		annot.IPAddress = ipRes.ip
+		// Store the IP in the annotation too (compat anchor: old provisions and a
+		// rolled-back binary read the IP from here).
+		annot.IPAddress = ip.ip
 
-		log.Debug(ctx, "IP: %s; Gateway: %v; DNS: %v", ipRes.ip, customSpec.NicSettingMap[0].Adapter.Gateway, customSpec.GlobalIPSettings.DnsServerList)
+		log.Debug(ctx, "IP: %s; Gateway: %v; DNS: %v", ip.ip, customSpec.NicSettingMap[0].Adapter.Gateway, customSpec.GlobalIPSettings.DnsServerList)
 	}
 
 	annotStr, err := json.Marshal(annot)
 	if err != nil {
-		// The IP was reserved just above; release it since this clone spec will
-		// not be used.
-		h.releaseIPAddress(annot.IPAddress)
 		return nil, sdk.WrapError(err, "unable to marshal annotation")
 	}
 

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -299,16 +299,13 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 	}
 
 	if len(h.availableIPAddresses) > 0 {
+		// findAvailableIP already reserves the returned IP atomically, so parallel
+		// provisioning clones never receive the same address.
 		ipRes, err := h.findAvailableIP(ctx)
 		if err != nil {
 			return nil, err
 		}
 		log.Debug(ctx, "Found %s as available IP (gw=%s, mask=%s)", ipRes.ip, ipRes.gateway, ipRes.subnetMask)
-		// Once we found an IP Address, we have to reserve this IP in local memory
-		// because the IP address won't be used directly on the server
-		if err := h.reserveIPAddress(ctx, ipRes.ip); err != nil {
-			return nil, err
-		}
 
 		customSpec.NicSettingMap = []types.CustomizationAdapterMapping{
 			{

--- a/engine/hatchery/vsphere/client_test.go
+++ b/engine/hatchery/vsphere/client_test.go
@@ -226,39 +226,6 @@ func TestHatcheryVSphere_deleteServer(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Observing the vSphere VM list is the source of truth: when a listed VM's
-// annotation carries an IP that is still locally reserved, the reservation must
-// be released (the annotation now protects the IP). A reservation for an IP not
-// yet backed by any VM (in-flight clone) must be kept.
-func TestHatcheryVSphere_countAvailableIPs_releasesObservedReservations(t *testing.T) {
-	log.Factory = log.NewTestingWrapper(t)
-
-	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{vSphereClient: c}
-	h.availableNetworks = []availableNetwork{{ipAddresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}}}
-	// 10.0.0.1 is reserved AND now backed by a real VM; 10.0.0.2 is reserved but
-	// not yet backed by any VM (in-flight clone).
-	h.reservedIPAddresses = []string{"10.0.0.1", "10.0.0.2"}
-
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]mo.VirtualMachine, error) {
-			return []mo.VirtualMachine{
-				{
-					ManagedEntity: mo.ManagedEntity{Name: "worker-x"},
-					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"ip_address": "10.0.0.1"}`},
-				},
-			}, nil
-		},
-	)
-
-	count := h.countAvailableIPs(context.Background())
-
-	// 10.0.0.1 used (annotation), 10.0.0.2 still reserved (in-flight) → only 10.0.0.3 free.
-	assert.Equal(t, 1, count)
-	assert.False(t, sdk.IsInArray("10.0.0.1", h.reservedIPAddresses), "reservation must be released once a VM carries the IP")
-	assert.True(t, sdk.IsInArray("10.0.0.2", h.reservedIPAddresses), "an unbacked (in-flight) reservation must be kept")
-}
-
 func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
@@ -269,19 +236,6 @@ func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 	h.Config.VSphereNetworkString = "vbox-net"
 	h.Config.VSphereCardName = "ethernet-card"
 	h.Config.VSphereDatastoreString = "datastore"
-	h.availableIPAddresses = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
-	h.availableNetworks = []availableNetwork{
-		{
-			config: NetworkConfig{
-				IPRange:    "192.168.0.0/24",
-				Gateway:    "192.168.0.254",
-				SubnetMask: "255.255.255.0",
-			},
-			ipAddresses: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"},
-		},
-	}
-	h.reservedIPAddresses = []string{"192.168.0.1", "192.168.0.2"}
-	h.Config.Gateway = "192.168.0.254"
 	h.Config.DNS = "192.168.0.253"
 
 	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -292,65 +246,23 @@ func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 			}, nil
 		},
 	)
-
-	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").DoAndReturn(
-		func(ctx context.Context, s string) (object.NetworkReference, error) {
-			return &object.Network{}, nil
-		},
-	)
-
-	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).DoAndReturn(
-		func(ctx context.Context, card *types.VirtualEthernetCard, ethernetCardName string, network object.NetworkReference) error {
-			return nil
-		},
-	)
-
-	c.EXPECT().LoadResourcePool(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) (*object.ResourcePool, error) {
-			return &object.ResourcePool{}, nil
-		},
-	)
-
-	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").DoAndReturn(
-		func(ctx context.Context, name string) (*object.Datastore, error) {
-			return &object.Datastore{}, nil
-		},
-	)
-
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]mo.VirtualMachine, error) {
-			return []mo.VirtualMachine{
-				{
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{
-							Template: false,
-						},
-					},
-					Guest: &types.GuestInfo{
-						Net: []types.GuestNicInfo{
-							{
-								IpAddress: []string{"192.168.0.2"},
-							},
-						},
-					},
-				},
-			}, nil
-		},
-	).AnyTimes()
+	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").Return(&object.Network{}, nil)
+	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).Return(nil)
+	c.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
+	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").Return(&object.Datastore{}, nil)
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
+	annot := annotation{}
+	ip := &ipResult{ip: "192.168.0.3", gateway: "192.168.0.254", subnetMask: "255.255.255.0"}
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annot, ip)
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 
-	// Assert the IP address
+	// The clone spec uses the caller-chosen IP, and the IP is recorded in the annotation.
 	assert.Equal(t, "192.168.0.3", (cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp).IpAddress))
-	assert.EqualValues(t, []string{"192.168.0.1", "192.168.0.3"}, h.reservedIPAddresses) // "192.168.0.2" should be removed because it's returned by the ListVirtualMachine
-	// Assert the Gateway
 	assert.Equal(t, "192.168.0.254", cloneSpec.Customization.NicSettingMap[0].Adapter.Gateway[0])
-	// Assert the DNS
 	assert.Equal(t, "192.168.0.253", cloneSpec.Customization.GlobalIPSettings.DnsServerList[0])
-
+	assert.Equal(t, "192.168.0.3", annot.IPAddress)
 }
 
 func TestHatcheryVSphere_launchClientOpV2(t *testing.T) {

--- a/engine/hatchery/vsphere/client_test.go
+++ b/engine/hatchery/vsphere/client_test.go
@@ -226,6 +226,39 @@ func TestHatcheryVSphere_deleteServer(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Observing the vSphere VM list is the source of truth: when a listed VM's
+// annotation carries an IP that is still locally reserved, the reservation must
+// be released (the annotation now protects the IP). A reservation for an IP not
+// yet backed by any VM (in-flight clone) must be kept.
+func TestHatcheryVSphere_countAvailableIPs_releasesObservedReservations(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{vSphereClient: c}
+	h.availableNetworks = []availableNetwork{{ipAddresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}}}
+	// 10.0.0.1 is reserved AND now backed by a real VM; 10.0.0.2 is reserved but
+	// not yet backed by any VM (in-flight clone).
+	h.reservedIPAddresses = []string{"10.0.0.1", "10.0.0.2"}
+
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "worker-x"},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: `{"ip_address": "10.0.0.1"}`},
+				},
+			}, nil
+		},
+	)
+
+	count := h.countAvailableIPs(context.Background())
+
+	// 10.0.0.1 used (annotation), 10.0.0.2 still reserved (in-flight) → only 10.0.0.3 free.
+	assert.Equal(t, 1, count)
+	assert.False(t, sdk.IsInArray("10.0.0.1", h.reservedIPAddresses), "reservation must be released once a VM carries the IP")
+	assert.True(t, sdk.IsInArray("10.0.0.2", h.reservedIPAddresses), "an unbacked (in-flight) reservation must be kept")
+}
+
 func TestHatcheryVSphere_prepareCloneSpec(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 

--- a/engine/hatchery/vsphere/flavor_test.go
+++ b/engine/hatchery/vsphere/flavor_test.go
@@ -43,7 +43,7 @@ func TestPrepareCloneSpec(t *testing.T) {
 	mockClient.EXPECT().LoadDatastore(gomock.Any(), "datastore1").Return(&object.Datastore{}, nil)
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -580,110 +579,32 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 			continue
 		}
 
-		// skipping vm starting with provision-
+		// Pooled provisions (still in the pool, holding their reserved IP on
+		// purpose) and model templates must not be reaped here.
 		if strings.HasPrefix(s.Name, "provision-") {
 			continue
 		}
-
 		if annot.Model {
 			continue
 		}
 
-		// reload virtual machine to have fresh data from vsphere
-		vm, err := h.vSphereClient.LoadVirtualMachine(ctx, s.Name)
-		if err != nil {
-			ctx = sdk.ContextWithStacktrace(ctx, err)
-			log.Error(ctx, "unable to load vm: %v", err)
-			return
+		// Determine when this worker actually started. Prefer the worker start
+		// time stamped on the annotation at claim time (persistent, survives a
+		// restart, does not age out like vSphere events). For VMs created before
+		// this field existed (transitional / upgrade), fall back to the VM's
+		// vSphere creation date so they are still handled and eventually cleaned.
+		startTime := annot.WorkerStartTime
+		if startTime.IsZero() && s.Config != nil && s.Config.CreateDate != nil {
+			startTime = *s.Config.CreateDate
 		}
-
-		// gettings events for this vm, we have to check if we have a types.VmStartingEvent
-		vmEvents, err := h.vSphereClient.LoadVirtualMachineEvents(ctx, vm, "VmStartingEvent", "VmPoweredOffEvent", "VmRenamedEvent")
-		if err != nil {
-			ctx = sdk.ContextWithStacktrace(ctx, err)
-			log.Error(ctx, "unable to load VmStartingEvent events: %v", err)
-			return
-		}
-
-		// if we don't have a types.VmStartingEvent, we skip this vm
-		if len(vmEvents) == 0 {
-			log.Debug(ctx, "killAwolServers> no VmStartingEvent found - we keep this vm")
+		if startTime.IsZero() {
+			// No reliable timestamp at all (should not happen). Keep it rather than
+			// risk deleting a VM we cannot reason about.
+			log.Warn(ctx, "killAwolServers> no start time for %q, keeping it", s.Name)
 			continue
 		}
-		// we can have many VmStartingEvent: one for the provision, another with the worker from on the provision
 
-		var vmStartedTime, vmPoweredOffTime, vmRenamedEvent time.Time
-		var foundStarted, foundPoweredOff, foundRenamedEvent bool
-		for _, event := range vmEvents {
-			// events on the vm can contain event from the provision.
-			// Skipping this event if it's a provision's event
-			if strings.Contains(event.GetEvent().FullFormattedMessage, "provision-") {
-				log.Debug(ctx, "killAwolServers> skipping event %+v with provision text", event)
-				continue
-			}
-
-			// take most recent VmStartingEvent and vmPoweredOffTime
-			switch reflect.TypeOf(event).Elem().Name() {
-			case "VmStartingEvent":
-				// first event found, take it
-				if !foundStarted {
-					vmStartedTime = event.GetEvent().CreatedTime
-					foundStarted = true
-					continue
-				}
-				// if current event is youngest than previous, take it
-				if event.GetEvent().CreatedTime.After(vmStartedTime) {
-					vmStartedTime = event.GetEvent().CreatedTime
-				}
-			case "VmRenamedEvent":
-				if !foundRenamedEvent {
-					vmRenamedEvent = event.GetEvent().CreatedTime
-					foundRenamedEvent = true
-					continue
-				}
-				// if current event is youngest than previous, take it
-				if event.GetEvent().CreatedTime.After(vmRenamedEvent) {
-					vmRenamedEvent = event.GetEvent().CreatedTime
-				}
-			case "VmPoweredOffEvent":
-				if !foundPoweredOff {
-					vmPoweredOffTime = event.GetEvent().CreatedTime
-					foundPoweredOff = true
-					continue
-				}
-				if event.GetEvent().CreatedTime.After(vmPoweredOffTime) {
-					vmPoweredOffTime = event.GetEvent().CreatedTime
-				}
-			}
-		}
-
-		// In some condition (restart hatchery for exemple),
-		// we can see some vm renamed, but not started. Deleting them if the renamed is too old
-		if !foundStarted && foundRenamedEvent {
-			expire := vmRenamedEvent.Add(time.Duration(h.Config.WorkerRegistrationTTL) * time.Minute)
-			if time.Now().After(expire) {
-				log.Debug(ctx, "deleting machine %q started not found and vmRenamedEvent found but it's too old: %v expire:%v", s.Name, vmRenamedEvent, expire)
-				if err := h.deleteServer(ctx, s); err != nil {
-					ctx = sdk.ContextWithStacktrace(ctx, err)
-					log.Error(ctx, "killAwolServers> cannot delete server (renamed but not started) %s", s.Name)
-				}
-				// next vm
-				continue
-			}
-		}
-
-		if !foundStarted {
-			log.Debug(ctx, "killAwolServers> vmStartedTime NOT found for %v - events analyzed:%d", s.Name, len(vmEvents))
-			continue
-		}
-		if foundPoweredOff {
-			// this should not happen, but we check if the powerOff Time is AFTER the started time
-			if vmPoweredOffTime.Before(vmStartedTime) {
-				foundPoweredOff = false
-			}
-		}
-
-		log.Debug(ctx, "killAwolServers> vmStartedTime %v found: %s events analyzed:%d", s.Name, vmStartedTime, len(vmEvents))
+		poweredOff := s.Summary.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff
 
 		var existsOnAPISide bool
 		for _, w := range allWorkers {
@@ -693,54 +614,33 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 			}
 		}
 
-		var toDelete bool
-
-		log.Debug(ctx, "checking if %v is outdated. vmStartedTime: %v. existsOnAPISide:%t foundPoweredOff:%t vmPoweredOffTime:%v", s.Name, vmStartedTime, existsOnAPISide, foundPoweredOff, vmPoweredOffTime)
-
-		if existsOnAPISide {
-			expire := vmStartedTime.Add(time.Duration(h.Config.WorkerTTL) * time.Minute)
-			if time.Now().After(expire) {
-				toDelete = true
-			}
-		} else {
-			// not currently visible on API. Can be:
-			// - worker starting, not yet visible on api
-			// - worker ended (job finished), removed on api
-
-			// if we found a foundPoweredOff event, it's a worker used, and terminated. We can delete it
-			if foundPoweredOff {
-				// poweredOff found, we can delete this vm
-				toDelete = true
-			} else { // worker starting
-				// not poweredOff found, check the WorkerRegistrationTTL
-				expire := vmStartedTime.Add(time.Duration(h.Config.WorkerRegistrationTTL) * time.Minute)
-				if time.Now().After(expire) {
-					toDelete = true
-				}
-			}
+		// Decide when this VM expires:
+		// - powered off: a claimed worker is never restarted, so it has finished or
+		//   failed. WorkerRegistrationTTL frees its IP quickly while still covering
+		//   the brief rename->power-on window of an in-flight spawn (whose
+		//   WorkerStartTime is "now").
+		// - powered on and registered on the API: running worker, capped at WorkerTTL.
+		// - powered on but not on the API: still booting/registering, give it
+		//   WorkerRegistrationTTL to show up.
+		var expire time.Time
+		switch {
+		case poweredOff:
+			expire = startTime.Add(time.Duration(h.Config.WorkerRegistrationTTL) * time.Minute)
+		case existsOnAPISide:
+			expire = startTime.Add(time.Duration(h.Config.WorkerTTL) * time.Minute)
+		default:
+			expire = startTime.Add(time.Duration(h.Config.WorkerRegistrationTTL) * time.Minute)
 		}
 
-		if !toDelete {
-			log.Debug(ctx, "We keep %v as not expired", s.Name)
+		if !time.Now().After(expire) {
+			log.Debug(ctx, "killAwolServers> keeping %q (poweredOff=%t existsOnAPISide=%t startTime=%v expire=%v)", s.Name, poweredOff, existsOnAPISide, startTime, expire)
 			continue
 		}
 
-		// debug with event if necessary
-		if log.Factory().GetLevel() == log.LevelDebug {
-			events, err := h.vSphereClient.LoadVirtualMachineEvents(ctx, vm, "")
-			if err != nil {
-				log.Error(ctx, "event machine %q - can't load LoadVirtualMachineEvents", s.Name, err)
-			}
-			for _, e := range events {
-				log.Debug(ctx, "event machine %q - event: %T time:%v msg:%+v", s.Name, e, e.GetEvent().CreatedTime, e.GetEvent().FullFormattedMessage)
-			}
-		}
-
-		log.Info(ctx, "deleting machine %q - expired. vmStartedTime: %v. existsOnAPISide:%t foundPoweredOff:%t", s.Name, vmStartedTime, existsOnAPISide, foundPoweredOff)
-
+		log.Info(ctx, "deleting machine %q - expired (poweredOff=%t existsOnAPISide=%t startTime=%v)", s.Name, poweredOff, existsOnAPISide, startTime)
 		if err := h.deleteServer(ctx, s); err != nil {
 			ctx = sdk.ContextWithStacktrace(ctx, err)
-			log.Error(ctx, "killAwolServers> cannot delete server (expire) %s", s.Name)
+			log.Error(ctx, "killAwolServers> cannot delete server (expire) %s: %v", s.Name, err)
 		}
 	}
 }

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -737,6 +737,13 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 	mapAlreadyProvisionned := make(map[string]int)
 	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
 	listableProvisions := make(map[string]struct{})
+	// Breakdown of the total by state, for observability only — the deficit is
+	// always driven by the total. Only READY (powered off, not dying) provisions
+	// can actually be claimed; STARTING, DYING and in-flight ones are counted
+	// because they each still hold their IP, but cannot serve a job yet.
+	mapReady := make(map[string]int)    // powered off, claimable now
+	mapStarting := make(map[string]int) // powered on, still being created/finished
+	mapDying := make(map[string]int)    // marked for deletion, not yet reaped
 	machines := h.getVirtualMachines(ctx)
 	for _, machine := range machines {
 		if !strings.HasPrefix(machine.Name, "provision-v2") {
@@ -754,15 +761,25 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 			mapAlreadyProvisionned[annot.VMwareModelPath]++
 			mapProvisionedMachines[annot.VMwareModelPath] = append(
 				mapProvisionedMachines[annot.VMwareModelPath], machine)
+			switch {
+			case h.isMarkedToDelete(machine):
+				mapDying[annot.VMwareModelPath]++
+			case machine.Summary.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff:
+				mapReady[annot.VMwareModelPath]++
+			default:
+				mapStarting[annot.VMwareModelPath]++
+			}
 		}
 	}
 	// Also count in-flight clones whose VM is not yet visible in the inventory, so
 	// a retrigger does not double-create them. This is the only cache-derived term
 	// and is naturally empty after a restart (a dead process leaves no
 	// not-yet-listable clone — its VM either exists in vSphere or never did).
+	mapInflight := make(map[string]int)
 	for name, model := range h.cacheProvisioning.pending {
 		if _, listable := listableProvisions[name]; !listable {
 			mapAlreadyProvisionned[model]++
+			mapInflight[model]++
 		}
 	}
 	h.cacheProvisioning.mu.Unlock()
@@ -781,8 +798,9 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 			continue
 		}
 		existing := mapAlreadyProvisionned[modelVMware]
-		log.Info(ctx, "model vmware %q provisioning: %d/%d",
-			modelVMware, existing, number)
+		log.Info(ctx, "model vmware %q provisioning: %d/%d (ready=%d starting=%d dying=%d in-flight=%d)",
+			modelVMware, existing, number,
+			mapReady[modelVMware], mapStarting[modelVMware], mapDying[modelVMware], mapInflight[modelVMware])
 		if delta := number - existing; delta > 0 {
 			deficits[modelVMware] = delta
 		}

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -81,6 +81,12 @@ func (h *HatcheryVSphere) ApplyConfiguration(cfg interface{}) error {
 	if h.Config.WorkerRegistrationTTL == 0 {
 		h.Config.WorkerRegistrationTTL = 10
 	}
+	if h.Config.KillAwolServersInterval == 0 {
+		h.Config.KillAwolServersInterval = 60
+	}
+	if h.Config.FinishedWorkerGracePeriod == 0 {
+		h.Config.FinishedWorkerGracePeriod = 180
+	}
 
 	return nil
 }
@@ -558,6 +564,15 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 
 	srvs := h.getVirtualMachines(ctx)
 
+	// Track whether anything was deleted so we can trigger an immediate
+	// provisioning refill once resources (and their reserved IPs) are freed.
+	var deleted bool
+	defer func() {
+		if deleted {
+			h.requestProvisioning(ctx)
+		}
+	}()
+
 	for _, s := range srvs {
 		ctx = context.WithValue(ctx, cdslog.AuthWorkerName, s.Name)
 
@@ -575,6 +590,8 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 			if err := h.deleteServer(ctx, s); err != nil {
 				ctx = sdk.ContextWithStacktrace(ctx, err)
 				log.Error(ctx, "killAwolServers> cannot delete server (markedToDelete) %s: %v", s.Name, err)
+			} else {
+				deleted = true
 			}
 			continue
 		}
@@ -615,17 +632,21 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 		}
 
 		// Decide when this VM expires:
-		// - powered off: a claimed worker is never restarted, so it has finished or
-		//   failed. WorkerRegistrationTTL frees its IP quickly while still covering
-		//   the brief rename->power-on window of an in-flight spawn (whose
-		//   WorkerStartTime is "now").
-		// - powered on and registered on the API: running worker, capped at WorkerTTL.
-		// - powered on but not on the API: still booting/registering, give it
+		// - powered off and still registered on the API: the worker booted, ran, and
+		//   is now down — the job is over. Reclaim it immediately.
+		// - powered off and no longer on the API: a finished+deregistered worker, or
+		//   an in-flight spawn between rename and power-on. The short
+		//   FinishedWorkerGracePeriod reclaims the former quickly while still covering
+		//   the latter (its WorkerStartTime is "now").
+		// - powered on and registered: running worker, capped at WorkerTTL.
+		// - powered on but not registered: still booting/registering, give it
 		//   WorkerRegistrationTTL to show up.
 		var expire time.Time
 		switch {
+		case poweredOff && existsOnAPISide:
+			expire = startTime
 		case poweredOff:
-			expire = startTime.Add(time.Duration(h.Config.WorkerRegistrationTTL) * time.Minute)
+			expire = startTime.Add(time.Duration(h.Config.FinishedWorkerGracePeriod) * time.Second)
 		case existsOnAPISide:
 			expire = startTime.Add(time.Duration(h.Config.WorkerTTL) * time.Minute)
 		default:
@@ -641,6 +662,8 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 		if err := h.deleteServer(ctx, s); err != nil {
 			ctx = sdk.ContextWithStacktrace(ctx, err)
 			log.Error(ctx, "killAwolServers> cannot delete server (expire) %s: %v", s.Name, err)
+		} else {
+			deleted = true
 		}
 	}
 }

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -561,6 +561,17 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 		return
 	}
 
+	// Map each still-registered V2 worker to the job it is running. When we
+	// reclaim such a worker's VM, we release that job back to the queue right
+	// away instead of waiting for the API to notice the lost heartbeat (~5 min)
+	// before the job can be retried.
+	jobByWorker := make(map[string]string)
+	for _, w := range allWorkers {
+		if v2w, ok := w.(*sdk.V2Worker); ok && v2w.JobRunID != "" {
+			jobByWorker[v2w.Name] = v2w.JobRunID
+		}
+	}
+
 	srvs := h.getVirtualMachines(ctx)
 
 	// Track whether anything was deleted so we can trigger an immediate
@@ -591,6 +602,7 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 				log.Error(ctx, "killAwolServers> cannot delete server (markedToDelete) %s: %v", s.Name, err)
 			} else {
 				deleted = true
+				h.releaseDeadWorkerJob(ctx, s.Name, jobByWorker)
 			}
 			continue
 		}
@@ -663,8 +675,26 @@ func (h *HatcheryVSphere) killAwolServers(ctx context.Context) {
 			log.Error(ctx, "killAwolServers> cannot delete server (expire) %s: %v", s.Name, err)
 		} else {
 			deleted = true
+			h.releaseDeadWorkerJob(ctx, s.Name, jobByWorker)
 		}
 	}
+}
+
+// releaseDeadWorkerJob asks the API to requeue the V2 job that the reclaimed
+// worker was running, so it can be retried at once. Without it, the job stays
+// Building until the worker's heartbeat times out on the API side (~5 min).
+// It is a no-op for VMs that hold no job (provisions, models, finished workers).
+func (h *HatcheryVSphere) releaseDeadWorkerJob(ctx context.Context, workerName string, jobByWorker map[string]string) {
+	jobRunID, ok := jobByWorker[workerName]
+	if !ok {
+		return
+	}
+	if err := h.CDSClientV2().V2HatcheryReleaseJob(ctx, h.GetRegion(), jobRunID); err != nil {
+		ctx = sdk.ContextWithStacktrace(ctx, err)
+		log.Warn(ctx, "killAwolServers> unable to release job %s of reclaimed worker %q: %v", jobRunID, workerName, err)
+		return
+	}
+	log.Info(ctx, "killAwolServers> released job %s for re-queue after reclaiming worker %q", jobRunID, workerName)
 }
 
 // roundRobinInterleave takes an ordered list of model keys and a deficit count

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -782,18 +782,24 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 	}
 	provisionQueue := roundRobinInterleave(modelOrder, deficits)
 
-	// --- Step 3: cap by available IPs and enqueue tasks ---
-	ipBudget := -1
-	if len(h.availableIPAddresses) > 0 {
-		ipBudget = h.countAvailableIPs(ctx)
-		log.Info(ctx, "provisioning IP budget: %d available", ipBudget)
-	}
-	if ipBudget == 0 {
-		log.Warn(ctx, "provisioning stopped: no IPs available")
-		provisionQueue = nil
-	} else if ipBudget > 0 && len(provisionQueue) > ipBudget {
-		log.Warn(ctx, "provisioning capped to %d tasks (IP budget)", ipBudget)
-		provisionQueue = provisionQueue[:ipBudget]
+	// --- Step 3: assign IPs and launch clones ---
+	// Build the set of IPs already in use (from the vSphere list — annotations and
+	// provision-v2-ip names) plus the IPs of in-flight clones not yet listed
+	// (parsed from pending names). When an IP range is configured, each clone gets
+	// a distinct IP picked here, in this single goroutine, so parallel clones can
+	// never collide. The IP is encoded in the VM name (see provisionName), which
+	// makes the lock visible in vSphere during the clone and across a restart — no
+	// in-memory reservation, no timeout.
+	var usedIPs map[string]struct{}
+	if len(h.availableNetworks) > 0 {
+		usedIPs = h.getUsedIPs(ctx, machines)
+		h.cacheProvisioning.mu.Lock()
+		for name := range h.cacheProvisioning.pending {
+			if ip, ok := ipFromProvisionName(name); ok {
+				usedIPs[ip] = struct{}{}
+			}
+		}
+		h.cacheProvisioning.mu.Unlock()
 	}
 
 	// Reuse any in-flight provisions orphaned by a restart, then submit the
@@ -803,6 +809,16 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 	h.reconcileProvisionedVMs(ctx, machines, "provision-v2")
 
 	for _, modelVMware := range provisionQueue {
-		h.startProvisionClone(ctx, modelVMware)
+		var ip *ipResult
+		if usedIPs != nil {
+			res, ok := h.pickFreeIP(usedIPs)
+			if !ok {
+				log.Warn(ctx, "provisioning stopped: no IP address available")
+				break
+			}
+			usedIPs[res.ip] = struct{}{} // exclude from subsequent picks this pass
+			ip = &res
+		}
+		h.startProvisionClone(ctx, modelVMware, provisionName(ip), ip)
 	}
 }

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v4"
@@ -701,11 +700,13 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 	h.cacheProvisioning.mu.Lock()
 
 	// --- Step 1: compute current state and deficit per model ---
-	// Count ALL VMs with Provisioning annotation regardless of power state,
-	// so orphaned VMs (powered on, stuck) are included. This ensures that
-	// reconciled VMs don't cause additional clones in the deficit calculation.
+	// vSphere is the source of truth. Count every provision VM with the
+	// Provisioning annotation regardless of power state — both READY (powered off,
+	// claimable) and STARTING (powered on, still being created). This makes the
+	// deficit correct even after a restart with an empty pending cache.
 	mapAlreadyProvisionned := make(map[string]int)
 	mapProvisionedMachines := make(map[string][]mo.VirtualMachine)
+	listableProvisions := make(map[string]struct{})
 	machines := h.getVirtualMachines(ctx)
 	for _, machine := range machines {
 		if !strings.HasPrefix(machine.Name, "provision-v2") {
@@ -719,9 +720,19 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 			continue
 		}
 		if annot.Provisioning {
+			listableProvisions[machine.Name] = struct{}{}
 			mapAlreadyProvisionned[annot.VMwareModelPath]++
 			mapProvisionedMachines[annot.VMwareModelPath] = append(
 				mapProvisionedMachines[annot.VMwareModelPath], machine)
+		}
+	}
+	// Also count in-flight clones whose VM is not yet visible in the inventory, so
+	// a retrigger does not double-create them. This is the only cache-derived term
+	// and is naturally empty after a restart (a dead process leaves no
+	// not-yet-listable clone — its VM either exists in vSphere or never did).
+	for name, model := range h.cacheProvisioning.pending {
+		if _, listable := listableProvisions[name]; !listable {
+			mapAlreadyProvisionned[model]++
 		}
 	}
 	h.cacheProvisioning.mu.Unlock()
@@ -785,16 +796,13 @@ func (h *HatcheryVSphere) provisioningV2(ctx context.Context) {
 		provisionQueue = provisionQueue[:ipBudget]
 	}
 
-	var batch sync.WaitGroup
-	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
+	// Reuse any in-flight provisions orphaned by a restart, then submit the
+	// deficit's worth of clones. Fire-and-forget: each clone runs in its own
+	// goroutine and is tracked as pending, so this returns immediately and the
+	// provisioning loop stays responsive to the next tick/signal.
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2")
 
 	for _, modelVMware := range provisionQueue {
-		batch.Add(1)
-		h.provisioningPool.tasks <- provisionTask{
-			cloneV2: modelVMware,
-			wg:      &batch,
-		}
+		h.startProvisionClone(ctx, modelVMware)
 	}
-
-	batch.Wait()
 }

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -473,8 +474,71 @@ func TestHatcheryVSphere_provisioning_v2_do_nothing(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	setupTestPool(ctx, &h)
 	h.provisioningV2(ctx)
+}
+
+// provisioningV2 must count both ready (existing) and in-flight (starting,
+// tracked in the pending cache) provisions when computing the deficit, so a
+// retrigger while clones are still in flight does not double-create.
+func TestHatcheryVSphere_provisioningV2_noDoubleCreate(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+		Common: hatchery.Common{
+			Common: service.Common{GoRoutines: sdk.NewGoRoutines(context.Background())},
+		},
+		Config: HatcheryConfiguration{
+			WorkerProvisioning: []WorkerProvisioningConfig{{ModelVMWare: "the-model", Number: 3}},
+		},
+	}
+
+	// One ready provision (powered off) already exists in vSphere.
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			return []mo.VirtualMachine{{
+				ManagedEntity: mo.ManagedEntity{Name: "provision-v2-ready"},
+				Summary:       types.VirtualMachineSummary{Config: types.VirtualMachineConfigSummary{Template: false}},
+				Config:        &types.VirtualMachineConfigInfo{Annotation: `{"vmware_model_path": "the-model", "provisioning": true}`},
+				Runtime:       types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
+			}}, nil
+		},
+	).AnyTimes()
+
+	// One in-flight clone already tracked (not yet visible in the inventory).
+	h.cacheProvisioning.pending = map[string]string{"provision-v2-starting": "the-model"}
+
+	// Each launched clone first loads the model template; block it so the clone
+	// stays in flight, and count how many clones were launched.
+	var cloneCount int64
+	release := make(chan struct{})
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "the-model").DoAndReturn(
+		func(ctx context.Context, name string) (*object.VirtualMachine, error) {
+			atomic.AddInt64(&cloneCount, 1)
+			<-release
+			return nil, fmt.Errorf("stop the clone here")
+		},
+	).AnyTimes()
+
+	// deficit = Number(3) − existing(1) − starting(1) = 1
+	h.provisioningV2(context.Background())
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&cloneCount) == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Retrigger while the clone is still in flight: it is now tracked as pending,
+	// so deficit = 3 − 1 − 2 = 0 → no new clone.
+	h.provisioningV2(context.Background())
+	time.Sleep(200 * time.Millisecond) // give any erroneous extra clone time to start
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cloneCount), "a retrigger must not re-create in-flight provisions")
+
+	// Let the blocked clone fail and unwind, and wait for it to drop from pending
+	// so its goroutine is done before the test (and gomock controller) tears down.
+	close(release)
+	assert.Eventually(t, func() bool {
+		h.cacheProvisioning.mu.Lock()
+		defer h.cacheProvisioning.mu.Unlock()
+		return len(h.cacheProvisioning.pending) == 1 // only the manually-seeded "starting" entry remains
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestHatcheryVSphere_GetDetaultModelV2Name(t *testing.T) {
@@ -563,7 +627,6 @@ func TestHatcheryVSphere_provisioning_v2_deprovision_excess(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	setupTestPool(ctx, &h)
 	h.provisioningV2(ctx)
 
 	// 2 excess VMs should be marked for deletion (3 exist - 1 configured = 2 excess)
@@ -618,7 +681,6 @@ func TestHatcheryVSphere_provisioning_v2_deprovision_removed_model(t *testing.T)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	setupTestPool(ctx, &h)
 	h.provisioningV2(ctx)
 
 	// Both VMs should be marked for deletion since model is removed from config

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -254,6 +254,7 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 	}
 	h.Config.WorkerTTL = 5
 	h.Config.WorkerRegistrationTTL = 5
+	h.Config.FinishedWorkerGracePeriod = 300 // 5 min
 
 	now := time.Now()
 	old := now.Add(-10 * time.Minute)
@@ -264,10 +265,10 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 		return string(b)
 	}
 
-	// worker0 and worker1 are registered on the API side.
+	// worker0, worker1 and worker6 are registered on the API side.
 	cdsclient.EXPECT().WorkerList(gomock.Any()).DoAndReturn(
 		func(ctx context.Context) ([]sdk.Worker, error) {
-			return []sdk.Worker{{Name: "worker0"}, {Name: "worker1"}}, nil
+			return []sdk.Worker{{Name: "worker0"}, {Name: "worker1"}, {Name: "worker6"}}, nil
 		},
 	)
 
@@ -301,8 +302,13 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
 					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{}), CreateDate: &old},
 				},
-				{ // just-claimed worker, powered off but recent start → KEEP (in-flight)
+				{ // just-claimed worker, powered off but recent start, not on API → KEEP (in-flight)
 					ManagedEntity: mo.ManagedEntity{Name: "worker5"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: now})},
+				},
+				{ // finished worker, powered off but still on API, recent start → DELETE NOW
+					ManagedEntity: mo.ManagedEntity{Name: "worker6"},
 					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
 					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: now})},
 				},
@@ -314,6 +320,7 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 	var vm1 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker1"}}
 	var vm3 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker3"}}
 	var vm4 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker4"}}
+	var vm6 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker6"}}
 
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vmname string) (*object.VirtualMachine, error) {
@@ -324,19 +331,41 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 				return &vm3, nil
 			case "worker4":
 				return &vm4, nil
+			case "worker6":
+				return &vm6, nil
 			}
 			return nil, fmt.Errorf("not expected: %s", vmname)
 		},
-	).Times(3)
+	).Times(4)
 
-	// worker1 is powered on → shutdown then destroy; worker3/worker4 are powered
-	// off → destroy only.
+	// worker1 is powered on → shutdown then destroy; worker3/worker4/worker6 are
+	// powered off → destroy only.
 	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &vm1).Return(nil)
 	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm1).Return(nil)
 	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm3).Return(nil)
 	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm4).Return(nil)
+	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm6).Return(nil)
 
 	h.killAwolServers(context.Background())
+}
+
+func TestHatcheryVSphere_requestProvisioning(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	ctx := context.Background()
+
+	// nil channel (provisioning disabled): must be a safe no-op.
+	h := &HatcheryVSphere{}
+	h.requestProvisioning(ctx)
+
+	// buffered size-1: repeated requests coalesce into a single pending refill.
+	h.provisionSignal = make(chan struct{}, 1)
+	h.requestProvisioning(ctx)
+	h.requestProvisioning(ctx)
+	h.requestProvisioning(ctx)
+	assert.Len(t, h.provisionSignal, 1, "requests must coalesce to a single pending refill")
+
+	<-h.provisionSignal
+	assert.Len(t, h.provisionSignal, 0)
 }
 
 func TestHatcheryVSphere_Status(t *testing.T) {

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -254,155 +255,86 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 	h.Config.WorkerTTL = 5
 	h.Config.WorkerRegistrationTTL = 5
 
+	now := time.Now()
+	old := now.Add(-10 * time.Minute)
+
+	annot := func(a annotation) string {
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	// worker0 and worker1 are registered on the API side.
 	cdsclient.EXPECT().WorkerList(gomock.Any()).DoAndReturn(
 		func(ctx context.Context) ([]sdk.Worker, error) {
-			var un int64 = 1
-			return []sdk.Worker{
-				{
-					Name:    "worker1",
-					ModelID: &un,
-					Status:  sdk.StatusDisabled,
-				},
-			}, nil
+			return []sdk.Worker{{Name: "worker0"}, {Name: "worker1"}}, nil
 		},
 	)
 
-	c.EXPECT().GetVirtualMachinePowerState(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) (types.VirtualMachinePowerState, error) {
-			switch vm.Name() {
-			case "worker0":
-				return types.VirtualMachinePowerStatePoweredOn, nil
-			default:
-				return types.VirtualMachinePowerStatePoweredOff, nil
-			}
-		},
-	).AnyTimes()
-
-	c.EXPECT().LoadVirtualMachineEvents(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine, eventTypes ...string) ([]types.BaseEvent, error) {
-			t.Logf("LoadVirtualMachineEvents for %s", vm.Name())
-			switch vm.Name() {
-			case "worker0":
-				return []types.BaseEvent{
-					&types.VmStartingEvent{
-						VmEvent: types.VmEvent{
-							Event: types.Event{
-								CreatedTime: time.Now(),
-							},
-						},
-					},
-				}, nil
-			default:
-				return []types.BaseEvent{
-					&types.VmStartingEvent{
-						VmEvent: types.VmEvent{
-							Event: types.Event{
-								CreatedTime: time.Now().Add(-10 * time.Minute),
-							},
-						},
-					},
-				}, nil
-			}
-		},
-	).Times(5)
-
 	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
 		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			poweredOn := types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn}
+			poweredOff := types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff}
 			return []mo.VirtualMachine{
-				{
-					ManagedEntity: mo.ManagedEntity{
-						Name: "worker0",
-					},
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{
-							Template: false,
-						},
-						Runtime: types.VirtualMachineRuntimeInfo{
-							PowerState: types.VirtualMachinePowerStatePoweredOn,
-						},
-					},
-					Config: &types.VirtualMachineConfigInfo{
-						Annotation: `{"model": false, "to_delete": false, "worker_model_path": "someting"}`,
-					},
+				{ // running worker, recently started, on API → KEEP
+					ManagedEntity: mo.ManagedEntity{Name: "worker0"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOn},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: now})},
 				},
-				{
-					ManagedEntity: mo.ManagedEntity{
-						Name: "worker1",
-					},
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{
-							Template: false,
-						},
-					},
-					Config: &types.VirtualMachineConfigInfo{
-						Annotation: `{"model": false, "to_delete": true}`,
-					},
+				{ // running worker, started long ago, on API → DELETE (WorkerTTL)
+					ManagedEntity: mo.ManagedEntity{Name: "worker1"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOn},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: old})},
 				},
-				{ // Provisionned worker not used should be kept
-					ManagedEntity: mo.ManagedEntity{
-						Name: "provision-worker2",
-					},
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{
-							Template: false,
-						},
-					},
-					Config: &types.VirtualMachineConfigInfo{
-						Annotation: `{"worker_name":"provision-worker2", "provisioning": true}`,
-					},
+				{ // pooled provision → SKIP (provision- prefix)
+					ManagedEntity: mo.ManagedEntity{Name: "provision-worker2"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerName: "provision-worker2", Provisioning: true})},
 				},
-				{ // Provisionned worker already used should be deleted
-					ManagedEntity: mo.ManagedEntity{
-						Name: "worker3",
-					},
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{
-							Template: false,
-						},
-					},
-					Config: &types.VirtualMachineConfigInfo{
-						Annotation: `{"worker_name":"provision-worker3", "provisioning": true}`,
-					},
+				{ // finished/failed worker, powered off, old start → DELETE
+					ManagedEntity: mo.ManagedEntity{Name: "worker3"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: old})},
+				},
+				{ // legacy worker (no WorkerStartTime), powered off, old CreateDate → DELETE
+					ManagedEntity: mo.ManagedEntity{Name: "worker4"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{}), CreateDate: &old},
+				},
+				{ // just-claimed worker, powered off but recent start → KEEP (in-flight)
+					ManagedEntity: mo.ManagedEntity{Name: "worker5"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: now})},
 				},
 			}, nil
 		},
 	).Times(1)
 
-	var vm0 = object.VirtualMachine{
-		Common: object.Common{
-			InventoryPath: "worker0",
-		},
-	}
+	// deleteServer reloads the VM by name; only the deleted ones are loaded.
 	var vm1 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker1"}}
 	var vm3 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker3"}}
+	var vm4 = object.VirtualMachine{Common: object.Common{InventoryPath: "worker4"}}
 
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vmname string) (*object.VirtualMachine, error) {
-			t.Logf("calling LoadVirtualMachine: %s", vmname)
 			switch vmname {
-			case "worker0":
-				return &vm0, nil
 			case "worker1":
 				return &vm1, nil
 			case "worker3":
 				return &vm3, nil
+			case "worker4":
+				return &vm4, nil
 			}
 			return nil, fmt.Errorf("not expected: %s", vmname)
 		},
-	).Times(5)
+	).Times(3)
 
-	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &vm1).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) error { return nil },
-	)
-	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm1).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) error { return nil },
-	)
-	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &vm3).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) error { return nil },
-	)
-	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm3).DoAndReturn(
-		func(ctx context.Context, vm *object.VirtualMachine) error { return nil },
-	)
+	// worker1 is powered on → shutdown then destroy; worker3/worker4 are powered
+	// off → destroy only.
+	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &vm1).Return(nil)
+	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm1).Return(nil)
+	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm3).Return(nil)
+	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vm4).Return(nil)
 
 	h.killAwolServers(context.Background())
 }

--- a/engine/hatchery/vsphere/hatchery_test.go
+++ b/engine/hatchery/vsphere/hatchery_test.go
@@ -350,6 +350,70 @@ func TestHatcheryVSphere_killAwolServers(t *testing.T) {
 	h.killAwolServers(context.Background())
 }
 
+// When killAwolServers reclaims the VM of a worker that is still registered on
+// the V2 API and running a job, it must release that job back to the queue so
+// it can be retried at once instead of waiting out the API heartbeat timeout.
+func TestHatcheryVSphere_killAwolServers_releasesDeadWorkerJob(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	sdkhatchery.InitMetrics(context.Background())
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	clientV1 := mock_cdsclient.NewMockInterface(ctrl)
+	clientV2 := mock_cdsclient.NewMockHatcheryServiceClient(ctrl)
+
+	h := HatcheryVSphere{
+		vSphereClient: c,
+		Common: hatchery.Common{
+			Clientv2: clientV2,
+			Common: service.Common{
+				Client: clientV1,
+				Region: "reg1",
+			},
+		},
+	}
+	h.Config.FinishedWorkerGracePeriod = 300
+
+	now := time.Now()
+
+	annot := func(a annotation) string {
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	// No V1 workers; one V2 worker still registered and bound to job-1.
+	clientV1.EXPECT().WorkerList(gomock.Any()).Return([]sdk.Worker{}, nil)
+	clientV2.EXPECT().V2WorkerList(gomock.Any()).Return([]sdk.V2Worker{
+		{Name: "workerA", JobRunID: "job-1"},
+	}, nil)
+
+	// workerA: powered off but still on the API → DELETE NOW and release its job.
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) ([]mo.VirtualMachine, error) {
+			poweredOff := types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff}
+			return []mo.VirtualMachine{
+				{
+					ManagedEntity: mo.ManagedEntity{Name: "workerA"},
+					Summary:       types.VirtualMachineSummary{Runtime: poweredOff},
+					Config:        &types.VirtualMachineConfigInfo{Annotation: annot(annotation{WorkerStartTime: now})},
+				},
+			}, nil
+		},
+	).Times(1)
+
+	var vmA = object.VirtualMachine{Common: object.Common{InventoryPath: "workerA"}}
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "workerA").Return(&vmA, nil)
+	c.EXPECT().DestroyVirtualMachine(gomock.Any(), &vmA).Return(nil)
+
+	// The job is released for the configured region.
+	clientV2.EXPECT().V2HatcheryReleaseJob(gomock.Any(), "reg1", "job-1").Return(nil)
+
+	h.killAwolServers(context.Background())
+}
+
 func TestHatcheryVSphere_requestProvisioning(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 	ctx := context.Background()

--- a/engine/hatchery/vsphere/init.go
+++ b/engine/hatchery/vsphere/init.go
@@ -46,8 +46,11 @@ func (h *HatcheryVSphere) InitHatchery(ctx context.Context) error {
 	if len(h.Config.WorkerProvisioning) > 0 {
 		log.Debug(ctx, "provisioning is enabled")
 
-		// Start the provisioning worker pool
-		h.startProvisioningPool(ctx)
+		// Optional concurrency cap on provisioning operations. 0 = unbounded
+		// (clones run fully in parallel, bounded only by the deficit / IP budget).
+		if h.Config.WorkerProvisioningPoolSize > 0 {
+			h.provisionSem = make(chan struct{}, h.Config.WorkerProvisioningPoolSize)
+		}
 
 		provisioningInterval := 2 * time.Minute
 		if h.Config.WorkerProvisioningInterval > 0 {

--- a/engine/hatchery/vsphere/init.go
+++ b/engine/hatchery/vsphere/init.go
@@ -35,8 +35,13 @@ func (h *HatcheryVSphere) InitHatchery(ctx context.Context) error {
 		return err
 	}
 
-	killAwolServersTick := time.NewTicker(2 * time.Minute)
-	killDisabledWorkersTick := time.NewTicker(2 * time.Minute)
+	killInterval := time.Duration(h.Config.KillAwolServersInterval) * time.Second
+	killAwolServersTick := time.NewTicker(killInterval)
+	killDisabledWorkersTick := time.NewTicker(killInterval)
+
+	// Buffered (size 1) so cleanup/spawn can request an immediate provisioning
+	// refill without blocking; bursts coalesce into a single pending run.
+	h.provisionSignal = make(chan struct{}, 1)
 
 	if len(h.Config.WorkerProvisioning) > 0 {
 		log.Debug(ctx, "provisioning is enabled")
@@ -58,6 +63,9 @@ func (h *HatcheryVSphere) InitHatchery(ctx context.Context) error {
 					case <-ctx.Done():
 						return
 					case <-provisioningTick.C:
+						h.provisioningV2(ctx)
+					case <-h.provisionSignal:
+						// on-demand refill requested by cleanup or a spawn claim
 						h.provisioningV2(ctx)
 					}
 				}

--- a/engine/hatchery/vsphere/ip.go
+++ b/engine/hatchery/vsphere/ip.go
@@ -34,6 +34,22 @@ func (h *HatcheryVSphere) getUsedIPs(ctx context.Context, srvs []mo.VirtualMachi
 	return usedIPs
 }
 
+// releaseObservedReservations drops reservations for IPs now confirmed in use by
+// a real VM (its annotation or guest network). The VM list returned by vSphere is
+// the source of truth: a reservation is only an optimistic, in-memory lock that
+// covers the window between picking an IP and the cloned VM becoming visible in
+// the inventory. Once a VM carrying the IP is observed, the annotation is
+// authoritative and the reservation is redundant, so it is released. This keeps
+// the lock self-healing (and harmless to lose on restart). Caller must hold
+// IpAddressesMutex.
+func (h *HatcheryVSphere) releaseObservedReservations(usedIPs map[string]struct{}) {
+	for ip := range usedIPs {
+		if sdk.IsInArray(ip, h.reservedIPAddresses) {
+			h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
+		}
+	}
+}
+
 // findAvailableIP looks for the first free IP across all configured networks
 // and returns the IP along with its associated network configuration.
 func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error) {
@@ -42,13 +58,7 @@ func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error)
 
 	srvs := h.getVirtualMachines(ctx)
 	usedIPs := h.getUsedIPs(ctx, srvs)
-
-	// If an IP appears in guest network, it's confirmed in use — clean up stale reservations
-	for ip := range usedIPs {
-		if sdk.IsInArray(ip, h.reservedIPAddresses) {
-			h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
-		}
-	}
+	h.releaseObservedReservations(usedIPs)
 
 	for _, network := range h.availableNetworks {
 		for _, ip := range network.ipAddresses {
@@ -76,6 +86,7 @@ func (h *HatcheryVSphere) countAvailableIPs(ctx context.Context) int {
 
 	srvs := h.getVirtualMachines(ctx)
 	usedIPs := h.getUsedIPs(ctx, srvs)
+	h.releaseObservedReservations(usedIPs)
 
 	count := 0
 	for _, network := range h.availableNetworks {
@@ -88,6 +99,18 @@ func (h *HatcheryVSphere) countAvailableIPs(ctx context.Context) int {
 		}
 	}
 	return count
+}
+
+// releaseIPAddress drops an IP reservation explicitly. Used when a provision
+// clone that reserved the IP fails before any VM ends up carrying it, so the IP
+// returns to the pool immediately instead of waiting out the reservation TTL.
+func (h *HatcheryVSphere) releaseIPAddress(ip string) {
+	if ip == "" {
+		return
+	}
+	h.IpAddressesMutex.Lock()
+	h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
+	h.IpAddressesMutex.Unlock()
 }
 
 func (h *HatcheryVSphere) reserveIPAddress(ctx context.Context, ip string) error {

--- a/engine/hatchery/vsphere/ip.go
+++ b/engine/hatchery/vsphere/ip.go
@@ -50,8 +50,13 @@ func (h *HatcheryVSphere) releaseObservedReservations(usedIPs map[string]struct{
 	}
 }
 
-// findAvailableIP looks for the first free IP across all configured networks
-// and returns the IP along with its associated network configuration.
+// findAvailableIP looks for the first free IP across all configured networks and
+// atomically reserves it before returning. Picking and reserving happen under a
+// single lock so concurrent callers (parallel provisioning clones) can never get
+// the same IP. The reservation is an in-memory lock covering the window until the
+// cloned VM becomes visible in the inventory; a safety TTL releases it if the
+// clone never produces a VM (see releaseIPAddress / the error paths that release
+// it explicitly).
 func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error) {
 	h.IpAddressesMutex.Lock()
 	defer h.IpAddressesMutex.Unlock()
@@ -65,6 +70,15 @@ func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error)
 			_, isUsed := usedIPs[ip]
 			isReserved := sdk.IsInArray(ip, h.reservedIPAddresses)
 			if !isUsed && !isReserved {
+				h.reservedIPAddresses = append(h.reservedIPAddresses, ip)
+				// Safety net: release the reservation if it is never confirmed by a
+				// VM carrying the IP (e.g. the clone fails after this point). Use
+				// Exec (short-lived, panic-recovered, not monitored).
+				reservedIP := ip
+				h.GoRoutines.Exec(context.Background(), "vsphere-ip-reservation-ttl", func(_ context.Context) {
+					time.Sleep(5 * time.Minute)
+					h.releaseIPAddress(reservedIP)
+				})
 				return ipResult{
 					ip:         ip,
 					gateway:    network.config.Gateway,
@@ -113,20 +127,3 @@ func (h *HatcheryVSphere) releaseIPAddress(ip string) {
 	h.IpAddressesMutex.Unlock()
 }
 
-func (h *HatcheryVSphere) reserveIPAddress(ctx context.Context, ip string) error {
-	h.IpAddressesMutex.Lock()
-	if sdk.IsInArray(ip, h.reservedIPAddresses) {
-		return sdk.WithStack(errors.New("address already reserved"))
-	}
-	h.reservedIPAddresses = append(h.reservedIPAddresses, ip)
-	h.IpAddressesMutex.Unlock()
-
-	go func() {
-		time.Sleep(5 * time.Minute)
-		h.IpAddressesMutex.Lock()
-		h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
-		h.IpAddressesMutex.Unlock()
-	}()
-
-	return nil
-}

--- a/engine/hatchery/vsphere/ip.go
+++ b/engine/hatchery/vsphere/ip.go
@@ -2,22 +2,60 @@ package vsphere
 
 import (
 	"context"
-	"errors"
-	"time"
+	"strconv"
+	"strings"
 
 	"github.com/vmware/govmomi/vim25/mo"
 
-	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/namesgenerator"
 )
 
-// getUsedIPs builds the set of IP addresses currently in use across all VMs.
-// It checks both the CDS annotation (IP assigned at clone time, before the VM
-// actually uses it) and the guest network info (IP visible on the running VM).
-// The annotation lookup is needed because a newly cloned VM may not yet have
-// the IP visible in guest tools, but the IP is already allocated.
+// provisionIPNamePrefix marks a provision VM name that encodes its assigned IP,
+// e.g. "provision-v2-ip-10-0-0-5-<random>". Encoding the IP in the name makes the
+// reserved IP visible in the vSphere inventory from the moment the clone starts —
+// before the annotation is populated — and survives a hatchery restart. The IP is
+// also stored in the annotation (see prepareCloneSpec) so older provisions
+// (without this name) and a rolled-back binary keep working.
+const provisionIPNamePrefix = "provision-v2-ip-"
+
+// provisionName builds the name for a new provision VM. When an IP is assigned it
+// is encoded into the name; otherwise (DHCP / no IP range) a plain name is used.
+func provisionName(ip *ipResult) string {
+	if ip == nil || ip.ip == "" {
+		return namesgenerator.GenerateWorkerName("provision-v2")
+	}
+	return namesgenerator.GenerateWorkerName(provisionIPNamePrefix + strings.ReplaceAll(ip.ip, ".", "-"))
+}
+
+// ipFromProvisionName extracts the IP encoded in a provision VM name, if present.
+func ipFromProvisionName(name string) (string, bool) {
+	if !strings.HasPrefix(name, provisionIPNamePrefix) {
+		return "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(name, provisionIPNamePrefix), "-", 5)
+	if len(parts) < 4 {
+		return "", false
+	}
+	for _, octet := range parts[:4] {
+		n, err := strconv.Atoi(octet)
+		if err != nil || n < 0 || n > 255 {
+			return "", false
+		}
+	}
+	return strings.Join(parts[:4], "."), true
+}
+
+// getUsedIPs builds the set of IP addresses currently in use across all VMs. An
+// IP is "used" if it is encoded in a provision VM name (visible during the clone,
+// before the annotation exists), recorded in the CDS annotation (set at clone
+// time, the compatibility anchor for old provisions and claimed workers), or seen
+// on the running guest's network.
 func (h *HatcheryVSphere) getUsedIPs(ctx context.Context, srvs []mo.VirtualMachine) map[string]struct{} {
 	usedIPs := make(map[string]struct{}, len(srvs))
 	for _, s := range srvs {
+		if ip, ok := ipFromProvisionName(s.Name); ok {
+			usedIPs[ip] = struct{}{}
+		}
 		annot := getVirtualMachineCDSAnnotation(ctx, s)
 		if annot != nil && annot.IPAddress != "" {
 			usedIPs[annot.IPAddress] = struct{}{}
@@ -34,96 +72,21 @@ func (h *HatcheryVSphere) getUsedIPs(ctx context.Context, srvs []mo.VirtualMachi
 	return usedIPs
 }
 
-// releaseObservedReservations drops reservations for IPs now confirmed in use by
-// a real VM (its annotation or guest network). The VM list returned by vSphere is
-// the source of truth: a reservation is only an optimistic, in-memory lock that
-// covers the window between picking an IP and the cloned VM becoming visible in
-// the inventory. Once a VM carrying the IP is observed, the annotation is
-// authoritative and the reservation is redundant, so it is released. This keeps
-// the lock self-healing (and harmless to lose on restart). Caller must hold
-// IpAddressesMutex.
-func (h *HatcheryVSphere) releaseObservedReservations(usedIPs map[string]struct{}) {
-	for ip := range usedIPs {
-		if sdk.IsInArray(ip, h.reservedIPAddresses) {
-			h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
-		}
-	}
-}
-
-// findAvailableIP looks for the first free IP across all configured networks and
-// atomically reserves it before returning. Picking and reserving happen under a
-// single lock so concurrent callers (parallel provisioning clones) can never get
-// the same IP. The reservation is an in-memory lock covering the window until the
-// cloned VM becomes visible in the inventory; a safety TTL releases it if the
-// clone never produces a VM (see releaseIPAddress / the error paths that release
-// it explicitly).
-func (h *HatcheryVSphere) findAvailableIP(ctx context.Context) (ipResult, error) {
-	h.IpAddressesMutex.Lock()
-	defer h.IpAddressesMutex.Unlock()
-
-	srvs := h.getVirtualMachines(ctx)
-	usedIPs := h.getUsedIPs(ctx, srvs)
-	h.releaseObservedReservations(usedIPs)
-
+// pickFreeIP returns the first configured IP that is not in the given used set,
+// scanning networks in config order. It is pure (no shared state): the caller
+// (provisioningV2, a single goroutine) adds each picked IP to the used set so the
+// next pick in the same pass returns a distinct address.
+func (h *HatcheryVSphere) pickFreeIP(used map[string]struct{}) (ipResult, bool) {
 	for _, network := range h.availableNetworks {
 		for _, ip := range network.ipAddresses {
-			_, isUsed := usedIPs[ip]
-			isReserved := sdk.IsInArray(ip, h.reservedIPAddresses)
-			if !isUsed && !isReserved {
-				h.reservedIPAddresses = append(h.reservedIPAddresses, ip)
-				// Safety net: release the reservation if it is never confirmed by a
-				// VM carrying the IP (e.g. the clone fails after this point). Use
-				// Exec (short-lived, panic-recovered, not monitored).
-				reservedIP := ip
-				h.GoRoutines.Exec(context.Background(), "vsphere-ip-reservation-ttl", func(_ context.Context) {
-					time.Sleep(5 * time.Minute)
-					h.releaseIPAddress(reservedIP)
-				})
+			if _, taken := used[ip]; !taken {
 				return ipResult{
 					ip:         ip,
 					gateway:    network.config.Gateway,
 					subnetMask: network.config.SubnetMask,
-				}, nil
+				}, true
 			}
 		}
 	}
-
-	return ipResult{}, sdk.WithStack(errors.New("no IP address available"))
+	return ipResult{}, false
 }
-
-// countAvailableIPs returns the number of IPs that are currently free (not used
-// by any VM and not reserved). Used by provisioning to cap tasks to the actual
-// IP budget and avoid submitting work that would fail at clone time.
-func (h *HatcheryVSphere) countAvailableIPs(ctx context.Context) int {
-	h.IpAddressesMutex.Lock()
-	defer h.IpAddressesMutex.Unlock()
-
-	srvs := h.getVirtualMachines(ctx)
-	usedIPs := h.getUsedIPs(ctx, srvs)
-	h.releaseObservedReservations(usedIPs)
-
-	count := 0
-	for _, network := range h.availableNetworks {
-		for _, ip := range network.ipAddresses {
-			_, isUsed := usedIPs[ip]
-			isReserved := sdk.IsInArray(ip, h.reservedIPAddresses)
-			if !isUsed && !isReserved {
-				count++
-			}
-		}
-	}
-	return count
-}
-
-// releaseIPAddress drops an IP reservation explicitly. Used when a provision
-// clone that reserved the IP fails before any VM ends up carrying it, so the IP
-// returns to the pool immediately instead of waiting out the reservation TTL.
-func (h *HatcheryVSphere) releaseIPAddress(ip string) {
-	if ip == "" {
-		return
-	}
-	h.IpAddressesMutex.Lock()
-	h.reservedIPAddresses = sdk.DeleteFromArray(h.reservedIPAddresses, ip)
-	h.IpAddressesMutex.Unlock()
-}
-

--- a/engine/hatchery/vsphere/ip_test.go
+++ b/engine/hatchery/vsphere/ip_test.go
@@ -2,59 +2,77 @@ package vsphere
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/rockbears/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/vim25/mo"
-	"go.uber.org/mock/gomock"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
-// findAvailableIP must reserve atomically: concurrent callers (parallel
-// provisioning clones) must each get a distinct IP, never the same one.
-func TestHatcheryVSphere_findAvailableIP_concurrentDistinct(t *testing.T) {
+func TestIPFromProvisionName(t *testing.T) {
+	encoded := provisionName(&ipResult{ip: "10.0.0.5"})
+	assert.Contains(t, encoded, "provision-v2-ip-10-0-0-5-")
+
+	ip, ok := ipFromProvisionName(encoded)
+	assert.True(t, ok)
+	assert.Equal(t, "10.0.0.5", ip)
+
+	// A plain provision name (DHCP mode / old style) has no IP.
+	_, ok = ipFromProvisionName("provision-v2-nervous-but-tender-pascal")
+	assert.False(t, ok)
+
+	// A claimed worker name has no IP.
+	_, ok = ipFromProvisionName("worker-abc")
+	assert.False(t, ok)
+}
+
+// getUsedIPs must see an in-flight provision's IP from its NAME (visible during
+// the clone, before the annotation is populated), and an old-style/claimed VM's
+// IP from its annotation or guest network.
+func TestHatcheryVSphere_getUsedIPs(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
+	h := HatcheryVSphere{}
 
-	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{vSphereClient: c}
+	srvs := []mo.VirtualMachine{
+		{ // cloning provision: only the IP-encoded name, no annotation yet
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-ip-10-0-0-1-foo"},
+		},
+		{ // old-style provision: IP only in the annotation
+			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-bar"},
+			Config:        &types.VirtualMachineConfigInfo{Annotation: `{"ip_address": "10.0.0.2"}`},
+		},
+		{ // running worker: IP on the guest network
+			ManagedEntity: mo.ManagedEntity{Name: "worker-baz"},
+			Guest:         &types.GuestInfo{Net: []types.GuestNicInfo{{IpAddress: []string{"10.0.0.3"}}}},
+		},
+	}
 
-	ips := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+	used := h.getUsedIPs(context.Background(), srvs)
+	for _, ip := range []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"} {
+		_, ok := used[ip]
+		assert.Truef(t, ok, "expected %s to be counted as used", ip)
+	}
+}
+
+// pickFreeIP returns distinct IPs as the caller marks each one used.
+func TestHatcheryVSphere_pickFreeIP_distinct(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	h := HatcheryVSphere{}
 	h.availableNetworks = []availableNetwork{{
 		config:      NetworkConfig{Gateway: "10.0.0.254", SubnetMask: "255.255.255.0"},
-		ipAddresses: ips,
+		ipAddresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
 	}}
-	h.availableIPAddresses = ips
 
-	// No VM uses any IP yet.
-	c.EXPECT().ListVirtualMachines(gomock.Any()).Return([]mo.VirtualMachine{}, nil).AnyTimes()
-
-	const goroutines = 8
-	var mu sync.Mutex
-	handed := map[string]int{}
-	var errCount int64
-	var wg sync.WaitGroup
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			res, err := h.findAvailableIP(context.Background())
-			if err != nil {
-				atomic.AddInt64(&errCount, 1)
-				return
-			}
-			mu.Lock()
-			handed[res.ip]++
-			mu.Unlock()
-		}()
+	used := map[string]struct{}{}
+	seen := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		res, ok := h.pickFreeIP(used)
+		assert.True(t, ok)
+		assert.Falsef(t, seen[res.ip], "IP %s handed out twice", res.ip)
+		seen[res.ip] = true
+		used[res.ip] = struct{}{}
 	}
-	wg.Wait()
-
-	// Exactly the 3 IPs are handed out, each exactly once; the rest fail.
-	assert.Len(t, handed, 3, "all 3 IPs should have been allocated")
-	for ip, n := range handed {
-		assert.Equalf(t, 1, n, "IP %s was handed to more than one caller", ip)
-	}
-	assert.Equal(t, int64(goroutines-len(ips)), errCount, "callers beyond the IP budget must get an error, not a duplicate")
+	_, ok := h.pickFreeIP(used)
+	assert.False(t, ok, "no IP should remain after all are used")
 }

--- a/engine/hatchery/vsphere/ip_test.go
+++ b/engine/hatchery/vsphere/ip_test.go
@@ -1,0 +1,60 @@
+package vsphere
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rockbears/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vim25/mo"
+	"go.uber.org/mock/gomock"
+)
+
+// findAvailableIP must reserve atomically: concurrent callers (parallel
+// provisioning clones) must each get a distinct IP, never the same one.
+func TestHatcheryVSphere_findAvailableIP_concurrentDistinct(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{vSphereClient: c}
+
+	ips := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{Gateway: "10.0.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: ips,
+	}}
+	h.availableIPAddresses = ips
+
+	// No VM uses any IP yet.
+	c.EXPECT().ListVirtualMachines(gomock.Any()).Return([]mo.VirtualMachine{}, nil).AnyTimes()
+
+	const goroutines = 8
+	var mu sync.Mutex
+	handed := map[string]int{}
+	var errCount int64
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := h.findAvailableIP(context.Background())
+			if err != nil {
+				atomic.AddInt64(&errCount, 1)
+				return
+			}
+			mu.Lock()
+			handed[res.ip]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Exactly the 3 IPs are handed out, each exactly once; the rest fail.
+	assert.Len(t, handed, 3, "all 3 IPs should have been allocated")
+	for ip, n := range handed {
+		assert.Equalf(t, 1, n, "IP %s was handed to more than one caller", ip)
+	}
+	assert.Equal(t, int64(goroutines-len(ips)), errCount, "callers beyond the IP budget must get an error, not a duplicate")
+}

--- a/engine/hatchery/vsphere/mock_vsphere/client_mock.go
+++ b/engine/hatchery/vsphere/mock_vsphere/client_mock.go
@@ -257,6 +257,20 @@ func (mr *MockVSphereClientMockRecorder) RenameVirtualMachine(ctx, vm, newName a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameVirtualMachine", reflect.TypeOf((*MockVSphereClient)(nil).RenameVirtualMachine), ctx, vm, newName)
 }
 
+// SetVirtualMachineAnnotation mocks base method.
+func (m *MockVSphereClient) SetVirtualMachineAnnotation(ctx context.Context, vm *object.VirtualMachine, annotation string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVirtualMachineAnnotation", ctx, vm, annotation)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVirtualMachineAnnotation indicates an expected call of SetVirtualMachineAnnotation.
+func (mr *MockVSphereClientMockRecorder) SetVirtualMachineAnnotation(ctx, vm, annotation any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVirtualMachineAnnotation", reflect.TypeOf((*MockVSphereClient)(nil).SetVirtualMachineAnnotation), ctx, vm, annotation)
+}
+
 // SetupEthernetCard mocks base method.
 func (m *MockVSphereClient) SetupEthernetCard(ctx context.Context, card *types.VirtualEthernetCard, ethernetCardName string, network object.NetworkReference) error {
 	m.ctrl.T.Helper()

--- a/engine/hatchery/vsphere/monitoring.go
+++ b/engine/hatchery/vsphere/monitoring.go
@@ -26,10 +26,17 @@ type vsphereMetrics struct {
 	AllocatedMemoryMB  *stats.Int64Measure
 	AllocatedDiskGB    *stats.Int64Measure
 	VMCount            *stats.Int64Measure
+	WorkerVMCount      *stats.Int64Measure
 	ProvisionedVMCount *stats.Int64Measure
-	TemplateVCPUs      *stats.Int64Measure
-	TemplateMemoryMB   *stats.Int64Measure
-	TemplateCount      *stats.Int64Measure
+	// Provisioned VMs broken down by state (sum of ready+starting+dying equals
+	// ProvisionedVMCount; in-flight clones are not VMs yet so they are tracked apart).
+	ProvisionReadyCount    *stats.Int64Measure
+	ProvisionStartingCount *stats.Int64Measure
+	ProvisionDyingCount    *stats.Int64Measure
+	ProvisionInflightCount *stats.Int64Measure
+	TemplateVCPUs          *stats.Int64Measure
+	TemplateMemoryMB       *stats.Int64Measure
+	TemplateCount          *stats.Int64Measure
 
 	// Level 3: Global pool (all VMs in datacenter)
 	PoolTotalVCPUs    *stats.Int64Measure
@@ -83,10 +90,25 @@ func (h *HatcheryVSphere) initVSphereMetricsMeasures() {
 		"total disk capacity (GB) allocated by this hatchery's VMs", stats.UnitDimensionless)
 	h.metrics.VMCount = stats.Int64(
 		"cds/hatchery/vsphere/vm_count",
-		"total VMs managed by this hatchery", stats.UnitDimensionless)
+		"total VMs managed by this hatchery (workers + provisions)", stats.UnitDimensionless)
+	h.metrics.WorkerVMCount = stats.Int64(
+		"cds/hatchery/vsphere/worker_vm_count",
+		"VMs running as workers (claimed, no longer in the provision pool)", stats.UnitDimensionless)
 	h.metrics.ProvisionedVMCount = stats.Int64(
 		"cds/hatchery/vsphere/provisioned_vm_count",
-		"pre-provisioned idle VMs", stats.UnitDimensionless)
+		"pre-provisioned VMs (ready + starting + dying)", stats.UnitDimensionless)
+	h.metrics.ProvisionReadyCount = stats.Int64(
+		"cds/hatchery/vsphere/provision_ready_count",
+		"provisioned VMs powered off and ready to be claimed", stats.UnitDimensionless)
+	h.metrics.ProvisionStartingCount = stats.Int64(
+		"cds/hatchery/vsphere/provision_starting_count",
+		"provisioned VMs powered on, still being created/finished", stats.UnitDimensionless)
+	h.metrics.ProvisionDyingCount = stats.Int64(
+		"cds/hatchery/vsphere/provision_dying_count",
+		"provisioned VMs marked for deletion, not yet reaped", stats.UnitDimensionless)
+	h.metrics.ProvisionInflightCount = stats.Int64(
+		"cds/hatchery/vsphere/provision_inflight_count",
+		"in-flight provision clones not yet visible in the inventory", stats.UnitDimensionless)
 	h.metrics.TemplateVCPUs = stats.Int64(
 		"cds/hatchery/vsphere/template_vcpus",
 		"total vCPUs defined by template VMs", stats.UnitDimensionless)
@@ -163,7 +185,12 @@ func (h *HatcheryVSphere) initVSphereMetricsMeasures() {
 		telemetry.NewViewLast("cds/hatchery/vsphere/allocated_memory_mb", h.metrics.AllocatedMemoryMB, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/allocated_disk_gb", h.metrics.AllocatedDiskGB, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/vm_count", h.metrics.VMCount, baseTags),
+		telemetry.NewViewLast("cds/hatchery/vsphere/worker_vm_count", h.metrics.WorkerVMCount, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/provisioned_vm_count", h.metrics.ProvisionedVMCount, baseTags),
+		telemetry.NewViewLast("cds/hatchery/vsphere/provision_ready_count", h.metrics.ProvisionReadyCount, baseTags),
+		telemetry.NewViewLast("cds/hatchery/vsphere/provision_starting_count", h.metrics.ProvisionStartingCount, baseTags),
+		telemetry.NewViewLast("cds/hatchery/vsphere/provision_dying_count", h.metrics.ProvisionDyingCount, baseTags),
+		telemetry.NewViewLast("cds/hatchery/vsphere/provision_inflight_count", h.metrics.ProvisionInflightCount, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/template_vcpus", h.metrics.TemplateVCPUs, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/template_memory_mb", h.metrics.TemplateMemoryMB, baseTags),
 		telemetry.NewViewLast("cds/hatchery/vsphere/template_count", h.metrics.TemplateCount, baseTags),
@@ -217,8 +244,12 @@ func (h *HatcheryVSphere) collectVSphereMetrics(ctx context.Context) {
 
 	// Level 2: Hatchery-level counters
 	var hatcheryCPUs, hatcheryMemMB, hatcheryDiskGB int64
-	var vmCount, provisionedCount int64
+	var vmCount, workerCount, provisionedCount int64
+	var provisionReady, provisionStarting, provisionDying int64
 	var templateCPUs, templateMemMB, templateCount int64
+	// Names of provisions currently listed, used to count in-flight clones (in the
+	// pending cache but not yet visible in the inventory) without double counting.
+	provisionNames := make(map[string]struct{})
 
 	// Level 3: Global pool counters (ALL VMs, no annotation filtering)
 	var poolCPUs, poolMemMB, poolVMCount int64
@@ -257,8 +288,24 @@ func (h *HatcheryVSphere) collectVSphereMetrics(ctx context.Context) {
 		hatcheryDiskGB += diskGB
 		vmCount++
 
-		if strings.HasPrefix(s.Name, "provision-") {
+		// Classify the VM. A pooled provision still carries the Provisioning flag
+		// and the provision-v2 prefix; once claimed it is renamed and the flag is
+		// cleared, so it counts as a worker. Provisions are broken down by state
+		// (same rule as provisioningV2): dying first, then ready (powered off) vs
+		// starting (powered on).
+		if strings.HasPrefix(s.Name, "provision-v2") && annot.Provisioning {
 			provisionedCount++
+			provisionNames[s.Name] = struct{}{}
+			switch {
+			case h.isMarkedToDelete(s):
+				provisionDying++
+			case s.Summary.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff:
+				provisionReady++
+			default:
+				provisionStarting++
+			}
+		} else {
+			workerCount++
 		}
 
 		// Level 1: Per-worker metrics
@@ -271,13 +318,29 @@ func (h *HatcheryVSphere) collectVSphereMetrics(ctx context.Context) {
 		)
 	}
 
+	// In-flight clones: tracked in the pending cache but not yet visible in the
+	// inventory above. Counted apart from the VM-based provision states.
+	var provisionInflight int64
+	h.cacheProvisioning.mu.Lock()
+	for name := range h.cacheProvisioning.pending {
+		if _, listed := provisionNames[name]; !listed {
+			provisionInflight++
+		}
+	}
+	h.cacheProvisioning.mu.Unlock()
+
 	// Level 2: Hatchery aggregate
 	stats.Record(ctx,
 		h.metrics.AllocatedVCPUs.M(hatcheryCPUs),
 		h.metrics.AllocatedMemoryMB.M(hatcheryMemMB),
 		h.metrics.AllocatedDiskGB.M(hatcheryDiskGB),
 		h.metrics.VMCount.M(vmCount),
+		h.metrics.WorkerVMCount.M(workerCount),
 		h.metrics.ProvisionedVMCount.M(provisionedCount),
+		h.metrics.ProvisionReadyCount.M(provisionReady),
+		h.metrics.ProvisionStartingCount.M(provisionStarting),
+		h.metrics.ProvisionDyingCount.M(provisionDying),
+		h.metrics.ProvisionInflightCount.M(provisionInflight),
 		h.metrics.TemplateVCPUs.M(templateCPUs),
 		h.metrics.TemplateMemoryMB.M(templateMemMB),
 		h.metrics.TemplateCount.M(templateCount),

--- a/engine/hatchery/vsphere/monitoring_test.go
+++ b/engine/hatchery/vsphere/monitoring_test.go
@@ -81,7 +81,8 @@ func TestCollectVSphereMetrics(t *testing.T) {
 					},
 				},
 			},
-			// Provisioned VM owned by this hatchery: 2 vCPUs, 4096 MB, 20GB disk
+			// Provisioned VM owned by this hatchery: 2 vCPUs, 4096 MB, 20GB disk.
+			// Powered off → ready to be claimed.
 			{
 				ManagedEntity: mo.ManagedEntity{Name: "provision-v2-xxx"},
 				Summary: types.VirtualMachineSummary{
@@ -89,6 +90,9 @@ func TestCollectVSphereMetrics(t *testing.T) {
 						Template:     false,
 						NumCpu:       2,
 						MemorySizeMB: 4096,
+					},
+					Runtime: types.VirtualMachineRuntimeInfo{
+						PowerState: types.VirtualMachinePowerStatePoweredOff,
 					},
 				},
 				Config: &types.VirtualMachineConfigInfo{
@@ -168,7 +172,14 @@ func TestCollectVSphereMetrics(t *testing.T) {
 	assertLastMetricValue(t, "cds/hatchery/vsphere/allocated_memory_mb", 12288)
 	assertLastMetricValue(t, "cds/hatchery/vsphere/allocated_disk_gb", 70)
 	assertLastMetricValue(t, "cds/hatchery/vsphere/vm_count", 2)
+	assertLastMetricValue(t, "cds/hatchery/vsphere/worker_vm_count", 1)
 	assertLastMetricValue(t, "cds/hatchery/vsphere/provisioned_vm_count", 1)
+
+	// Provision breakdown: the single provision is powered off → ready.
+	assertLastMetricValue(t, "cds/hatchery/vsphere/provision_ready_count", 1)
+	assertLastMetricValue(t, "cds/hatchery/vsphere/provision_starting_count", 0)
+	assertLastMetricValue(t, "cds/hatchery/vsphere/provision_dying_count", 0)
+	assertLastMetricValue(t, "cds/hatchery/vsphere/provision_inflight_count", 0)
 
 	// Verify Level 2: Template metrics
 	assertLastMetricValue(t, "cds/hatchery/vsphere/template_vcpus", 2)

--- a/engine/hatchery/vsphere/networks_test.go
+++ b/engine/hatchery/vsphere/networks_test.go
@@ -8,110 +8,67 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/mock/gomock"
 )
 
-func TestHatcheryVSphere_findAvailableIP_MultipleNetworks(t *testing.T) {
+func TestHatcheryVSphere_pickFreeIP_MultipleNetworks(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
-	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{
-		vSphereClient: c,
-	}
-
-	// Configure two networks with different gateways and subnets
-	h.availableIPAddresses = []string{
-		"10.0.1.1", "10.0.1.2", "10.0.1.3",
-		"10.0.2.1", "10.0.2.2", "10.0.2.3",
-	}
+	h := HatcheryVSphere{}
 	h.availableNetworks = []availableNetwork{
 		{
-			config: NetworkConfig{
-				IPRange:    "10.0.1.0/29",
-				Gateway:    "10.0.1.254",
-				SubnetMask: "255.255.255.0",
-			},
+			config:      NetworkConfig{Gateway: "10.0.1.254", SubnetMask: "255.255.255.0"},
 			ipAddresses: []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"},
 		},
 		{
-			config: NetworkConfig{
-				IPRange:    "10.0.2.0/29",
-				Gateway:    "10.0.2.254",
-				SubnetMask: "255.255.248.0",
-			},
+			config:      NetworkConfig{Gateway: "10.0.2.254", SubnetMask: "255.255.248.0"},
 			ipAddresses: []string{"10.0.2.1", "10.0.2.2", "10.0.2.3"},
 		},
 	}
 
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]mo.VirtualMachine, error) {
-			return []mo.VirtualMachine{}, nil
-		},
-	).AnyTimes()
-
-	ctx := context.Background()
-
-	// First available IP should come from the first network
-	result, err := h.findAvailableIP(ctx)
-	require.NoError(t, err)
+	// First free IP comes from the first network.
+	result, ok := h.pickFreeIP(map[string]struct{}{})
+	require.True(t, ok)
 	assert.Equal(t, "10.0.1.1", result.ip)
 	assert.Equal(t, "10.0.1.254", result.gateway)
 	assert.Equal(t, "255.255.255.0", result.subnetMask)
 }
 
-func TestHatcheryVSphere_findAvailableIP_FallsToSecondNetwork(t *testing.T) {
+func TestHatcheryVSphere_pickFreeIP_FallsToSecondNetwork(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
-	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{
-		vSphereClient: c,
-	}
-
-	// First network is fully reserved, second has availability
-	h.availableIPAddresses = []string{
-		"10.0.1.1", "10.0.1.2",
-		"10.0.2.1", "10.0.2.2",
-	}
+	h := HatcheryVSphere{}
 	h.availableNetworks = []availableNetwork{
 		{
-			config: NetworkConfig{
-				IPRange:    "10.0.1.0/30",
-				Gateway:    "10.0.1.254",
-				SubnetMask: "255.255.255.0",
-			},
+			config:      NetworkConfig{Gateway: "10.0.1.254", SubnetMask: "255.255.255.0"},
 			ipAddresses: []string{"10.0.1.1", "10.0.1.2"},
 		},
 		{
-			config: NetworkConfig{
-				IPRange:    "10.0.2.0/30",
-				Gateway:    "10.0.2.254",
-				SubnetMask: "255.255.248.0",
-			},
+			config:      NetworkConfig{Gateway: "10.0.2.254", SubnetMask: "255.255.248.0"},
 			ipAddresses: []string{"10.0.2.1", "10.0.2.2"},
 		},
 	}
-	// Reserve all IPs from first network
-	h.reservedIPAddresses = []string{"10.0.1.1", "10.0.1.2"}
 
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]mo.VirtualMachine, error) {
-			return []mo.VirtualMachine{}, nil
-		},
-	).AnyTimes()
-
-	ctx := context.Background()
-
-	// Should fall to second network
-	result, err := h.findAvailableIP(ctx)
-	require.NoError(t, err)
+	// All IPs of the first network are taken → fall to the second.
+	used := map[string]struct{}{"10.0.1.1": {}, "10.0.1.2": {}}
+	result, ok := h.pickFreeIP(used)
+	require.True(t, ok)
 	assert.Equal(t, "10.0.2.1", result.ip)
 	assert.Equal(t, "10.0.2.254", result.gateway)
 	assert.Equal(t, "255.255.248.0", result.subnetMask)
+
+	// Exhaust everything → no free IP.
+	for _, n := range h.availableNetworks {
+		for _, ip := range n.ipAddresses {
+			used[ip] = struct{}{}
+		}
+	}
+	_, ok = h.pickFreeIP(used)
+	assert.False(t, ok)
 }
 
-func TestHatcheryVSphere_prepareCloneSpec_MultiNetwork(t *testing.T) {
+func TestHatcheryVSphere_prepareCloneSpec_UsesGivenIP(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
 	c := NewVSphereClientTest(t)
@@ -123,91 +80,31 @@ func TestHatcheryVSphere_prepareCloneSpec_MultiNetwork(t *testing.T) {
 	h.Config.VSphereDatastoreString = "datastore"
 	h.Config.DNS = "8.8.8.8"
 
-	// First network exhausted (IPs used by VMs), second network has availability
-	h.availableIPAddresses = []string{
-		"10.0.1.1",
-		"10.0.2.1", "10.0.2.2",
-	}
-	h.availableNetworks = []availableNetwork{
-		{
-			config: NetworkConfig{
-				IPRange:    "10.0.1.0/30",
-				Gateway:    "10.0.1.254",
-				SubnetMask: "255.255.255.0",
-			},
-			ipAddresses: []string{"10.0.1.1"},
-		},
-		{
-			config: NetworkConfig{
-				IPRange:    "10.0.2.0/30",
-				Gateway:    "10.0.2.254",
-				SubnetMask: "255.255.248.0",
-			},
-			ipAddresses: []string{"10.0.2.1", "10.0.2.2"},
-		},
-	}
-
 	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vm *object.VirtualMachine) (object.VirtualDeviceList, error) {
 			card := types.VirtualEthernetCard{}
 			return object.VirtualDeviceList{&card}, nil
 		},
 	)
-
-	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").DoAndReturn(
-		func(ctx context.Context, s string) (object.NetworkReference, error) {
-			return &object.Network{}, nil
-		},
-	)
-
-	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).DoAndReturn(
-		func(ctx context.Context, card *types.VirtualEthernetCard, ethernetCardName string, network object.NetworkReference) error {
-			return nil
-		},
-	)
-
-	c.EXPECT().LoadResourcePool(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) (*object.ResourcePool, error) {
-			return &object.ResourcePool{}, nil
-		},
-	)
-
-	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").DoAndReturn(
-		func(ctx context.Context, name string) (*object.Datastore, error) {
-			return &object.Datastore{}, nil
-		},
-	)
-
-	// Simulate 10.0.1.1 already in use by a VM
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(
-		func(ctx context.Context) ([]mo.VirtualMachine, error) {
-			return []mo.VirtualMachine{
-				{
-					Summary: types.VirtualMachineSummary{
-						Config: types.VirtualMachineConfigSummary{Template: false},
-					},
-					Guest: &types.GuestInfo{
-						Net: []types.GuestNicInfo{
-							{IpAddress: []string{"10.0.1.1"}},
-						},
-					},
-				},
-			}, nil
-		},
-	).AnyTimes()
+	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").Return(&object.Network{}, nil)
+	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).Return(nil)
+	c.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
+	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").Return(&object.Datastore{}, nil)
 
 	ctx := context.Background()
-	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annotation{})
+	annot := annotation{}
+	ip := &ipResult{ip: "10.0.2.1", gateway: "10.0.2.254", subnetMask: "255.255.248.0"}
+	cloneSpec, err := h.prepareCloneSpec(ctx, &object.VirtualMachine{}, &annot, ip)
 	require.NoError(t, err)
 	require.NotNil(t, cloneSpec)
 
-	// Should use IP from second network since first is exhausted
+	// The clone spec uses the IP chosen by the caller, and the IP is recorded in
+	// the annotation (the compatibility anchor).
 	assert.Equal(t, "10.0.2.1", cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp).IpAddress)
-	// Gateway and subnet from second network
 	assert.Equal(t, "10.0.2.254", cloneSpec.Customization.NicSettingMap[0].Adapter.Gateway[0])
 	assert.Equal(t, "255.255.248.0", cloneSpec.Customization.NicSettingMap[0].Adapter.SubnetMask)
-	// DNS still global
 	assert.Equal(t, "8.8.8.8", cloneSpec.Customization.GlobalIPSettings.DnsServerList[0])
+	assert.Equal(t, "10.0.2.1", annot.IPAddress)
 }
 
 func TestHatcheryVSphere_initNetworks_LegacyConfig(t *testing.T) {

--- a/engine/hatchery/vsphere/provision.go
+++ b/engine/hatchery/vsphere/provision.go
@@ -7,8 +7,6 @@ import (
 	"github.com/rockbears/log"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-
-	"github.com/ovh/cds/sdk/namesgenerator"
 )
 
 // requestProvisioning asks the provisioning loop to run a refill pass now instead
@@ -61,11 +59,12 @@ func (h *HatcheryVSphere) releaseProvisionSlot() {
 	}
 }
 
-// startProvisionClone clones a new provision for the model and finishes it
-// (wait IP + shutdown), tracked as pending for its whole lifetime. Fire-and-forget:
-// it returns immediately so the provisioning loop stays responsive.
-func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model string) {
-	name := namesgenerator.GenerateWorkerName("provision-v2")
+// startProvisionClone clones a new provision (with the caller-chosen name and IP)
+// and finishes it (wait IP + shutdown), tracked as pending for its whole lifetime.
+// Fire-and-forget: it returns immediately so the provisioning loop stays
+// responsive. The name and IP are chosen by provisioningV2 (single goroutine) so
+// parallel clones never receive the same IP; the name encodes the IP.
+func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model, name string, ip *ipResult) {
 	h.addPending(name, model)
 
 	// Exec (not Run): these are short-lived, fire-and-forget routines, so they
@@ -75,7 +74,7 @@ func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model string)
 		h.acquireProvisionSlot()
 		defer h.releaseProvisionSlot()
 
-		if err := h.ProvisionWorkerV2(ctx, model, name); err != nil {
+		if err := h.ProvisionWorkerV2(ctx, model, name, ip); err != nil {
 			ctx = log.ContextWithStackTrace(ctx, err)
 			log.Error(ctx, "unable to provision vmware worker v2 %q model %q: %v", name, model, err)
 			h.markToDelete(ctx, name)

--- a/engine/hatchery/vsphere/provision.go
+++ b/engine/hatchery/vsphere/provision.go
@@ -3,32 +3,13 @@ package vsphere
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/rockbears/log"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
-	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/namesgenerator"
 )
-
-// provisionTask represents a unit of provisioning work submitted to the pool.
-type provisionTask struct {
-	// For "clone" tasks: clone a new VM then finish provisioning
-	cloneV2 string // non-empty for V2 clone tasks (vmware model path)
-
-	// For "finish" tasks: the VM already exists, just wait IP + shutdown
-	finishVM string // non-nil for reconciled VMs (name of existing powered-on VM)
-
-	wg *sync.WaitGroup // shared per-batch WaitGroup, caller calls wg.Wait()
-}
-
-// provisioningPool manages a fixed set of long-lived worker goroutines that
-// execute provisioning tasks. Created at startup, shut down on context cancel.
-type provisioningPool struct {
-	tasks chan provisionTask
-}
 
 // requestProvisioning asks the provisioning loop to run a refill pass now instead
 // of waiting for the next tick. It is non-blocking: if a refill is already pending
@@ -46,84 +27,86 @@ func (h *HatcheryVSphere) requestProvisioning(ctx context.Context) {
 	}
 }
 
-// startProvisioningPool launches the worker pool. Workers are long-lived and
-// pull tasks from the channel until the context is cancelled.
-func (h *HatcheryVSphere) startProvisioningPool(ctx context.Context) {
-	poolSize := h.Config.WorkerProvisioningPoolSize
-	if poolSize == 0 {
-		poolSize = 1
+// addPending records an in-flight provision (vm name -> vmware model) so a
+// concurrent/subsequent provisioning pass does not re-create a clone whose VM is
+// not yet visible in the vSphere inventory. The map is an accelerator only and is
+// safe to lose on restart (state is rebuilt from vSphere — see provisioningV2).
+func (h *HatcheryVSphere) addPending(name, model string) {
+	h.cacheProvisioning.mu.Lock()
+	if h.cacheProvisioning.pending == nil {
+		h.cacheProvisioning.pending = map[string]string{}
 	}
+	h.cacheProvisioning.pending[name] = model
+	h.cacheProvisioning.mu.Unlock()
+}
 
-	h.provisioningPool = &provisioningPool{
-		tasks: make(chan provisionTask, poolSize*2),
-	}
+func (h *HatcheryVSphere) removePending(name string) {
+	h.cacheProvisioning.mu.Lock()
+	delete(h.cacheProvisioning.pending, name)
+	h.cacheProvisioning.mu.Unlock()
+}
 
-	for i := 0; i < poolSize; i++ {
-		h.GoRoutines.Run(ctx, "hatchery-vsphere-provisioning-worker",
-			func(ctx context.Context) {
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case task, ok := <-h.provisioningPool.tasks:
-						if !ok {
-							return
-						}
-						h.executeProvisionTask(ctx, task)
-					}
-				}
-			},
-		)
+// acquireProvisionSlot / releaseProvisionSlot bound the number of concurrent
+// provisioning operations when WorkerProvisioningPoolSize > 0. When it is 0 the
+// semaphore is nil and provisioning runs fully in parallel (maximize throughput).
+func (h *HatcheryVSphere) acquireProvisionSlot() {
+	if h.provisionSem != nil {
+		h.provisionSem <- struct{}{}
 	}
 }
 
-// executeProvisionTask runs a single provisioning task.
-func (h *HatcheryVSphere) executeProvisionTask(ctx context.Context, task provisionTask) {
-	defer task.wg.Done()
-
-	if task.finishVM != "" {
-		// Reconciled VM: just finish provisioning (wait IP + shutdown)
-		h.finishProvisioning(ctx, task.finishVM)
-		return
+func (h *HatcheryVSphere) releaseProvisionSlot() {
+	if h.provisionSem != nil {
+		<-h.provisionSem
 	}
+}
 
-	// Clone task: generate name, clone the VM, then finish provisioning
-	var workerName string
-	var err error
+// startProvisionClone clones a new provision for the model and finishes it
+// (wait IP + shutdown), tracked as pending for its whole lifetime. Fire-and-forget:
+// it returns immediately so the provisioning loop stays responsive.
+func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model string) {
+	name := namesgenerator.GenerateWorkerName("provision-v2")
+	h.addPending(name, model)
 
-	if task.cloneV2 != "" {
-		workerName = namesgenerator.GenerateWorkerName("provision-v2")
+	h.GoRoutines.Run(ctx, "hatchery-vsphere-provision-clone", func(ctx context.Context) {
+		defer h.removePending(name)
+		h.acquireProvisionSlot()
+		defer h.releaseProvisionSlot()
 
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, workerName)
-		h.cacheProvisioning.mu.Unlock()
-
-		err = h.ProvisionWorkerV2(ctx, task.cloneV2, workerName)
-		if err != nil {
+		if err := h.ProvisionWorkerV2(ctx, model, name); err != nil {
 			ctx = log.ContextWithStackTrace(ctx, err)
-			log.Error(ctx, "unable to provision vmware worker v2 %q model %q: %v", workerName, task.cloneV2, err)
+			log.Error(ctx, "unable to provision vmware worker v2 %q model %q: %v", name, model, err)
+			h.markToDelete(ctx, name)
+			return
 		}
-	}
+		h.finishProvisioning(ctx, name)
+	})
+}
 
-	if err != nil {
-		h.markToDelete(ctx, workerName)
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, workerName)
-		h.cacheProvisioning.mu.Unlock()
-		return
-	}
+// startProvisionFinish resumes finishing an already-cloned provision VM (used by
+// reconciliation, e.g. after a restart). Tracked as pending; fire-and-forget.
+func (h *HatcheryVSphere) startProvisionFinish(ctx context.Context, name, model string) {
+	h.addPending(name, model)
 
-	// Clone succeeded — now wait for IP and shut down
-	h.finishProvisioning(ctx, workerName)
+	h.GoRoutines.Run(ctx, "hatchery-vsphere-provision-finish", func(ctx context.Context) {
+		defer h.removePending(name)
+		h.acquireProvisionSlot()
+		defer h.releaseProvisionSlot()
+
+		h.finishProvisioning(ctx, name)
+	})
 }
 
 // reconcileProvisionedVMs detects provisioned VMs that are powered on but not
-// actively being provisioned (not in cacheProvisioning.pending). For each
-// orphaned VM it submits a "finish" task to the pool via the provided batch.
-func (h *HatcheryVSphere) reconcileProvisionedVMs(ctx context.Context, machines []mo.VirtualMachine, prefix string, batch *sync.WaitGroup) {
+// actively being provisioned (not in cacheProvisioning.pending) — typically
+// in-flight provisions orphaned by a hatchery restart — and resumes (reuses)
+// them by finishing their provisioning.
+func (h *HatcheryVSphere) reconcileProvisionedVMs(ctx context.Context, machines []mo.VirtualMachine, prefix string) {
 	h.cacheProvisioning.mu.Lock()
-	pending := make([]string, len(h.cacheProvisioning.pending))
-	copy(pending, h.cacheProvisioning.pending)
+	pending := make(map[string]struct{}, len(h.cacheProvisioning.pending))
+	for name := range h.cacheProvisioning.pending {
+		pending[name] = struct{}{}
+	}
 	h.cacheProvisioning.mu.Unlock()
 
 	for _, machine := range machines {
@@ -146,36 +129,20 @@ func (h *HatcheryVSphere) reconcileProvisionedVMs(ctx context.Context, machines 
 			continue
 		}
 
-		if sdk.IsInArray(machine.Name, pending) {
+		if _, ok := pending[machine.Name]; ok {
 			continue
 		}
 
-		vmName := machine.Name
-		log.Info(ctx, "reconcileProvisionedVMs: resuming provisioning for VM %q", vmName)
-
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.pending = append(h.cacheProvisioning.pending, vmName)
-		h.cacheProvisioning.mu.Unlock()
-
-		batch.Add(1)
-		h.provisioningPool.tasks <- provisionTask{
-			finishVM: vmName,
-			wg:       batch,
-		}
+		log.Info(ctx, "reconcileProvisionedVMs: resuming provisioning for VM %q", machine.Name)
+		h.startProvisionFinish(ctx, machine.Name, annot.VMwareModelPath)
 	}
 }
 
 // finishProvisioning completes the provisioning of an already-cloned VM by
 // waiting for it to get an IP and then shutting it down. On failure the VM is
-// marked for deletion. In all cases the VM name is removed from
-// cacheProvisioning.pending when done.
+// marked for deletion. Pending bookkeeping is owned by the caller
+// (startProvisionClone / startProvisionFinish).
 func (h *HatcheryVSphere) finishProvisioning(ctx context.Context, vmName string) {
-	defer func() {
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.pending = sdk.DeleteFromArray(h.cacheProvisioning.pending, vmName)
-		h.cacheProvisioning.mu.Unlock()
-	}()
-
 	vm, err := h.vSphereClient.LoadVirtualMachine(ctx, vmName)
 	if err != nil {
 		log.Error(ctx, "finishProvisioning: unable to load VM %q: %v", vmName, err)

--- a/engine/hatchery/vsphere/provision.go
+++ b/engine/hatchery/vsphere/provision.go
@@ -30,6 +30,22 @@ type provisioningPool struct {
 	tasks chan provisionTask
 }
 
+// requestProvisioning asks the provisioning loop to run a refill pass now instead
+// of waiting for the next tick. It is non-blocking: if a refill is already pending
+// (or provisioning is not enabled), the request is dropped — the pending run will
+// pick up the latest state anyway.
+func (h *HatcheryVSphere) requestProvisioning(ctx context.Context) {
+	if h.provisionSignal == nil {
+		return
+	}
+	select {
+	case h.provisionSignal <- struct{}{}:
+		log.Debug(ctx, "provisioning refill requested")
+	default:
+		// a refill is already pending
+	}
+}
+
 // startProvisioningPool launches the worker pool. Workers are long-lived and
 // pull tasks from the channel until the context is cancelled.
 func (h *HatcheryVSphere) startProvisioningPool(ctx context.Context) {

--- a/engine/hatchery/vsphere/provision.go
+++ b/engine/hatchery/vsphere/provision.go
@@ -68,7 +68,9 @@ func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model string)
 	name := namesgenerator.GenerateWorkerName("provision-v2")
 	h.addPending(name, model)
 
-	h.GoRoutines.Run(ctx, "hatchery-vsphere-provision-clone", func(ctx context.Context) {
+	// Exec (not Run): these are short-lived, fire-and-forget routines, so they
+	// must not be registered in the long-lived goroutine monitoring status.
+	h.GoRoutines.Exec(ctx, "hatchery-vsphere-provision-clone", func(ctx context.Context) {
 		defer h.removePending(name)
 		h.acquireProvisionSlot()
 		defer h.releaseProvisionSlot()
@@ -88,7 +90,8 @@ func (h *HatcheryVSphere) startProvisionClone(ctx context.Context, model string)
 func (h *HatcheryVSphere) startProvisionFinish(ctx context.Context, name, model string) {
 	h.addPending(name, model)
 
-	h.GoRoutines.Run(ctx, "hatchery-vsphere-provision-finish", func(ctx context.Context) {
+	// Exec (not Run): short-lived, fire-and-forget; not monitored like long-lived routines.
+	h.GoRoutines.Exec(ctx, "hatchery-vsphere-provision-finish", func(ctx context.Context) {
 		defer h.removePending(name)
 		h.acquireProvisionSlot()
 		defer h.releaseProvisionSlot()

--- a/engine/hatchery/vsphere/provision_test.go
+++ b/engine/hatchery/vsphere/provision_test.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,93 +12,64 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/mock/gomock"
-)
 
-// setupTestPool creates a provisioning pool with a single worker for testing.
-func setupTestPool(ctx context.Context, h *HatcheryVSphere) {
-	h.provisioningPool = &provisioningPool{
-		tasks: make(chan provisionTask, 10),
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case task, ok := <-h.provisioningPool.tasks:
-				if !ok {
-					return
-				}
-				h.executeProvisionTask(ctx, task)
-			}
-		}
-	}()
-}
+	"github.com/ovh/cds/sdk"
+)
 
 func TestHatcheryVSphere_reconcileProvisionedVMs_completesProvisioning(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 
 	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{
-		vSphereClient: c,
-	}
+	h := HatcheryVSphere{vSphereClient: c}
+	h.GoRoutines = sdk.NewGoRoutines(context.Background())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	setupTestPool(ctx, &h)
-
-	stuckCreatedAt := time.Now().Add(-15 * time.Minute)
+	ctx := context.Background()
 
 	machines := []mo.VirtualMachine{
-		{
-			// Powered on, provisioning annotation — should be reconciled
+		{ // powered on + provisioning → reconciled (reused)
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-orphan"},
-			Summary: types.VirtualMachineSummary{
-				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
-			},
-			Config: &types.VirtualMachineConfigInfo{
-				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
-			},
+			Summary:       types.VirtualMachineSummary{Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn}},
+			Config:        &types.VirtualMachineConfigInfo{Annotation: `{"provisioning": true, "vmware_model_path": "model-a"}`},
 		},
-		{
-			// Already powered off → ignored
+		{ // already powered off (ready) → ignored
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-ready"},
-			Summary: types.VirtualMachineSummary{
-				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff},
-			},
-			Config: &types.VirtualMachineConfigInfo{
-				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
-			},
+			Summary:       types.VirtualMachineSummary{Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff}},
+			Config:        &types.VirtualMachineConfigInfo{Annotation: `{"provisioning": true, "vmware_model_path": "model-a"}`},
 		},
-		{
-			// In pending cache → ignored
+		{ // already tracked as pending → ignored
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-pending"},
-			Summary: types.VirtualMachineSummary{
-				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
-			},
-			Config: &types.VirtualMachineConfigInfo{
-				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
-			},
+			Summary:       types.VirtualMachineSummary{Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn}},
+			Config:        &types.VirtualMachineConfigInfo{Annotation: `{"provisioning": true, "vmware_model_path": "model-a"}`},
 		},
 	}
 
-	h.cacheProvisioning.pending = []string{"provision-v2-pending"}
+	h.cacheProvisioning.pending = map[string]string{"provision-v2-pending": "model-a"}
 
-	// The worker will: LoadVirtualMachine → WaitForVirtualMachineIP → ShutdownVirtualMachine
+	// Only the orphan is resumed: LoadVirtualMachine → WaitForVirtualMachineIP → ShutdownVirtualMachine.
 	vmObj := &object.VirtualMachine{}
+	done := make(chan struct{})
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-orphan").Return(vmObj, nil)
 	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), vmObj, nil, "provision-v2-orphan").Return(nil)
-	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), vmObj).Return(nil)
+	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), vmObj).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine) error { close(done); return nil },
+	)
 
-	var batch sync.WaitGroup
-	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
-	batch.Wait()
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2")
 
-	// VM should have been removed from pending after completion
-	h.cacheProvisioning.mu.Lock()
-	assert.NotContains(t, h.cacheProvisioning.pending, "provision-v2-orphan")
-	h.cacheProvisioning.mu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconcile did not finish provisioning the orphan in time")
+	}
 
-	// No VMs should be marked for deletion — provisioning completed successfully
+	// orphan removed from pending after completion; nothing marked for deletion.
+	assert.Eventually(t, func() bool {
+		h.cacheProvisioning.mu.Lock()
+		_, stillPending := h.cacheProvisioning.pending["provision-v2-orphan"]
+		h.cacheProvisioning.mu.Unlock()
+		return !stillPending
+	}, 2*time.Second, 10*time.Millisecond)
+
 	h.cacheToDelete.mu.Lock()
 	defer h.cacheToDelete.mu.Unlock()
 	assert.Empty(t, h.cacheToDelete.list)
@@ -109,42 +79,30 @@ func TestHatcheryVSphere_reconcileProvisionedVMs_deletesOnIPTimeout(t *testing.T
 	log.Factory = log.NewTestingWrapper(t)
 
 	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{
-		vSphereClient: c,
-	}
+	h := HatcheryVSphere{vSphereClient: c}
+	h.GoRoutines = sdk.NewGoRoutines(context.Background())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	setupTestPool(ctx, &h)
-
-	stuckCreatedAt := time.Now().Add(-15 * time.Minute)
+	ctx := context.Background()
 
 	machines := []mo.VirtualMachine{
-		{
-			// No IP, WaitForVirtualMachineIP will fail → marked for deletion
+		{ // no IP → WaitForVirtualMachineIP fails → marked for deletion
 			ManagedEntity: mo.ManagedEntity{Name: "provision-v2-stuck"},
-			Summary: types.VirtualMachineSummary{
-				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
-			},
-			Config: &types.VirtualMachineConfigInfo{
-				Annotation: fmt.Sprintf(`{"provisioning": true, "vmware_model_path": "model-a", "created": "%s"}`, stuckCreatedAt.Format(time.RFC3339)),
-			},
+			Summary:       types.VirtualMachineSummary{Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn}},
+			Config:        &types.VirtualMachineConfigInfo{Annotation: `{"provisioning": true, "vmware_model_path": "model-a"}`},
 		},
 	}
 
 	vmObj := &object.VirtualMachine{}
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-stuck").Return(vmObj, nil)
 	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), vmObj, nil, "provision-v2-stuck").Return(fmt.Errorf("context deadline exceeded"))
-
-	// markToDelete calls ListVirtualMachines
+	// markToDelete reloads the VM list.
 	c.EXPECT().ListVirtualMachines(gomock.Any()).Return(machines, nil).AnyTimes()
 
-	var batch sync.WaitGroup
-	h.reconcileProvisionedVMs(ctx, machines, "provision-v2", &batch)
-	batch.Wait()
+	h.reconcileProvisionedVMs(ctx, machines, "provision-v2")
 
-	// The stuck VM should be marked for deletion
-	h.cacheToDelete.mu.Lock()
-	defer h.cacheToDelete.mu.Unlock()
-	assert.Equal(t, []string{"provision-v2-stuck"}, h.cacheToDelete.list)
+	assert.Eventually(t, func() bool {
+		h.cacheToDelete.mu.Lock()
+		defer h.cacheToDelete.mu.Unlock()
+		return sdk.IsInArray("provision-v2-stuck", h.cacheToDelete.list)
+	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -380,7 +380,7 @@ func (h *HatcheryVSphere) markToDelete(ctx context.Context, vmName string) {
 	h.cacheToDelete.list = append(h.cacheToDelete.list, vmRef.Name)
 }
 
-func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel string, workerName string) error {
+func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel string, workerName string, ip *ipResult) error {
 	vmTemplate, err := h.vSphereClient.LoadVirtualMachine(ctx, vmwareModel)
 	if err != nil {
 		return sdk.WrapError(err, "cannot find virtual machine template with VMware model %v", vmwareModel)
@@ -394,29 +394,17 @@ func (h *HatcheryVSphere) ProvisionWorkerV2(ctx context.Context, vmwareModel str
 		Created:         time.Now(),
 	}
 
-	return h.cloneProvisionedWorker(ctx, vmTemplate, annot, workerName)
+	return h.cloneProvisionedWorker(ctx, vmTemplate, annot, workerName, ip)
 }
 
-// cloneProvisionedWorker clones a VM template for provisioning. After the clone
-// the VM is powered on but not yet shut down — the caller is responsible for
-// completing provisioning via finishProvisioning.
-func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate *object.VirtualMachine, annot annotation, workerName string) error {
-	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot)
+// cloneProvisionedWorker clones a VM template for provisioning, giving it the
+// caller-chosen IP (when set). After the clone the VM is powered on but not yet
+// shut down — the caller completes provisioning via finishProvisioning.
+func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate *object.VirtualMachine, annot annotation, workerName string, ip *ipResult) error {
+	cloneSpec, err := h.prepareCloneSpec(ctx, vmTemplate, &annot, ip)
 	if err != nil {
 		return err
 	}
-
-	// prepareCloneSpec reserved annot.IPAddress (when an IP range is configured).
-	// If the clone does not complete, no VM will ever carry that IP, so release
-	// the reservation right away instead of waiting out its TTL. On success the
-	// reservation is kept until the new VM is observed (its annotation then
-	// becomes the source of truth).
-	provisioned := false
-	defer func() {
-		if !provisioned {
-			h.releaseIPAddress(annot.IPAddress)
-		}
-	}()
 
 	folder, err := h.vSphereClient.LoadFolder(ctx)
 	if err != nil {
@@ -434,7 +422,6 @@ func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate
 		return err
 	}
 
-	provisioned = true
 	return nil
 }
 

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -139,6 +139,10 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 			_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
 			h.markToDelete(ctx, provisionnedVMWorker.Name())
 		}
+		// A provision was consumed (claimed for this job, or marked for deletion on
+		// failure): ask the provisioning loop to refill the pool without waiting for
+		// its next tick.
+		h.requestProvisioning(ctx)
 	}()
 
 	log.Info(ctx, "starting worker %q with provisionned machine %q", spawnArgs.Model.GetName(), provisionName)
@@ -402,6 +406,18 @@ func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate
 		return err
 	}
 
+	// prepareCloneSpec reserved annot.IPAddress (when an IP range is configured).
+	// If the clone does not complete, no VM will ever carry that IP, so release
+	// the reservation right away instead of waiting out its TTL. On success the
+	// reservation is kept until the new VM is observed (its annotation then
+	// becomes the source of truth).
+	provisioned := false
+	defer func() {
+		if !provisioned {
+			h.releaseIPAddress(annot.IPAddress)
+		}
+	}()
+
 	folder, err := h.vSphereClient.LoadFolder(ctx)
 	if err != nil {
 		return err
@@ -418,6 +434,7 @@ func (h *HatcheryVSphere) cloneProvisionedWorker(ctx context.Context, vmTemplate
 		return err
 	}
 
+	provisioned = true
 	return nil
 }
 

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"strings"
@@ -26,10 +27,16 @@ type annotation struct {
 	VMwareModelPath string `json:"vmware_model_path,omitempty"`
 	// Model is true for VM template used by provision / new worker without provision
 	// we don't want to destroy (with killawolServer for exemple) a vm with model = true
-	Model     bool      `json:"model,omitempty"`
-	Created   time.Time `json:"created,omitempty"`
-	JobID     string    `json:"job_id,omitempty"`
-	IPAddress string    `json:"ip_address,omitempty"`
+	Model   bool      `json:"model,omitempty"`
+	Created time.Time `json:"created,omitempty"`
+	// WorkerStartTime is set when a provision is claimed for a job (turned into a
+	// worker). Unlike Created (the provision clone time, which can be arbitrarily
+	// old), it marks when the worker actually started, and being stored in the VM
+	// annotation it survives a hatchery restart and never ages out like vSphere
+	// events. killAwolServers uses it to decide when an orphaned VM can be removed.
+	WorkerStartTime time.Time `json:"worker_start_time,omitempty"`
+	JobID           string    `json:"job_id,omitempty"`
+	IPAddress       string    `json:"ip_address,omitempty"`
 }
 
 // SpawnWorker creates a new vm instance
@@ -103,64 +110,121 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 		return sdk.WithStack(fmt.Errorf("no provisioned worker available for model %q", spawnArgs.Model.GetName()))
 	}
 
-	log.Info(ctx, "starting worker %q with provisionned machine %q", spawnArgs.Model.GetName(), provisionnedVMWorker.Name())
+	// provisionName is the name under which the VM was claimed (and added to
+	// cacheProvisioning.using by FindProvisionnedWorker). Capture it before any
+	// rename: RenameVirtualMachine reloads the object, so provisionnedVMWorker.Name()
+	// returns the worker name afterwards.
+	provisionName := provisionnedVMWorker.Name()
+
+	// Read the provision annotation before mutating it, to preserve the fields set
+	// at provisioning time (IPAddress reserved at clone time, VMwareModelPath).
+	moProvision, err := h.getVirtualMachineByName(ctx, provisionName)
+	if err != nil {
+		h.releaseProvisioning(provisionName)
+		return sdk.WrapError(err, "unable to load provisioned VM %q", provisionName)
+	}
+	workerAnnot := annotation{}
+	if a := getVirtualMachineCDSAnnotation(ctx, *moProvision); a != nil {
+		workerAnnot = *a
+	}
+
+	// From this point the VM is being turned into a worker. Any failure must tear
+	// it down so we never leave a partially-configured worker holding an IP.
+	spawnOK := false
+	defer func() {
+		h.releaseProvisioning(provisionName)
+		if !spawnOK {
+			// provisionnedVMWorker.Name() is the current vSphere name: provisionName
+			// if we failed before rename, the worker name if after.
+			_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
+			h.markToDelete(ctx, provisionnedVMWorker.Name())
+		}
+	}()
+
+	log.Info(ctx, "starting worker %q with provisionned machine %q", spawnArgs.Model.GetName(), provisionName)
 
 	// Amendment C: Reconfigure VM to flavor before starting (if flavor requested)
 	if flavor != nil {
-		log.Info(ctx, "reconfiguring provisioned VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
+		log.Info(ctx, "reconfiguring provisioned VM %q to flavor %q", provisionName, flavorName)
 		if err := h.reconfigureVM(ctx, provisionnedVMWorker, flavor); err != nil {
-			h.cacheProvisioning.mu.Lock()
-			h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-			h.cacheProvisioning.mu.Unlock()
-			return sdk.WrapError(err, "unable to reconfigure VM %q to flavor %q", provisionnedVMWorker.Name(), flavorName)
+			return sdk.WrapError(err, "unable to reconfigure VM %q to flavor %q", provisionName, flavorName)
 		}
 	}
 
 	if err := h.vSphereClient.RenameVirtualMachine(ctx, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-		h.cacheProvisioning.mu.Unlock()
-		return sdk.WrapError(err, "unable to rename VM %q", provisionnedVMWorker.Name())
+		return sdk.WrapError(err, "unable to rename VM %q", provisionName)
 	}
 
-	time.Sleep(2 * time.Second)
+	// Record the claim/start time on the VM annotation so cleanup does not depend
+	// on vSphere events. Persisted before power-on so it survives a crash during
+	// start. Existing fields (IPAddress, VMwareModelPath) are preserved.
+	workerAnnot.HatcheryName = h.Name()
+	workerAnnot.WorkerName = spawnArgs.WorkerName
+	workerAnnot.Provisioning = false
+	workerAnnot.JobID = spawnArgs.JobID
+	workerAnnot.WorkerStartTime = time.Now()
+	workerAnnotStr, err := json.Marshal(workerAnnot)
+	if err != nil {
+		return sdk.WrapError(err, "unable to marshal worker annotation for VM %q", spawnArgs.WorkerName)
+	}
+	if err := h.vSphereClient.SetVirtualMachineAnnotation(ctx, provisionnedVMWorker, string(workerAnnotStr)); err != nil {
+		return sdk.WrapError(err, "unable to set worker annotation on VM %q", spawnArgs.WorkerName)
+	}
 
-	if err := h.vSphereClient.StartVirtualMachine(ctx, provisionnedVMWorker); err != nil {
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-		h.cacheProvisioning.mu.Unlock()
-
-		_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
-		h.markToDelete(ctx, provisionnedVMWorker.Name())
+	// Power on, tolerating a VM that is not immediately startable right after the
+	// reconfigure/annotation update.
+	if err := h.startVirtualMachineWithRetry(ctx, provisionnedVMWorker); err != nil {
 		return sdk.WrapError(err, "unable to start VM %q", spawnArgs.WorkerName)
 	}
 
-	// wait for the right IP, probably keep track of the IP address in the server annotations
-	// to avoid having two provisionned VM with the same IP address
-	// so we if to peek a random IP address by considering already provisionned IP addresses
-	moProvisionnedVMWorker, err := h.getVirtualMachineByName(ctx, provisionnedVMWorker.Name())
-	if err != nil {
-		return sdk.WrapError(err, "unable to find VM %q", spawnArgs.WorkerName)
-	}
-	annot := getVirtualMachineCDSAnnotation(ctx, *moProvisionnedVMWorker)
-
-	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, provisionnedVMWorker, &annot.IPAddress, spawnArgs.WorkerName); err != nil {
-		h.cacheProvisioning.mu.Lock()
-		h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
-		h.cacheProvisioning.mu.Unlock()
-
-		_ = h.vSphereClient.ShutdownVirtualMachine(ctx, provisionnedVMWorker)
-		h.markToDelete(ctx, provisionnedVMWorker.Name())
+	// Wait for the VM to come back with the IP reserved at provisioning time.
+	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, provisionnedVMWorker, &workerAnnot.IPAddress, spawnArgs.WorkerName); err != nil {
 		return sdk.WrapError(err, "unable to get VM %q IP Address", spawnArgs.WorkerName)
 	}
 
-	errLaunch := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName)
+	if err := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
+		return err
+	}
 
+	spawnOK = true
+	return nil
+}
+
+// releaseProvisioning removes a claimed provision name from the in-use cache.
+func (h *HatcheryVSphere) releaseProvisioning(provisionName string) {
 	h.cacheProvisioning.mu.Lock()
-	h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionnedVMWorker.Name())
+	h.cacheProvisioning.using = sdk.DeleteFromArray(h.cacheProvisioning.using, provisionName)
 	h.cacheProvisioning.mu.Unlock()
+}
 
-	return errLaunch
+// startVMRetryTimeout / startVMRetryInterval bound the power-on retry below.
+// They are vars (not consts) so tests can shorten them.
+var (
+	startVMRetryTimeout  = 60 * time.Second
+	startVMRetryInterval = 2 * time.Second
+)
+
+// startVirtualMachineWithRetry powers on a VM, tolerating the transient errors
+// that can occur right after a reconfigure (the VM may briefly not be in a
+// startable state). It retries within a bounded budget before giving up.
+func (h *HatcheryVSphere) startVirtualMachineWithRetry(ctx context.Context, vm *object.VirtualMachine) error {
+	ctx, cancel := context.WithTimeout(ctx, startVMRetryTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		lastErr = h.vSphereClient.StartVirtualMachine(ctx, vm)
+		if lastErr == nil {
+			return nil
+		}
+		log.Warn(ctx, "unable to start VM %q yet, retrying: %v", vm.Name(), lastErr)
+
+		select {
+		case <-ctx.Done():
+			return sdk.WrapError(lastErr, "VM %q did not become startable in time", vm.Name())
+		case <-time.After(startVMRetryInterval):
+		}
+	}
 }
 
 func (h *HatcheryVSphere) checkVirtualMachineIsReady(ctx context.Context, model sdk.WorkerStarterWorkerModel, vm *object.VirtualMachine, vmName string) error {

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -447,8 +447,10 @@ func (h *HatcheryVSphere) hasAvailableProvisionedWorker(ctx context.Context, mod
 	expectedModelPath := model.GetVSphereImage()
 
 	h.cacheProvisioning.mu.Lock()
-	pending := make([]string, len(h.cacheProvisioning.pending))
-	copy(pending, h.cacheProvisioning.pending)
+	pending := make(map[string]struct{}, len(h.cacheProvisioning.pending))
+	for name := range h.cacheProvisioning.pending {
+		pending[name] = struct{}{}
+	}
 	using := make([]string, len(h.cacheProvisioning.using))
 	copy(using, h.cacheProvisioning.using)
 	h.cacheProvisioning.mu.Unlock()
@@ -478,7 +480,7 @@ func (h *HatcheryVSphere) hasAvailableProvisionedWorker(ctx context.Context, mod
 			continue
 		}
 
-		if sdk.IsInArray(machine.Name, pending) ||
+		if _, isPending := pending[machine.Name]; isPending ||
 			sdk.IsInArray(machine.Name, using) ||
 			sdk.IsInArray(machine.Name, toDelete) {
 			continue
@@ -520,7 +522,7 @@ func (h *HatcheryVSphere) FindProvisionnedWorker(ctx context.Context, model sdk.
 		}
 
 		h.cacheProvisioning.mu.Lock()
-		if sdk.IsInArray(machine.Name, h.cacheProvisioning.pending) {
+		if _, isPending := h.cacheProvisioning.pending[machine.Name]; isPending {
 			h.cacheProvisioning.mu.Unlock()
 			log.Debug(ctx, "provision %q is in pending provisioning - skip it", machine.Name)
 			continue

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -191,12 +192,15 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 
 	var ctx = context.Background()
 
+	// The claimed provision keeps its provision name until rename; capturing it
+	// before rename is what SpawnWorker relies on.
 	var vmProvisionned = object.VirtualMachine{
 		Common: object.Common{
-			InventoryPath: "worker-name",
+			InventoryPath: "provision-v2-worker",
 		},
 	}
 
+	// Both FindProvisionnedWorker and the pre-rename annotation read list the VMs.
 	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
 		return []mo.VirtualMachine{
 			{
@@ -215,15 +219,17 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 				ManagedEntity: mo.ManagedEntity{
 					Name: "provision-v2-worker",
 				},
-				Runtime: types.VirtualMachineRuntimeInfo{
-					PowerState: types.VirtualMachinePowerStatePoweredOff,
+				Summary: types.VirtualMachineSummary{
+					Runtime: types.VirtualMachineRuntimeInfo{
+						PowerState: types.VirtualMachinePowerStatePoweredOff,
+					},
 				},
 				Config: &types.VirtualMachineConfigInfo{
-					Annotation: `{"provisioning": true, "vmware_model_path": "the-model"}`,
+					Annotation: `{"provisioning": true, "vmware_model_path": "the-model", "ip_address": "192.168.0.1"}`,
 				},
 			},
 		}, nil
-	}).Times(1)
+	}).Times(2)
 
 	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-worker").DoAndReturn(
 		func(ctx context.Context, name string) (*object.VirtualMachine, error) {
@@ -233,7 +239,6 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 
 	c.EXPECT().LoadVirtualMachineEvents(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vm *object.VirtualMachine, eventTypes ...string) ([]types.BaseEvent, error) {
-			t.Logf("LoadVirtualMachineEvents for %s", vm.Name())
 			return []types.BaseEvent{
 				&types.VmPoweredOffEvent{
 					VmEvent: types.VmEvent{
@@ -252,39 +257,26 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 		},
 	)
 
+	// The claim time is persisted on the VM annotation before power-on, preserving
+	// the provisioning fields (IP, vmware model path) and clearing the provisioning flag.
+	c.EXPECT().SetVirtualMachineAnnotation(gomock.Any(), &vmProvisionned, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine, annotStr string) error {
+			var a annotation
+			require.NoError(t, json.Unmarshal([]byte(annotStr), &a))
+			assert.False(t, a.WorkerStartTime.IsZero(), "WorkerStartTime must be stamped")
+			assert.Equal(t, "666", a.JobID)
+			assert.False(t, a.Provisioning, "claimed worker must not be flagged as provisioning")
+			assert.Equal(t, "the-model", a.VMwareModelPath, "vmware model path must be preserved")
+			assert.Equal(t, "192.168.0.1", a.IPAddress, "reserved IP must be preserved")
+			return nil
+		},
+	)
+
 	c.EXPECT().StartVirtualMachine(gomock.Any(), &vmProvisionned).DoAndReturn(
 		func(ctx context.Context, vm *object.VirtualMachine) error {
 			return nil
 		},
 	)
-
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
-		return []mo.VirtualMachine{
-			{
-				ManagedEntity: mo.ManagedEntity{
-					Name: "the-model",
-				},
-				Summary: types.VirtualMachineSummary{
-					Config: types.VirtualMachineConfigSummary{
-						Template: true,
-					},
-				},
-				Config: &types.VirtualMachineConfigInfo{
-					Annotation: `{"vmware_model_path": "the-model", "model": true}`,
-				},
-			}, {
-				ManagedEntity: mo.ManagedEntity{
-					Name: "worker-name",
-				},
-				Runtime: types.VirtualMachineRuntimeInfo{
-					PowerState: types.VirtualMachinePowerStatePoweredOn,
-				},
-				Config: &types.VirtualMachineConfigInfo{
-					Annotation: `{"provisioning": true, "vmware_model_path": "the-model"}`,
-				},
-			},
-		}, nil
-	})
 
 	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), &vmProvisionned, gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, vm *object.VirtualMachine, _ *string, _ string) error {
@@ -357,6 +349,88 @@ func TestHatcheryVSphere_SpawnWorkerFromProvisioning(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+}
+
+// When a step of the spawn fails after a provision has been claimed, the VM must
+// be torn down (marked for deletion) and released from the in-use cache, so we
+// never leave a partially-configured worker holding an IP.
+func TestHatcheryVSphere_SpawnWorker_TeardownOnFailure(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{vSphereClient: c}
+
+	var ctx = context.Background()
+	var vmProvisionned = object.VirtualMachine{Common: object.Common{InventoryPath: "provision-v2-worker"}}
+
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
+		return []mo.VirtualMachine{
+			{
+				ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker"},
+				Summary:       types.VirtualMachineSummary{Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOff}},
+				Config:        &types.VirtualMachineConfigInfo{Annotation: `{"provisioning": true, "vmware_model_path": "the-model"}`},
+			},
+		}, nil
+	}).AnyTimes()
+
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-worker").Return(&vmProvisionned, nil).AnyTimes()
+	c.EXPECT().LoadVirtualMachineEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return([]types.BaseEvent{
+		&types.VmPoweredOffEvent{VmEvent: types.VmEvent{Event: types.Event{CreatedTime: time.Now().Add(-10 * time.Minute)}}},
+	}, nil)
+	c.EXPECT().RenameVirtualMachine(gomock.Any(), &vmProvisionned, "worker-name").Return(nil)
+
+	// The annotation update fails: the spawn must abort and tear the VM down.
+	c.EXPECT().SetVirtualMachineAnnotation(gomock.Any(), &vmProvisionned, gomock.Any()).Return(fmt.Errorf("boom"))
+	c.EXPECT().ShutdownVirtualMachine(gomock.Any(), &vmProvisionned).Return(nil)
+
+	err := h.SpawnWorker(ctx, hatchery.SpawnArguments{
+		WorkerName: "worker-name",
+		Model: sdk.WorkerStarterWorkerModel{
+			ModelV2:     &sdk.V2WorkerModel{Name: "cds-model-name", Spec: json.RawMessage(`{"image":"the-model"}`)},
+			VSphereSpec: sdk.V2WorkerModelVSphereSpec{Image: "the-model"},
+			Cmd:         "./worker",
+		},
+		JobID: "666",
+	})
+
+	require.Error(t, err)
+	assert.True(t, sdk.IsInArray("provision-v2-worker", h.cacheToDelete.list), "the VM must be marked for deletion")
+	assert.Empty(t, h.cacheProvisioning.using, "the provision must be released from the in-use cache")
+}
+
+func TestHatcheryVSphere_startVirtualMachineWithRetry(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	// Speed up the retry loop for the test.
+	defer func(to, iv time.Duration) { startVMRetryTimeout, startVMRetryInterval = to, iv }(startVMRetryTimeout, startVMRetryInterval)
+	startVMRetryTimeout = time.Second
+	startVMRetryInterval = 5 * time.Millisecond
+
+	vm := &object.VirtualMachine{Common: object.Common{InventoryPath: "worker-name"}}
+
+	t.Run("transient failure then success", func(t *testing.T) {
+		c := NewVSphereClientTest(t)
+		h := HatcheryVSphere{vSphereClient: c}
+		var calls int
+		c.EXPECT().StartVirtualMachine(gomock.Any(), vm).DoAndReturn(func(ctx context.Context, vm *object.VirtualMachine) error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("invalid state")
+			}
+			return nil
+		}).Times(3)
+
+		require.NoError(t, h.startVirtualMachineWithRetry(context.Background(), vm))
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("failure for the whole budget", func(t *testing.T) {
+		c := NewVSphereClientTest(t)
+		h := HatcheryVSphere{vSphereClient: c}
+		c.EXPECT().StartVirtualMachine(gomock.Any(), vm).Return(fmt.Errorf("invalid state")).MinTimes(1)
+
+		require.Error(t, h.startVirtualMachineWithRetry(context.Background(), vm))
+	})
 }
 
 func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -559,3 +559,36 @@ func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {
 	err := h.ProvisionWorkerV2(ctx, "the-model", "provisionned-worker")
 	require.NoError(t, err)
 }
+
+// When a provision clone fails after an IP has been reserved, the reservation
+// must be released so the IP returns to the pool without waiting out its TTL.
+func TestHatcheryVSphere_ProvisionWorker_releasesIPOnCloneError(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{vSphereClient: c}
+	h.Config.VSphereNetworkString = "vbox-net"
+	h.Config.VSphereCardName = "ethernet-card"
+	h.Config.VSphereDatastoreString = "datastore"
+	h.availableIPAddresses = []string{"192.168.0.1"}
+	h.availableNetworks = []availableNetwork{{
+		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
+		ipAddresses: []string{"192.168.0.1"},
+	}}
+
+	var vmTemplate = object.VirtualMachine{Common: object.Common{InventoryPath: "the-model"}}
+
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "the-model").Return(&vmTemplate, nil)
+	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).Return(object.VirtualDeviceList{&types.VirtualEthernetCard{}}, nil)
+	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").Return(&object.Network{}, nil)
+	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).Return(nil)
+	c.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
+	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").Return(&object.Datastore{}, nil)
+	c.EXPECT().ListVirtualMachines(gomock.Any()).Return([]mo.VirtualMachine{}, nil)
+	c.EXPECT().LoadFolder(gomock.Any()).Return(&object.Folder{}, nil)
+	c.EXPECT().CloneVirtualMachine(gomock.Any(), &vmTemplate, gomock.Any(), "provisionned-worker", gomock.Any()).Return(nil, fmt.Errorf("clone boom"))
+
+	err := h.ProvisionWorkerV2(context.Background(), "the-model", "provisionned-worker")
+	require.Error(t, err)
+	assert.NotContains(t, h.reservedIPAddresses, "192.168.0.1", "the reserved IP must be released when the clone fails")
+}

--- a/engine/hatchery/vsphere/spawn_test.go
+++ b/engine/hatchery/vsphere/spawn_test.go
@@ -515,24 +515,6 @@ func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {
 		},
 	)
 
-	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
-		return []mo.VirtualMachine{
-			{
-				ManagedEntity: mo.ManagedEntity{
-					Name: "the-model",
-				},
-				Summary: types.VirtualMachineSummary{
-					Config: types.VirtualMachineConfigSummary{
-						Template: true,
-					},
-				},
-				Config: &types.VirtualMachineConfigInfo{
-					Annotation: `{"vmware_model_path": "the-model", "model": true}`,
-				},
-			},
-		}, nil
-	})
-
 	var workerRef types.ManagedObjectReference
 
 	c.EXPECT().CloneVirtualMachine(gomock.Any(), &vmTemplate, &folder, "provisionned-worker", gomock.Any()).DoAndReturn(
@@ -556,39 +538,6 @@ func TestHatcheryVSphere_ProvisionWorker(t *testing.T) {
 		},
 	)
 
-	err := h.ProvisionWorkerV2(ctx, "the-model", "provisionned-worker")
+	err := h.ProvisionWorkerV2(ctx, "the-model", "provisionned-worker", &ipResult{ip: "192.168.0.1", gateway: "192.168.0.254", subnetMask: "255.255.255.0"})
 	require.NoError(t, err)
-}
-
-// When a provision clone fails after an IP has been reserved, the reservation
-// must be released so the IP returns to the pool without waiting out its TTL.
-func TestHatcheryVSphere_ProvisionWorker_releasesIPOnCloneError(t *testing.T) {
-	log.Factory = log.NewTestingWrapper(t)
-
-	c := NewVSphereClientTest(t)
-	h := HatcheryVSphere{vSphereClient: c}
-	h.Config.VSphereNetworkString = "vbox-net"
-	h.Config.VSphereCardName = "ethernet-card"
-	h.Config.VSphereDatastoreString = "datastore"
-	h.availableIPAddresses = []string{"192.168.0.1"}
-	h.availableNetworks = []availableNetwork{{
-		config:      NetworkConfig{IPRange: "192.168.0.0/24", Gateway: "192.168.0.254", SubnetMask: "255.255.255.0"},
-		ipAddresses: []string{"192.168.0.1"},
-	}}
-
-	var vmTemplate = object.VirtualMachine{Common: object.Common{InventoryPath: "the-model"}}
-
-	c.EXPECT().LoadVirtualMachine(gomock.Any(), "the-model").Return(&vmTemplate, nil)
-	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).Return(object.VirtualDeviceList{&types.VirtualEthernetCard{}}, nil)
-	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").Return(&object.Network{}, nil)
-	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).Return(nil)
-	c.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
-	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").Return(&object.Datastore{}, nil)
-	c.EXPECT().ListVirtualMachines(gomock.Any()).Return([]mo.VirtualMachine{}, nil)
-	c.EXPECT().LoadFolder(gomock.Any()).Return(&object.Folder{}, nil)
-	c.EXPECT().CloneVirtualMachine(gomock.Any(), &vmTemplate, gomock.Any(), "provisionned-worker", gomock.Any()).Return(nil, fmt.Errorf("clone boom"))
-
-	err := h.ProvisionWorkerV2(context.Background(), "the-model", "provisionned-worker")
-	require.Error(t, err)
-	assert.NotContains(t, h.reservedIPAddresses, "192.168.0.1", "the reserved IP must be released when the clone fails")
 }

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -111,10 +111,8 @@ type HatcheryVSphere struct {
 	Config               HatcheryConfiguration
 	vSphereClient        VSphereClient
 	metrics              vsphereMetrics
-	IpAddressesMutex     sync.Mutex
 	availableIPAddresses []string // flat list kept for backward-compat checks (e.g. CanSpawn)
 	availableNetworks    []availableNetwork
-	reservedIPAddresses  []string
 	// provisionSignal lets cleanup and spawn request an immediate provisioning
 	// refill instead of waiting for the next tick. Buffered (size 1) so a burst
 	// of requests coalesces into at most one pending run.

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -27,6 +27,8 @@ type HatcheryConfiguration struct {
 	WorkerTTL                  int                        `mapstructure:"workerTTL" toml:"workerTTL" default:"120" commented:"false" comment:"Worker TTL (minutes)" json:"workerTTL"`
 	WorkerRegistrationTTL      int                        `mapstructure:"workerRegistrationTTL" toml:"workerRegistrationTTL" commented:"false" comment:"Worker Registration TTL (minutes)" json:"workerRegistrationTTL"`
 	WorkerProvisioningInterval int                        `mapstructure:"workerProvisioningInterval" toml:"workerProvisioningInterval" commented:"true" comment:"Worker Provisioning interval (seconds)" json:"workerProvisioningInterval"`
+	KillAwolServersInterval    int                        `mapstructure:"killAwolServersInterval" toml:"killAwolServersInterval" commented:"true" comment:"Interval between cleanup passes of awol/finished servers (seconds). Default 60." json:"killAwolServersInterval"`
+	FinishedWorkerGracePeriod  int                        `mapstructure:"finishedWorkerGracePeriod" toml:"finishedWorkerGracePeriod" commented:"true" comment:"Grace period before deleting a powered-off worker VM that is no longer on the API side (seconds). Default 180." json:"finishedWorkerGracePeriod"`
 	WorkerProvisioningPoolSize int                        `mapstructure:"workerProvisioningPoolSize" toml:"workerProvisioningPoolSize" commented:"true" comment:"Worker Provisioning pool size" json:"workerProvisioningPoolSize"`
 	WorkerProvisioning         []WorkerProvisioningConfig `mapstructure:"workerProvisioning" toml:"workerProvisioning" commented:"true" comment:"Worker Provisioning per model name" json:"workerProvisioning"`
 	GuestCredentials           []GuestCredential          `mapstructure:"guestCredentials" toml:"guestCredentials" commented:"true" comment:"Deprecated: use [[models]] instead. List of Guest credentials" json:"-"`
@@ -114,7 +116,11 @@ type HatcheryVSphere struct {
 	availableNetworks    []availableNetwork
 	reservedIPAddresses  []string
 	provisioningPool     *provisioningPool
-	cachePendingJobID    struct {
+	// provisionSignal lets cleanup and spawn request an immediate provisioning
+	// refill instead of waiting for the next tick. Buffered (size 1) so a burst
+	// of requests coalesces into at most one pending run.
+	provisionSignal   chan struct{}
+	cachePendingJobID struct {
 		mu   sync.Mutex
 		list []string
 	}

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -115,18 +115,25 @@ type HatcheryVSphere struct {
 	availableIPAddresses []string // flat list kept for backward-compat checks (e.g. CanSpawn)
 	availableNetworks    []availableNetwork
 	reservedIPAddresses  []string
-	provisioningPool     *provisioningPool
 	// provisionSignal lets cleanup and spawn request an immediate provisioning
 	// refill instead of waiting for the next tick. Buffered (size 1) so a burst
 	// of requests coalesces into at most one pending run.
-	provisionSignal   chan struct{}
+	provisionSignal chan struct{}
+	// provisionSem optionally bounds concurrent provisioning operations
+	// (WorkerProvisioningPoolSize). nil means unbounded (maximize parallelism).
+	provisionSem      chan struct{}
 	cachePendingJobID struct {
 		mu   sync.Mutex
 		list []string
 	}
 	cacheProvisioning struct {
-		mu      sync.Mutex
-		pending []string
+		mu sync.Mutex
+		// pending maps the name of a provision VM currently being created/finished
+		// to its VMware model. It is an in-memory accelerator only: it is safe to
+		// lose on restart, since provisioningV2 reconstructs the real state from the
+		// vSphere VM list (annotation + power state). Used to avoid double-creating a
+		// clone whose VM is not yet visible in the inventory.
+		pending map[string]string
 		using   []string
 	}
 	cacheToDelete struct {

--- a/engine/hatchery/vsphere/vsphere.go
+++ b/engine/hatchery/vsphere/vsphere.go
@@ -45,6 +45,13 @@ type VSphereClient interface {
 	LoadVirtualMachineEvents(ctx context.Context, vm *object.VirtualMachine, eventTypes ...string) ([]types.BaseEvent, error)
 }
 
+// vmTaskTimeout bounds the wait for long-running vCenter tasks (clone, power
+// off, destroy). Without it these waits use the root context and a stuck vCenter
+// task hangs the caller forever — which, for the provisioning path, freezes all
+// future provisioning. It is generous (these tasks legitimately take minutes)
+// but finite, so a genuinely stuck task becomes a recoverable error.
+const vmTaskTimeout = 10 * time.Minute
+
 func NewVSphereClient(vclient *govmomi.Client, datacenter string) VSphereClient {
 	return &vSphereClient{
 		vclient:        vclient,
@@ -160,20 +167,20 @@ func (c *vSphereClient) StartVirtualMachine(ctx context.Context, vm *object.Virt
 func (c *vSphereClient) ShutdownVirtualMachine(ctx context.Context, vm *object.VirtualMachine) error {
 	log.Info(ctx, "shutdown server %v", vm.Name())
 
-	ctxC, cancelC := context.WithTimeout(ctx, c.requestTimeout)
+	ctxC, cancelC := context.WithTimeout(ctx, vmTaskTimeout)
 	defer cancelC()
 
 	task, err := vm.PowerOff(ctxC)
 	if err != nil {
 		return sdk.WithStack(err)
 	}
-	return sdk.WithStack(task.Wait(ctx))
+	return sdk.WithStack(task.Wait(ctxC))
 }
 
 func (c *vSphereClient) DestroyVirtualMachine(ctx context.Context, vm *object.VirtualMachine) error {
 	log.Info(ctx, "destroying server %v", vm.Name())
 
-	ctxD, cancelD := context.WithTimeout(ctx, c.requestTimeout)
+	ctxD, cancelD := context.WithTimeout(ctx, vmTaskTimeout)
 	defer cancelD()
 
 	task, err := vm.Destroy(ctxD)
@@ -181,7 +188,7 @@ func (c *vSphereClient) DestroyVirtualMachine(ctx context.Context, vm *object.Vi
 		return sdk.WithStack(err)
 	}
 
-	return sdk.WithStack(task.Wait(ctx))
+	return sdk.WithStack(task.Wait(ctxD))
 }
 
 func (c *vSphereClient) LoadFolder(ctx context.Context) (*object.Folder, error) {
@@ -269,12 +276,15 @@ func (c *vSphereClient) LoadDatastore(ctx context.Context, name string) (*object
 }
 
 func (c *vSphereClient) CloneVirtualMachine(ctx context.Context, vm *object.VirtualMachine, folder *object.Folder, name string, config *types.VirtualMachineCloneSpec) (*types.ManagedObjectReference, error) {
-	task, err := vm.Clone(ctx, folder, name, *config)
+	ctxT, cancel := context.WithTimeout(ctx, vmTaskTimeout)
+	defer cancel()
+
+	task, err := vm.Clone(ctxT, folder, name, *config)
 	if err != nil {
 		return nil, sdk.WrapError(err, "cannot clone VM name %v", name)
 	}
 
-	info, err := task.WaitForResult(ctx, nil)
+	info, err := task.WaitForResult(ctxT, nil)
 	if err != nil || info.State == types.TaskInfoStateError {
 		return nil, sdk.WrapError(err, "state in error: %+v", info)
 	}

--- a/engine/hatchery/vsphere/vsphere.go
+++ b/engine/hatchery/vsphere/vsphere.go
@@ -32,6 +32,7 @@ type VSphereClient interface {
 	GetVirtualMachinePowerState(ctx context.Context, vm *object.VirtualMachine) (types.VirtualMachinePowerState, error)
 	NewVirtualMachine(ctx context.Context, cloneSpec *types.VirtualMachineCloneSpec, ref *types.ManagedObjectReference, vmName string) (*object.VirtualMachine, error)
 	RenameVirtualMachine(ctx context.Context, vm *object.VirtualMachine, newName string) error
+	SetVirtualMachineAnnotation(ctx context.Context, vm *object.VirtualMachine, annotation string) error
 	WaitForVirtualMachineShutdown(ctx context.Context, vm *object.VirtualMachine) error
 	WaitForVirtualMachineIP(ctx context.Context, vm *object.VirtualMachine, IPAddress *string, vmName string) error
 	LoadFolder(ctx context.Context) (*object.Folder, error)
@@ -387,6 +388,26 @@ func (c *vSphereClient) RenameVirtualMachine(ctx context.Context, vm *object.Vir
 	}
 
 	*vm = *vm2
+
+	return nil
+}
+
+// SetVirtualMachineAnnotation overwrites the VM annotation (the persistent
+// vSphere "notes" field, read back as config.annotation). It is used to record
+// the worker start time at claim time so cleanup does not depend on vSphere
+// events, which age out of the event log.
+func (c *vSphereClient) SetVirtualMachineAnnotation(ctx context.Context, vm *object.VirtualMachine, annotation string) error {
+	ctxTo, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
+	task, err := vm.Reconfigure(ctxTo, types.VirtualMachineConfigSpec{Annotation: annotation})
+	if err != nil {
+		return sdk.WrapError(err, "unable to reconfigure annotation of vm %q", vm.Name())
+	}
+
+	if err := task.Wait(ctxTo); err != nil {
+		return sdk.WrapError(err, "annotation reconfigure task failed for vm %q", vm.Name())
+	}
 
 	return nil
 }


### PR DESCRIPTION
Powered-off worker VMs (failed spawns, crashes mid-spawn, or finished workers) could accumulate and never be cleaned up, each holding a reserved IP until the pool exhausted its IP range and could no longer spawn workers.

killAwolServers derived a VM's start time only from vSphere events, and kept the VM forever when none was found. That happens when the worker never really started or when the start event aged out of vCenter's event retention.

Record the worker start time in the VM annotation at claim time and make killAwolServers decide from that stored time plus the VM's live power state, dropping its dependency on events:
- Add a SetVirtualMachineAnnotation client method (ReconfigVM_Task) and stamp WorkerStartTime (+JobID, Provisioning=false) when a provision is claimed, before power-on, preserving the reserved IP and model path.
- killAwolServers: powered-off VMs are removed after WorkerRegistrationTTL, powered-on registered workers after WorkerTTL, powered-on unregistered ones after WorkerRegistrationTTL. VMs predating this change fall back to the vSphere CreateDate so they are still reclaimed.

Also harden the spawn sequence so a failure never leaves a partially configured worker behind: a single deferred teardown releases the provision and marks the VM for deletion on any error, and power-on is retried within a bounded budget to tolerate a VM that is not immediately startable after reconfigure.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
