### PR TITLE
feat(hatchery/openstack): add per-image worker basedir override

### DIFF
--- a/engine/hatchery/openstack/init.go
+++ b/engine/hatchery/openstack/init.go
@@ -61,6 +61,7 @@ func (h *HatcheryOpenstack) InitHatchery(ctx context.Context) error {
 
 	h.initImagesUsername(ctx)
 	h.initImagesBookDelay()
+	h.initImagesWorkerBasedir()
 
 	h.GoRoutines.Run(ctx, "hatchery openstack routines", func(ctx context.Context) {
 		h.main(ctx)
@@ -139,6 +140,14 @@ func (h *HatcheryOpenstack) initImagesBookDelay() {
 
 	for _, override := range h.Config.OverrideImagesBookDelay {
 		h.imagesBookDelay[regexp.MustCompile(override.Image)] = override.Delay
+	}
+}
+
+func (h *HatcheryOpenstack) initImagesWorkerBasedir() {
+	h.imagesWorkerBasedir = make(map[*regexp.Regexp]string)
+
+	for _, override := range h.Config.OverrideImagesWorkerBasedir {
+		h.imagesWorkerBasedir[regexp.MustCompile(override.Image)] = override.Basedir
 	}
 }
 

--- a/engine/hatchery/openstack/openstack.go
+++ b/engine/hatchery/openstack/openstack.go
@@ -161,6 +161,10 @@ func (h *HatcheryOpenstack) CheckConfiguration(cfg interface{}) error {
 		return fmt.Errorf("invalid inject SSH public keys: %w", err)
 	}
 
+	if err := h.checkOverrideImagesWorkerBasedir(hconfig.OverrideImagesWorkerBasedir); err != nil {
+		return fmt.Errorf("invalid image worker basedir override: %w", err)
+	}
+
 	return nil
 }
 
@@ -176,6 +180,20 @@ func (h *HatcheryOpenstack) checkOverrideImagesUsername(overrides []ImageUsernam
 
 		if !usernameRe.MatchString(override.Username) {
 			return fmt.Errorf("invalid username %q: must match %s", override.Username, usernameRe.String())
+		}
+	}
+
+	return nil
+}
+
+func (h *HatcheryOpenstack) checkOverrideImagesWorkerBasedir(overrides []ImageWorkerBasedirOverride) error {
+	for _, override := range overrides {
+		if _, err := regexp.Compile(override.Image); err != nil {
+			return fmt.Errorf("invalid image expression %q: %w", override.Image, err)
+		}
+
+		if !strings.HasPrefix(override.Basedir, "/") {
+			return fmt.Errorf("invalid basedir %q: must be an absolute path", override.Basedir)
 		}
 	}
 
@@ -200,6 +218,15 @@ func (h *HatcheryOpenstack) GetImageUsername(ctx context.Context, imageName stri
 	for image, username := range h.imagesUsername {
 		if image.MatchString(imageName) {
 			return username
+		}
+	}
+	return ""
+}
+
+func (h *HatcheryOpenstack) GetImageWorkerBasedir(ctx context.Context, imageName string) string {
+	for image, basedir := range h.imagesWorkerBasedir {
+		if image.MatchString(imageName) {
+			return basedir
 		}
 	}
 	return ""

--- a/engine/hatchery/openstack/openstack_test.go
+++ b/engine/hatchery/openstack/openstack_test.go
@@ -285,6 +285,88 @@ func TestHatcheryOpenstack_checkOverrideImagesUsername(t *testing.T) {
 	}
 }
 
+func TestHatcheryOpenstack_checkOverrideImagesWorkerBasedir(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides []ImageWorkerBasedirOverride
+		wantErr   bool
+	}{
+		{
+			name:      "empty",
+			overrides: []ImageWorkerBasedirOverride{},
+		},
+		{
+			name:      "nil",
+			overrides: nil,
+		},
+		{
+			name: "valid-values",
+			overrides: []ImageWorkerBasedirOverride{
+				{
+					Image:   "foo",
+					Basedir: "/var/lib/cds-worker",
+				},
+				{
+					Image:   "^foo-[a-z]+",
+					Basedir: "/opt/cds/worker",
+				},
+			},
+		},
+		{
+			name: "invalid-image-regexp",
+			overrides: []ImageWorkerBasedirOverride{
+				{
+					Image:   "foo[",
+					Basedir: "/var/lib/cds-worker",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "relative-basedir",
+			overrides: []ImageWorkerBasedirOverride{
+				{
+					Image:   "^foo$",
+					Basedir: "var/lib/cds-worker",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty-basedir",
+			overrides: []ImageWorkerBasedirOverride{
+				{
+					Image:   "^foo$",
+					Basedir: "",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HatcheryOpenstack{}
+			if err := h.checkOverrideImagesWorkerBasedir(tt.overrides); (err != nil) != tt.wantErr {
+				t.Errorf("HatcheryOpenstack.checkOverrideImagesWorkerBasedir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHatcheryOpenstack_GetImageWorkerBasedir(t *testing.T) {
+	h := &HatcheryOpenstack{
+		Config: HatcheryConfiguration{
+			OverrideImagesWorkerBasedir: []ImageWorkerBasedirOverride{
+				{Image: "^Debian 12", Basedir: "/var/lib/cds-worker"},
+			},
+		},
+	}
+	h.initImagesWorkerBasedir()
+
+	require.Equal(t, "/var/lib/cds-worker", h.GetImageWorkerBasedir(context.TODO(), "Debian 12 - IAAS"))
+	require.Equal(t, "", h.GetImageWorkerBasedir(context.TODO(), "Ubuntu 22.04"))
+}
+
 func TestHatcheryOpenstack_checkInjectSSHPublicKeys(t *testing.T) {
 	rsa, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)

--- a/engine/hatchery/openstack/spawn.go
+++ b/engine/hatchery/openstack/spawn.go
@@ -95,6 +95,9 @@ func (h *HatcheryOpenstack) SpawnWorker(ctx context.Context, spawnArgs hatchery.
 		}
 	}
 	workerConfig := h.GenerateWorkerConfig(ctx, h, spawnArgs)
+	if basedir := h.GetImageWorkerBasedir(ctx, spawnArgs.Model.GetOpenstackImage()); basedir != "" {
+		workerConfig.Basedir = basedir
+	}
 
 	udataParam := struct {
 		// All fields below are deprecated

--- a/engine/hatchery/openstack/types.go
+++ b/engine/hatchery/openstack/types.go
@@ -77,6 +77,9 @@ type HatcheryConfiguration struct {
 	// OverrideImagesBookDelay define the worker book delay to use for the specified image.
 	OverrideImagesBookDelay []ImageBookDelayOverride `mapstructure:"overrideImagesBookDelay" toml:"overrideImagesBookDelay" default:"" commented:"true" comment:"Override the book delay used for the images" json:"overrideImagesBookDelay"`
 
+	// OverrideImagesWorkerBasedir define the worker basedir to use for the specified image.
+	OverrideImagesWorkerBasedir []ImageWorkerBasedirOverride `mapstructure:"overrideImagesWorkerBasedir" toml:"overrideImagesWorkerBasedir" default:"" commented:"true" comment:"Override the worker basedir used for the images" json:"overrideImagesWorkerBasedir"`
+
 	// InjectSSHPublicKeys define the list of SSH public keys to inject into spawned workers
 	InjectSSHPublicKeys []string `mapstructure:"injectSSHPublicKeys" toml:"injectSSHPublicKeys" default:"" commented:"true" comment:"List of SSH public keys to inject into spawned workers" json:"injectSSHPublicKeys"`
 
@@ -92,8 +95,9 @@ type HatcheryOpenstack struct {
 	openstackClient *gophercloud.ServiceClient
 	cache           *cache
 	networkID       string                    // computed from networkString
-	imagesUsername  map[*regexp.Regexp]string // computed from initImagesUsername
-	imagesBookDelay map[*regexp.Regexp]int64  // computed from initBookDelay
+	imagesUsername      map[*regexp.Regexp]string // computed from initImagesUsername
+	imagesBookDelay     map[*regexp.Regexp]int64  // computed from initBookDelay
+	imagesWorkerBasedir map[*regexp.Regexp]string // computed from initImagesWorkerBasedir
 }
 
 type ipInfos struct {
@@ -109,4 +113,9 @@ type ImageUsernameOverride struct {
 type ImageBookDelayOverride struct {
 	Image string `mapstructure:"image" toml:"image" default:"" commented:"true" comment:"The image name regular expression." json:"image"`
 	Delay int64  `mapstructure:"delay" toml:"delay" default:"" commented:"true" comment:"The delay to use (in seconds)." json:"delay"`
+}
+
+type ImageWorkerBasedirOverride struct {
+	Image   string `mapstructure:"image" toml:"image" default:"" commented:"true" comment:"The image name regular expression." json:"image"`
+	Basedir string `mapstructure:"basedir" toml:"basedir" default:"" commented:"true" comment:"The worker basedir to use. Must be an absolute path on an exec-allowed, non-world-writable filesystem (e.g. /var/lib/cds-worker)." json:"basedir"`
 }


### PR DESCRIPTION
Add an overrideImagesWorkerBasedir config option allowing the worker basedir to be set per image (matched by name regexp), instead of only globally via provision.workerBasedir. This relocates the worker working directory (where downloaded GRPC plugins are written and executed) off the default temp dir for the matching images.

Mirrors the existing overrideImagesUsername / overrideImagesBookDelay patterns: config struct, init-time regexp map, getter, and validation. The override is applied after GenerateWorkerConfig so it takes precedence over the global basedir, and keys off the resolved image name so it works for both v1 and v2 worker models.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
