### PR TITLE
feat(hatchery): make register container memory configurable

### DIFF
--- a/engine/hatchery/kubernetes/kubernetes.go
+++ b/engine/hatchery/kubernetes/kubernetes.go
@@ -302,6 +302,9 @@ func (h *HatcheryKubernetes) SpawnWorker(ctx context.Context, spawnArgs hatchery
 	if spawnArgs.RegisterOnly {
 		cmd += " register"
 		memory = hatchery.MemoryRegisterContainer
+		if h.Config.RegisterMemory > 0 {
+			memory = int64(h.Config.RegisterMemory)
+		}
 	}
 
 	envsWm := workerConfig.InjectEnvVars

--- a/engine/hatchery/kubernetes/types.go
+++ b/engine/hatchery/kubernetes/types.go
@@ -23,6 +23,8 @@ type HatcheryConfiguration struct {
 	DisableCPULimit bool   `mapstructure:"disableCPULimit" toml:"disableCPULimit" default:"false" commented:"false" comment:"Disable Worker default CPU" json:"disableCPULimit"`
 	// DefaultMemory Worker default memory
 	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"false" comment:"Worker default memory in Mo" json:"defaultMemory"`
+	// RegisterMemory Memory allocated to pods spawned to register a worker model
+	RegisterMemory int `mapstructure:"registerMemory" toml:"registerMemory" default:"128" commented:"true" comment:"Memory in Mo allocated to pods spawned to register a worker model" json:"registerMemory"`
 	// DefaultEphemeralStorage Worker default ephemeral storage size
 	DefaultEphemeralStorage string `mapstructure:"defaultEphemeralStorage" toml:"defaultEphemeralStorage" default:"1Gi" commented:"false" comment:"Worker default ephemeral storage size" json:"defaultEphemeralStorage"`
 	// DefaultServiceCPU Service default CPU

--- a/engine/hatchery/swarm/swarm.go
+++ b/engine/hatchery/swarm/swarm.go
@@ -404,6 +404,9 @@ func (h *HatcherySwarm) SpawnWorker(ctx context.Context, spawnArgs hatchery.Spaw
 	if spawnArgs.RegisterOnly {
 		cmd += " register"
 		memory = hatchery.MemoryRegisterContainer
+		if h.Config.RegisterMemory > 0 {
+			memory = int64(h.Config.RegisterMemory)
+		}
 	}
 
 	// labels are used to make container cleanup easier

--- a/engine/hatchery/swarm/types.go
+++ b/engine/hatchery/swarm/types.go
@@ -26,7 +26,9 @@ type HatcheryConfiguration struct {
 	MaxContainers int `mapstructure:"maxContainers" toml:"maxContainers" default:"10" commented:"false" comment:"Max Containers on Host managed by this Hatchery" json:"maxContainers"`
 
 	// DefaultMemory Worker default memory
-	DefaultMemory     int  `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"false" comment:"Worker default memory in Mo" json:"defaultMemory"`
+	DefaultMemory int `mapstructure:"defaultMemory" toml:"defaultMemory" default:"1024" commented:"false" comment:"Worker default memory in Mo" json:"defaultMemory"`
+	// RegisterMemory Memory allocated to containers spawned to register a worker model
+	RegisterMemory    int  `mapstructure:"registerMemory" toml:"registerMemory" default:"128" commented:"true" comment:"Memory in Mo allocated to containers spawned to register a worker model" json:"registerMemory"`
 	DisableMemorySwap bool `mapstructure:"disableMemorySwap" toml:"disableMemorySwap" default:"false" commented:"true" comment:"Set to true to disable memory swap" json:"disableMemorySwap"`
 
 	// DockerOpts Docker options

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -583,8 +583,9 @@ func canRunJob(ctx context.Context, h Interface, j workerStarterRequest) bool {
 	return h.CanSpawn(ctx, j.model, j.id, j.requirements)
 }
 
-// MemoryRegisterContainer is the RAM used for spawning
-// a docker container for register a worker model. 128 Mo
+// MemoryRegisterContainer is the default RAM (in Mo) used for spawning
+// a docker container for register a worker model, when the hatchery
+// configuration does not set registerMemory
 const MemoryRegisterContainer int64 = 128
 
 func canRunJobWithModelV2(ctx context.Context, h InterfaceWithModels, j workerStarterRequest, workerModelV2 string) (*sdk.Model, *sdk.WorkerStarterWorkerModel, error) {


### PR DESCRIPTION
Containers spawned to register a worker model had a hard-coded 128 Mo memory limit, which can be too low and make the worker crash with 'fatal error: runtime: cannot allocate memory' during registration.

Add a registerMemory option to the swarm and kubernetes hatchery configurations. It defaults to 128 Mo and falls back to the previous constant when unset, so existing deployments are unaffected.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
