### PR TITLE
feat(hatchery/openstack): log worker basedir override and surface it …

### DIFF
--- a/engine/hatchery/openstack/init.go
+++ b/engine/hatchery/openstack/init.go
@@ -148,7 +148,9 @@ func (h *HatcheryOpenstack) initImagesWorkerBasedir() {
 
 	for _, override := range h.Config.OverrideImagesWorkerBasedir {
 		h.imagesWorkerBasedir[regexp.MustCompile(override.Image)] = override.Basedir
+		log.Info(context.Background(), "initImagesWorkerBasedir> registered worker basedir override: image=%q basedir=%q", override.Image, override.Basedir)
 	}
+	log.Info(context.Background(), "initImagesWorkerBasedir> %d worker basedir override(s) configured", len(h.imagesWorkerBasedir))
 }
 
 // initIPStatus initializes ipsInfos to

--- a/engine/hatchery/openstack/openstack.go
+++ b/engine/hatchery/openstack/openstack.go
@@ -226,9 +226,11 @@ func (h *HatcheryOpenstack) GetImageUsername(ctx context.Context, imageName stri
 func (h *HatcheryOpenstack) GetImageWorkerBasedir(ctx context.Context, imageName string) string {
 	for image, basedir := range h.imagesWorkerBasedir {
 		if image.MatchString(imageName) {
+			log.Info(ctx, "GetImageWorkerBasedir> image %q matched override %q, using basedir %q", imageName, image.String(), basedir)
 			return basedir
 		}
 	}
+	log.Info(ctx, "GetImageWorkerBasedir> no worker basedir override matched image %q (%d override(s) configured)", imageName, len(h.imagesWorkerBasedir))
 	return ""
 }
 

--- a/engine/hatchery/openstack/spawn.go
+++ b/engine/hatchery/openstack/spawn.go
@@ -95,8 +95,20 @@ func (h *HatcheryOpenstack) SpawnWorker(ctx context.Context, spawnArgs hatchery.
 		}
 	}
 	workerConfig := h.GenerateWorkerConfig(ctx, h, spawnArgs)
-	if basedir := h.GetImageWorkerBasedir(ctx, spawnArgs.Model.GetOpenstackImage()); basedir != "" {
+	openstackImage := spawnArgs.Model.GetOpenstackImage()
+	if basedir := h.GetImageWorkerBasedir(ctx, openstackImage); basedir != "" {
+		log.Info(ctx, "SpawnWorker> overriding worker basedir for image %q: %q -> %q", openstackImage, workerConfig.Basedir, basedir)
 		workerConfig.Basedir = basedir
+		hatcheryBasedirInfo := sdk.V2SendJobRunInfo{
+			Level:   sdk.WorkflowRunInfoLevelInfo,
+			Time:    time.Now(),
+			Message: fmt.Sprintf("Hatchery %q is configured to use the worker basedir '%s' for this worker", h.Name(), basedir),
+		}
+		if err := h.CDSClientV2().V2QueuePushJobInfo(ctx, spawnArgs.Region, spawnArgs.JobID, hatcheryBasedirInfo); err != nil {
+			log.ErrorWithStackTrace(ctx, err)
+		}
+	} else {
+		log.Info(ctx, "SpawnWorker> no worker basedir override for image %q, keeping basedir %q", openstackImage, workerConfig.Basedir)
 	}
 
 	udataParam := struct {


### PR DESCRIPTION
…in job info

Add debug logs along the per-image worker basedir override path (config load, image match, spawn-time apply) to ease diagnosing why an override does not take effect, and push a job run info message when the override applies so it is visible in the job run feed, mirroring the existing username override behavior.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
