### PR TITLE
fix(sdk): increase worker v2 client timeouts and stop retrying on exp…

### DIFF
--- a/sdk/cdsclient/client_worker_v2.go
+++ b/sdk/cdsclient/client_worker_v2.go
@@ -37,7 +37,9 @@ func (c *client) V2WorkerGet(ctx context.Context, name string, mods ...RequestMo
 }
 
 func (c *client) V2QueueWorkerTakeJob(ctx context.Context, region, runJobID string) (*sdk.V2TakeJobResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// The timeout must be higher than the API processing time: a take that times out client-side
+	// but commits API-side leaves the job Building with no worker attached.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	var takenJob sdk.V2TakeJobResponse
 	url := fmt.Sprintf("/v2/queue/%s/job/%s/worker/take", region, runJobID)
@@ -48,7 +50,7 @@ func (c *client) V2QueueWorkerTakeJob(ctx context.Context, region, runJobID stri
 }
 
 func (c *client) V2WorkerRefresh(ctx context.Context, region, runJobID string) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	url := fmt.Sprintf("/v2/queue/%s/job/%s/worker/refresh", region, runJobID)
 	if _, err := c.PostJSON(ctx, url, nil, nil); err != nil {
@@ -58,7 +60,7 @@ func (c *client) V2WorkerRefresh(ctx context.Context, region, runJobID string) e
 }
 
 func (c *client) V2WorkerRegister(ctx context.Context, authToken string, form sdk.WorkerRegistrationForm, region, runJobID string) (*sdk.V2Worker, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	var w sdk.V2Worker
@@ -83,7 +85,7 @@ func (c *client) V2WorkerRegister(ctx context.Context, authToken string, form sd
 }
 
 func (c *client) V2WorkerUnregister(ctx context.Context, region, runJobID string) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	path := fmt.Sprintf("/v2/queue/%s/job/%s/worker/signout", region, runJobID)
 	if _, err := c.PostJSON(ctx, path, nil, nil); err != nil {

--- a/sdk/cdsclient/http.go
+++ b/sdk/cdsclient/http.go
@@ -359,7 +359,9 @@ func (c *client) Stream(ctx context.Context, httpClient HTTPClient, method strin
 
 	var savederror error
 	var savedCodeError int
+	var attempts int
 	for i := 0; i <= c.config.Retry; i++ {
+		attempts++
 		var req *http.Request
 		if rs, ok := body.(io.ReadSeeker); ok {
 			if _, err := rs.Seek(0, 0); err != nil {
@@ -421,8 +423,12 @@ func (c *client) Stream(ctx context.Context, httpClient HTTPClient, method strin
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			time.Sleep(250 * time.Millisecond)
 			savederror = newTransportError(err)
+			// The context is expired, no attempt can succeed anymore
+			if ctx.Err() != nil {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
 			continue
 		}
 
@@ -440,8 +446,12 @@ func (c *client) Stream(ctx context.Context, httpClient HTTPClient, method strin
 		}
 
 		if resp.StatusCode == 409 || resp.StatusCode >= 500 {
-			time.Sleep(250 * time.Millisecond)
 			savederror = extractBodyErrorFromResponse(resp)
+			// The context is expired, no attempt can succeed anymore
+			if ctx.Err() != nil {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
 			continue
 		}
 		return resp.Body, resp.Header, resp.StatusCode, nil
@@ -450,7 +460,7 @@ func (c *client) Stream(ctx context.Context, httpClient HTTPClient, method strin
 	if savedCodeError == 409 {
 		return nil, nil, savedCodeError, savederror
 	}
-	return nil, nil, savedCodeError, newError(fmt.Errorf("request failed after %d retries: %v savedCodeError: %d", c.config.Retry, savederror, savedCodeError))
+	return nil, nil, savedCodeError, newError(fmt.Errorf("request failed after %d attempts: %v savedCodeError: %d", attempts, savederror, savedCodeError))
 }
 
 // UploadMultiPart upload multipart


### PR DESCRIPTION
…ired context

The worker v2 lifecycle calls (take, refresh, signin, signout) used a hard-coded 5s timeout. A take slower than 5s on the API side made the client give up while the API still committed the job to Building, leaving it without a worker attached. Raise the timeout to 30s.

Also make the HTTP client retry loop stop as soon as the context is expired instead of consuming all remaining attempts on a dead context, and report the number of attempts actually made in the error message.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
