### PR TITLE
fix(api): avoid time.NewTicker panic in WorkflowRunJobDeletion

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -975,7 +975,7 @@ func (a *API) Serve(ctx context.Context) error {
 		a.WorkflowRunCraft(ctx, 100*time.Millisecond)
 	})
 	a.GoRoutines.RunWithRestart(ctx, "api.WorkflowRunJobDeletion", func(ctx context.Context) {
-		a.WorkflowRunJobDeletion(ctx, time.Duration(10*rand.Float64())*time.Second, 10)
+		a.WorkflowRunJobDeletion(ctx, time.Duration((1+9*rand.Float64())*float64(time.Second)), 10)
 	})
 	a.GoRoutines.RunWithRestart(ctx, "api.V2WorkflowRunCraft", func(ctx context.Context) {
 		a.V2WorkflowRunCraft(ctx, 10*time.Second)

--- a/engine/api/workflow_run_craft.go
+++ b/engine/api/workflow_run_craft.go
@@ -168,6 +168,9 @@ func (api *API) workflowRunCraft(ctx context.Context, id int64) error {
 }
 
 func (api *API) WorkflowRunJobDeletion(ctx context.Context, tick time.Duration, limit int) {
+	if tick <= 0 {
+		tick = 10 * time.Second
+	}
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 


### PR DESCRIPTION
The deletion ticker interval was computed as
`time.Duration(10*rand.Float64())*time.Second`. The float64-to-Duration conversion truncates before the multiplication, so the interval was always an integer number of seconds in {0..9}. Whenever rand.Float64() < 0.1 (~10% of the time) it yielded 0, and time.NewTicker(0) panics with "non-positive interval for NewTicker".

Compute the Duration after multiplying by float64(time.Second), bounded to [1s, 10s), and add a defensive guard in WorkflowRunJobDeletion so any non-positive tick falls back to 10s.
