### PR TITLE
fix(sdk/helm): use helm repository config when updating chart deps

### DIFF
--- a/sdk/helm/helm.go
+++ b/sdk/helm/helm.go
@@ -115,11 +115,17 @@ func UpdateDependencies(chartPath string, skipUpdate bool) error {
 		return nil
 	}
 
+	// RepositoryConfig and RepositoryCache must be set, otherwise the manager reads
+	// no repository at all: every dependency is then resolved as an unmanaged repository,
+	// fetched anonymously, and fails on private repositories.
 	downloadManager := &downloader.Manager{
-		Out:       os.Stdout,
-		ChartPath: chartPath,
-		Getters:   getter.All(settings),
-		Debug:     v2settings.Debug,
+		Out:              os.Stdout,
+		ChartPath:        chartPath,
+		Getters:          getter.All(settings),
+		RepositoryConfig: settings.RepositoryConfig,
+		RepositoryCache:  settings.RepositoryCache,
+		SkipUpdate:       skipUpdate,
+		Debug:            settings.Debug,
 	}
 	if err := downloadManager.Update(); err != nil {
 		return err


### PR DESCRIPTION
The download manager used by actions/helmPush was built without RepositoryConfig and RepositoryCache. Helm then reads an empty repository list, resolves every dependency as an unmanaged repository and fetches its index anonymously, which fails with a 401 on any private repository even though the repo was properly registered and authenticated in the job.

Pass the values already resolved by cli.New() from HELM_REPOSITORY_CONFIG and HELM_REPOSITORY_CACHE.