### PR TITLE
feat(hatchery/vsphere): support models driven through guestinfo

### DIFF
--- a/engine/hatchery/openstack/openstack.go
+++ b/engine/hatchery/openstack/openstack.go
@@ -15,9 +15,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gorilla/mux"
 	"github.com/rockbears/log"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
@@ -201,17 +201,7 @@ func (h *HatcheryOpenstack) checkOverrideImagesWorkerBasedir(overrides []ImageWo
 }
 
 func (h *HatcheryOpenstack) checkInjectSSHPublicKeys(publicKeys []string) error {
-	for _, publicKey := range publicKeys {
-		_, _, options, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
-		if err != nil {
-			return fmt.Errorf("invalid public key %q: %w", publicKey, err)
-		}
-		if len(options) == 0 || !slices.ContainsFunc(options, func(o string) bool { return strings.HasPrefix(o, "from=") }) {
-			return fmt.Errorf("invalid public key %q: from option is missing", publicKey)
-		}
-	}
-
-	return nil
+	return hatcheryCommon.CheckInjectSSHPublicKeys(publicKeys)
 }
 
 func (h *HatcheryOpenstack) GetImageUsername(ctx context.Context, imageName string) string {

--- a/engine/hatchery/sshkeys.go
+++ b/engine/hatchery/sshkeys.go
@@ -1,0 +1,28 @@
+package hatchery
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// CheckInjectSSHPublicKeys validates the SSH public keys a hatchery injects into
+// the workers it spawns. Each entry must be a complete authorized_keys line
+// carrying a from= option: the keys grant shell access to a machine running CI
+// payloads, so they must state which source addresses may use them rather than
+// being usable from anywhere.
+func CheckInjectSSHPublicKeys(publicKeys []string) error {
+	for _, publicKey := range publicKeys {
+		_, _, options, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+		if err != nil {
+			return fmt.Errorf("invalid public key %q: %w", publicKey, err)
+		}
+		if len(options) == 0 || !slices.ContainsFunc(options, func(o string) bool { return strings.HasPrefix(o, "from=") }) {
+			return fmt.Errorf("invalid public key %q: from option is missing", publicKey)
+		}
+	}
+
+	return nil
+}

--- a/engine/hatchery/vsphere/README.md
+++ b/engine/hatchery/vsphere/README.md
@@ -67,8 +67,10 @@ The hatchery is configured via `HatcheryConfiguration`, serialized as TOML.
 | `workerProvisioningPoolSize` | `int` | `0` | No | Optional cap on concurrent provisioning clones. `0` = unbounded (clones run fully in parallel, bounded by the deficit and IP budget) |
 | `workerProvisioning` | `[]WorkerProvisioningConfig` | — | No | List of models to pre-provision |
 | `guestCredentials` | `[]GuestCredential` | — | No | **Deprecated**: use `models` instead. Guest OS credentials per model |
-| `models` | `[]ModelConfig` | — | No | Per-model configuration (credentials, pre-start script) |
+| `models` | `[]ModelConfig` | — | No | Per-model configuration (credentials, pre-start script, guestinfo mode) |
 | `defaultWorkerModelsV2` | `[]DefaultWorkerModelsV2` | — | No | Default V2 models used to run V1 jobs (binary matching) |
+| `sshAllowedCIDRs` | `[]string` | — | No | Guestinfo models only. CIDRs allowed to reach workers over SSH, applied as a packet-filter allowlist in the guest (see section 3.5) |
+| `injectSSHPublicKeys` | `[]string` | — | No | Guestinfo models only. SSH public keys to inject into spawned workers; each must carry a `from=` option (see section 3.5) |
 
 ### 3.1.2 Networks Configuration
 
@@ -121,6 +123,7 @@ type ModelConfig struct {
     Username       string  // Guest OS username
     Password       string  // Guest OS password
     PreStartScript string  // Shell script executed inside the VM before the worker starts
+    GuestInfo      bool    // Drive the model through guestinfo (see section 3.5)
 }
 ```
 
@@ -156,6 +159,78 @@ type DefaultWorkerModelsV2 struct {
 
 Used to bridge V1 jobs (which select models by binary requirements) to V2 worker models.
 
+### 3.5 Guestinfo Models
+
+Some guest OSes cannot be driven the default way. The vSphere customization engine (GOSC) has no
+support for them, and a credential-less image offers no account for guest operations to
+authenticate against. FreeBSD is both. Such a model is declared with `guestInfo = true` in its
+`models` entry, and everything the guest needs is handed over as **guestinfo** keys instead: plain
+VM metadata, always accepted regardless of guest OS, read by the guest at every boot.
+
+```toml
+[[hatchery.vsphere.models]]
+  modelVMWare = "freebsd14"
+  guestInfo = true
+  # no username/password: the image is credential-less
+
+# Optional debug access. Left unset, workers accept no inbound SSH at all —
+# the intended default.
+[hatchery.vsphere]
+  sshAllowedCIDRs = ["10.0.0.0/24"]
+  injectSSHPublicKeys = [
+    "from=\"10.0.0.0/24\" ssh-ed25519 AAAAC3Nza... ops@example",
+  ]
+```
+
+These are **two independent layers, and neither substitutes for the other**:
+
+- `sshAllowedCIDRs` is a **network-level allowlist**. The guest is expected to load it into a
+  packet filter that denies inbound by default, so SSH from anywhere else is dropped before sshd
+  is ever reached. Omit it and the worker is unreachable no matter which keys are injected.
+- `injectSSHPublicKeys` is what **sshd then authenticates**, as in the OpenStack hatchery. Each
+  key must carry a `from=` option restricting its source addresses; `CheckConfiguration` rejects
+  the configuration otherwise, so an injected key can never be usable from anywhere. That
+  validation is shared with the OpenStack hatchery (`hatchery.CheckInjectSSHPublicKeys`).
+
+Malformed CIDRs are rejected at startup too: a bad entry would otherwise yield a silently broken
+allowlist.
+
+| Key | Written at | Value |
+|-----|-----------|-------|
+| `guestinfo.cds.net.ip` / `.mask` / `.gateway` / `.dns` / `.hostname` | Clone (provision) | Allocated IP, dotted-quad mask, gateway, DNS, VM name |
+| `guestinfo.cds.access.allowed_cidrs` | Clone, only when configured | `sshAllowedCIDRs` joined by spaces, for the guest's packet-filter allowlist |
+| `guestinfo.cds.access.authorized_keys` | Clone, only when configured | `injectSSHPublicKeys` joined by newline, i.e. an `authorized_keys` body |
+| `guestinfo.cds.cmd` / `.config` | Spawn, before power-on | Assembled worker command; base64(JSON) worker config, passed verbatim to the worker's `CDS_CONFIG` |
+| `guestinfo.cds.net.hostname` | Spawn, before power-on | Re-emitted with the worker name, the VM having been renamed out of its provision name |
+
+`provision.injectEnvVars` are **not** emitted as separate keys: the worker reads them from the
+config it decodes out of `cds.config`, so a copy would never be read — and it would outlive the
+config, which the guest scrubs once consumed.
+
+This is a contract: the hatchery emits these keys, and the guest image is responsible for acting
+on them at boot. An image implementing it must:
+
+- apply `cds.net.*` on **every** boot, the same VM being booted once to provision and again to
+  run a worker;
+- **no-op when `cds.cmd` is unset**. This is what makes the **provision boot** harmless: the
+  network is applied, the VM gets its IP, and it shuts down without ever starting a worker. The
+  worker only starts on the **spawn boot**, once `cds.cmd` and `cds.config` are in place;
+- scrub `cds.config` in-guest once consumed, since guestinfo values otherwise persist in the VM
+  config in clear text. Worker tokens should be short-lived regardless.
+
+`guestInfo` is the single gate for both the clone and the spawn path. It cannot be derived from
+the model's `OSArch`, because the provisioning loop only ever knows the VMware template name —
+never a CDS worker model. A clone made with guest customization cannot be bootstrapped through
+guestinfo, so the two must agree, and reading one flag on both paths is what guarantees it.
+
+Forgetting the flag on a model whose image needs it is therefore a configuration error the
+hatchery cannot detect: the clone applies a customization the guest ignores, the provision never
+reports an IP, and it is marked for deletion by `finishProvisioning`. The symptom is a model that
+never manages to provision.
+
+The commands wrapping the worker (download, start, power off) are not model fields; CDS derives
+them from the model's `osarch` — see §4.1.
+
 ## 4. Worker Models
 
 The vSphere hatchery only supports **Worker Model V2**. Worker Model V1 (CDS models that were registered
@@ -190,6 +265,28 @@ type V2WorkerModelVSphereSpec struct {
 For V2, the template must already exist in vSphere. The hatchery does **not** create or manage templates
 for V2 models. Guest credentials can be specified either in the model spec or in the hatchery
 `models` configuration (which takes precedence over the model spec).
+
+A guestinfo model (§3.5) carries no credentials at all:
+
+```yaml
+name: my-freebsd-worker
+type: vsphere
+osarch: freebsd/amd64
+spec:
+  image: "freebsd14"   # requires guestInfo = true in the hatchery models config
+```
+
+The commands that download and start the worker, and the one that powers the VM off afterwards,
+are not part of the model: CDS derives them from `osarch` (`sdk/hatchery`). The download URL
+carries the model's `osarch`, so the guest gets a matching binary rather than the Linux one, and
+a `freebsd/*` model is powered off with `shutdown -p now` — `-h` would halt the OS but leave the
+VM powered on as far as vSphere is concerned, so the provision would never be reclaimed. No
+`sudo` is involved either, the worker being started as root by the guest's boot script.
+
+The image must provide `curl` (or `wget`), as every other CDS worker model does.
+
+As on the guest-operations path, the hatchery redirects the worker's stdout and stderr to
+`/tmp/worker.log` inside the guest.
 
 ## 5. VM Annotations
 
@@ -259,8 +356,10 @@ SpawnWorker(spawnArgs)
 │   ├── Rename to the worker name
 │   ├── Stamp the annotation with WorkerStartTime (+ JobID, Provisioning=false)
 │   │   before power-on, preserving the reserved IP and VMware model path
+│   ├── If guestinfo model: push guestinfo.cds.{cmd,config} — BEFORE power-on
 │   ├── Power on (bounded retry, tolerates a VM not yet startable after reconfigure)
 │   ├── Wait for the reserved IP
+│   ├── Guestinfo model: DONE — the guest starts the worker itself at boot
 │   ├── Wait for guest operations readiness, run the pre-start script (if any)
 │   └── Launch worker script via guest operations → DONE
 │
@@ -284,7 +383,9 @@ scheduler, see §6.3):
 - **Datastore**: Relocates the VM to the configured datastore
 - **Disk**: Uses `MoveChildMostDiskBacking` disk move type (linked clone)
 - **Customization**: Linux prep with auto-generated hostname. If IP range is configured, assigns
-  a static IP with subnet mask, gateway, and DNS
+  a static IP with subnet mask, gateway, and DNS. **Guestinfo models carry no customization spec
+  at all** — their network goes into `ExtraConfig` as `guestinfo.cds.net.*` instead (see §3.5).
+  Either way the assigned IP is recorded in the annotation, which is what `getUsedIPs` reads
 - **Annotation**: Serializes the `annotation` struct as JSON into `VirtualMachineConfigSpec.Annotation`
 - **Power On**: `PowerOn: true`, the VM boots immediately to complete its provisioning
 - **VM Tools**: Configured to run after power on
@@ -306,6 +407,15 @@ After the VM is cloned and has obtained an IP:
 6. Execute the launch script via `StartProgramInGuest` with guest credentials
 7. The script is run as: `/bin/echo -n ;<script>`, with `CDS_CONFIG` passed as environment variable
 
+Steps 1-3 and 6-7 are **skipped entirely for guestinfo models**: there is no guest-operations
+channel to drive, and no credentials to drive it with. The assembled command and worker config
+are pushed as guestinfo keys before power-on (§3.5) and the guest starts the worker itself. The
+IP wait in `SpawnWorker` is kept, so IP accounting is unchanged.
+
+One consequence: with guest operations gone there is no synchronous launch error. A worker that
+fails to start does not fail the spawn — it surfaces as a CDS registration timeout and is reaped
+by `killAwolServers` (§8.1), the same as any other never-registered worker.
+
 #### 6.2.3 Guest Operations Authentication
 
 Guest OS credentials are resolved in order:
@@ -313,7 +423,8 @@ Guest OS credentials are resolved in order:
 2. From deprecated `guestCredentials` config (fallback)
 3. If not found in config, from the worker model spec (`Username`/`Password`)
 
-If neither provides valid credentials, spawning fails.
+If neither provides valid credentials, spawning fails. Guestinfo models need no credentials at
+all, never reaching this path.
 
 ### 6.3 Pre-Provisioning
 
@@ -734,6 +845,7 @@ type VSphereClient interface {
     NewVirtualMachine(ctx, cloneSpec, ref, vmName) (*object.VirtualMachine, error)
     RenameVirtualMachine(ctx, vm, newName) error
     SetVirtualMachineAnnotation(ctx, vm, annotation) error
+    ReconfigureVirtualMachine(ctx, vm, spec) error
     WaitForVirtualMachineShutdown(ctx, vm) error
     WaitForVirtualMachineIP(ctx, vm, IPAddress, vmName) error
     LoadFolder(ctx) (*object.Folder, error)
@@ -747,7 +859,12 @@ type VSphereClient interface {
 }
 ```
 
-The interface is mockable for unit testing (see `mock_vsphere/`).
+The interface is mockable for unit testing (see `mock_vsphere/`). Regenerate the mock after any
+change to the interface:
+
+```
+cd engine/hatchery/vsphere && go generate ./...
+```
 
 ### 9.1 VM Readiness
 
@@ -756,6 +873,10 @@ After cloning, the hatchery waits for full VM readiness in multiple stages:
 1. **Guest operations ready**: Polls `Guest.GuestOperationsReady` (timeout: 3 minutes)
 2. **IP address**: Polls `vm.WaitForIP()`, optionally matching an expected static IP (timeout: 3 minutes)
 3. **Command execution ready**: Runs `env` in the guest to verify guest operations work (timeout: 1 minute)
+
+Stage 3 is skipped for guestinfo models (§3.5). Stage 2 only matches against an expected IP when
+the clone carried a customization spec; a guestinfo clone applies its own network, so any IP
+reported by VMware Tools ends the wait.
 
 ### 9.2 VM Listing and Filtering
 
@@ -784,7 +905,9 @@ The hatchery maintains several in-memory caches protected by mutexes:
 
 1. **Unsupported job requirements**: Service, Memory, Hostname requirements
    cause the hatchery to reject the job.
-2. **Linux only**: Customization assumes Linux guests (`CustomizationLinuxPrep`).
+2. **Linux, or guestinfo**: guest customization assumes Linux guests (`CustomizationLinuxPrep`).
+   Any other guest OS must be declared as a guestinfo model (§3.5) and run an image that reads
+   the guestinfo contract at boot.
 3. **Single datacenter**: The hatchery operates on a single vSphere datacenter.
 4. **No V2 model registration**: V2 templates must be pre-created in vSphere manually.
 

--- a/engine/hatchery/vsphere/client.go
+++ b/engine/hatchery/vsphere/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/rockbears/log"
 	"github.com/vmware/govmomi/object"
@@ -13,18 +14,31 @@ import (
 	"github.com/ovh/cds/sdk"
 )
 
-// reconfigureVM changes the CPU and RAM of a powered-off VM to match the requested flavor
-//
 // getModelConfig returns the ModelConfig for the given model, or nil if not configured.
 func (h *HatcheryVSphere) getModelConfig(model sdk.WorkerStarterWorkerModel) *ModelConfig {
+	return h.getModelConfigByImage(model.GetVSphereImage())
+}
+
+// getModelConfigByImage returns the ModelConfig for a VMware template name, or
+// nil if not configured. The provisioning path only knows that name, never a
+// sdk.WorkerStarterWorkerModel.
+func (h *HatcheryVSphere) getModelConfigByImage(vmwareImage string) *ModelConfig {
 	for i := range h.Config.Models {
-		if h.Config.Models[i].ModelVMWare == model.GetVSphereImage() {
+		if h.Config.Models[i].ModelVMWare == vmwareImage {
 			return &h.Config.Models[i]
 		}
 	}
 	return nil
 }
 
+// isGuestInfoImage reports whether a VMware template is driven through guestinfo
+// rather than guest customization and guest operations. See ModelConfig.GuestInfo.
+func (h *HatcheryVSphere) isGuestInfoImage(vmwareImage string) bool {
+	cfg := h.getModelConfigByImage(vmwareImage)
+	return cfg != nil && cfg.GuestInfo
+}
+
+// reconfigureVM changes the CPU and RAM of a powered-off VM to match the requested flavor
 func (h *HatcheryVSphere) reconfigureVM(ctx context.Context, vm *object.VirtualMachine, flavor *VSphereFlavorConfig) error {
 	if flavor == nil {
 		return nil
@@ -72,14 +86,8 @@ func (h *HatcheryVSphere) reconfigureVM(ctx context.Context, vm *object.VirtualM
 
 	log.Info(ctx, "reconfigureVM> reconfiguring VM to %d vCPUs, %d MB RAM, disk %d GB", flavor.CPUs, flavor.MemoryMB, flavor.DiskSizeGB)
 
-	// Apply reconfiguration
-	task, err := vm.Reconfigure(ctx, spec)
-	if err != nil {
+	if err := h.vSphereClient.ReconfigureVirtualMachine(ctx, vm, spec); err != nil {
 		return sdk.WrapError(err, "reconfigureVM> cannot reconfigure VM")
-	}
-
-	if err := task.Wait(ctx); err != nil {
-		return sdk.WrapError(err, "reconfigureVM> VM reconfiguration task failed")
 	}
 
 	log.Info(ctx, "reconfigureVM> VM successfully reconfigured")
@@ -295,13 +303,18 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 	}
 	datastoreref := datastore.Reference()
 
+	// guestinfo models (see ModelConfig.GuestInfo) get their network through
+	// guestinfo keys read by the guest at every boot: GOSC does not support them
+	// and would reject or silently no-op the customization.
+	guestInfo := h.isGuestInfoImage(annot.VMwareModelPath)
+
 	customSpec := &types.CustomizationSpec{
 		Identity: &types.CustomizationLinuxPrep{
 			HostName: new(types.CustomizationVirtualMachineName),
 		},
 	}
 
-	if ip != nil {
+	if ip != nil && !guestInfo {
 		log.Debug(ctx, "assigning %s as IP (gw=%s, mask=%s)", ip.ip, ip.gateway, ip.subnetMask)
 
 		customSpec.NicSettingMap = []types.CustomizationAdapterMapping{
@@ -326,6 +339,24 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 		log.Debug(ctx, "IP: %s; Gateway: %v; DNS: %v", ip.ip, customSpec.NicSettingMap[0].Adapter.Gateway, customSpec.GlobalIPSettings.DnsServerList)
 	}
 
+	var extraConfig []types.BaseOptionValue
+	if ip != nil && guestInfo {
+		log.Debug(ctx, "assigning %s as IP through guestinfo (gw=%s, mask=%s)", ip.ip, ip.gateway, ip.subnetMask)
+
+		extraConfig = append(extraConfig,
+			&types.OptionValue{Key: "guestinfo.cds.net.ip", Value: ip.ip},
+			&types.OptionValue{Key: "guestinfo.cds.net.mask", Value: ip.subnetMask},
+			&types.OptionValue{Key: "guestinfo.cds.net.gateway", Value: ip.gateway},
+			&types.OptionValue{Key: "guestinfo.cds.net.dns", Value: h.Config.DNS},
+			&types.OptionValue{Key: "guestinfo.cds.net.hostname", Value: annot.WorkerName},
+		)
+		extraConfig = append(extraConfig, h.guestInfoAccessOptions()...)
+
+		// Same compat anchor as the customization path: getUsedIPs reads the IP
+		// from here to avoid handing it out twice.
+		annot.IPAddress = ip.ip
+	}
+
 	annotStr, err := json.Marshal(annot)
 	if err != nil {
 		return nil, sdk.WrapError(err, "unable to marshal annotation")
@@ -343,14 +374,43 @@ func (h *HatcheryVSphere) prepareCloneSpec(ctx context.Context, vm *object.Virtu
 			Tools: &types.ToolsConfigInfo{
 				AfterPowerOn: &sdk.True,
 			},
+			ExtraConfig: extraConfig,
 		},
 	}
 
-	cloneSpec.Customization = customSpec
+	// A guestinfo model must not carry a customization spec at all: the GOSC
+	// engine has no support for its guest OS. Everything it needs is in
+	// ExtraConfig above.
+	if !guestInfo {
+		cloneSpec.Customization = customSpec
+	}
 
 	// Set the destination datastore
 	cloneSpec.Location.Datastore = &datastoreref
 	return cloneSpec, nil
+}
+
+// guestInfoAccessOptions returns the optional debug-access guestinfo keys, empty
+// when nothing is configured — the guest image bakes no credentials and no
+// allowlist, so an unset key means the worker is unreachable, which is the
+// intended default. The two keys are separate layers: allowed_cidrs feeds the
+// guest's packet filter (inbound SSH is dropped from anywhere else), while
+// authorized_keys is what sshd authenticates once a packet gets through.
+func (h *HatcheryVSphere) guestInfoAccessOptions() []types.BaseOptionValue {
+	var opts []types.BaseOptionValue
+	if len(h.Config.SSHAllowedCIDRs) > 0 {
+		opts = append(opts, &types.OptionValue{
+			Key:   "guestinfo.cds.access.allowed_cidrs",
+			Value: strings.Join(h.Config.SSHAllowedCIDRs, " "),
+		})
+	}
+	if len(h.Config.InjectSSHPublicKeys) > 0 {
+		opts = append(opts, &types.OptionValue{
+			Key:   "guestinfo.cds.access.authorized_keys",
+			Value: strings.Join(h.Config.InjectSSHPublicKeys, "\n"),
+		})
+	}
+	return opts
 }
 
 // launchClientOp launch a script on the virtual machine given in parameters

--- a/engine/hatchery/vsphere/guestinfo_test.go
+++ b/engine/hatchery/vsphere/guestinfo_test.go
@@ -1,0 +1,289 @@
+package vsphere
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rockbears/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/hatchery"
+)
+
+// extraConfigMap flattens a VM ExtraConfig into key/value pairs.
+func extraConfigMap(t *testing.T, opts []types.BaseOptionValue) map[string]string {
+	t.Helper()
+	res := make(map[string]string, len(opts))
+	for _, o := range opts {
+		ov, ok := o.(*types.OptionValue)
+		require.True(t, ok, "unexpected option type %T", o)
+		v, ok := ov.Value.(string)
+		require.True(t, ok, "option %q has non-string value %T", ov.Key, ov.Value)
+		res[ov.Key] = v
+	}
+	return res
+}
+
+// newGuestInfoCloneHatchery returns a hatchery whose "freebsd14" image is
+// declared as a guestinfo model, with the clone-time vSphere calls mocked.
+func newGuestInfoCloneHatchery(t *testing.T) *HatcheryVSphere {
+	t.Helper()
+
+	c := NewVSphereClientTest(t)
+	h := &HatcheryVSphere{
+		vSphereClient: c,
+		Config: HatcheryConfiguration{
+			Models: []ModelConfig{{ModelVMWare: "freebsd14", GuestInfo: true}},
+		},
+	}
+	h.Config.VSphereNetworkString = "vbox-net"
+	h.Config.VSphereCardName = "ethernet-card"
+	h.Config.VSphereDatastoreString = "datastore"
+	h.Config.DNS = "192.168.0.253"
+
+	c.EXPECT().LoadVirtualMachineDevices(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine) (object.VirtualDeviceList, error) {
+			card := types.VirtualEthernetCard{}
+			return object.VirtualDeviceList{&card}, nil
+		},
+	)
+	c.EXPECT().LoadNetwork(gomock.Any(), "vbox-net").Return(&object.Network{}, nil)
+	c.EXPECT().SetupEthernetCard(gomock.Any(), gomock.Any(), "ethernet-card", gomock.Any()).Return(nil)
+	c.EXPECT().LoadResourcePool(gomock.Any()).Return(&object.ResourcePool{}, nil)
+	c.EXPECT().LoadDatastore(gomock.Any(), "datastore").Return(&object.Datastore{}, nil)
+
+	return h
+}
+
+// A guestinfo model gets its network through guestinfo keys and no customization
+// spec at all: GOSC does not support its guest OS.
+func TestHatcheryVSphere_prepareCloneSpec_guestInfo(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := newGuestInfoCloneHatchery(t)
+
+	annot := annotation{VMwareModelPath: "freebsd14", WorkerName: "provision-v2-ip-192-168-0-3-foo"}
+	ip := &ipResult{ip: "192.168.0.3", gateway: "192.168.0.254", subnetMask: "255.255.255.0"}
+	cloneSpec, err := h.prepareCloneSpec(context.Background(), &object.VirtualMachine{}, &annot, ip)
+	require.NoError(t, err)
+	require.NotNil(t, cloneSpec)
+
+	assert.Nil(t, cloneSpec.Customization, "a guestinfo clone must carry no customization spec")
+
+	extra := extraConfigMap(t, cloneSpec.Config.ExtraConfig)
+	assert.Equal(t, "192.168.0.3", extra["guestinfo.cds.net.ip"])
+	assert.Equal(t, "255.255.255.0", extra["guestinfo.cds.net.mask"])
+	assert.Equal(t, "192.168.0.254", extra["guestinfo.cds.net.gateway"])
+	assert.Equal(t, "192.168.0.253", extra["guestinfo.cds.net.dns"])
+	assert.Equal(t, "provision-v2-ip-192-168-0-3-foo", extra["guestinfo.cds.net.hostname"])
+
+	// Debug access is opt-in: unconfigured means the worker has no SSH access.
+	assert.NotContains(t, extra, "guestinfo.cds.access.allowed_cidrs")
+	assert.NotContains(t, extra, "guestinfo.cds.access.authorized_keys")
+
+	// The IP accounting anchor must survive: getUsedIPs reads it back.
+	assert.Equal(t, "192.168.0.3", annot.IPAddress)
+}
+
+// Debug access is two independent layers, and both must reach the guest: the
+// CIDRs drive its packet filter, the keys drive sshd. Emitting only one would
+// leave the worker either unreachable or filtered open.
+func TestHatcheryVSphere_prepareCloneSpec_guestInfoAccess(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := newGuestInfoCloneHatchery(t)
+	h.Config.SSHAllowedCIDRs = []string{"10.0.0.0/24", "10.1.0.0/24"}
+	h.Config.InjectSSHPublicKeys = []string{
+		`from="10.0.0.0/24" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA op@example`,
+		`from="10.1.0.0/24" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB ops@example`,
+	}
+
+	annot := annotation{VMwareModelPath: "freebsd14", WorkerName: "provision-v2-worker"}
+	ip := &ipResult{ip: "192.168.0.3", gateway: "192.168.0.254", subnetMask: "255.255.255.0"}
+	cloneSpec, err := h.prepareCloneSpec(context.Background(), &object.VirtualMachine{}, &annot, ip)
+	require.NoError(t, err)
+
+	extra := extraConfigMap(t, cloneSpec.Config.ExtraConfig)
+	// Space-separated: the guest iterates the value word by word.
+	assert.Equal(t, "10.0.0.0/24 10.1.0.0/24", extra["guestinfo.cds.access.allowed_cidrs"])
+	// Newline-separated: the value is dropped in as an authorized_keys body.
+	assert.Equal(t, strings.Join(h.Config.InjectSSHPublicKeys, "\n"), extra["guestinfo.cds.access.authorized_keys"])
+}
+
+// Injected keys must state which source addresses may use them: a key without a
+// from= option would be usable from anywhere.
+func TestHatcheryVSphere_CheckConfiguration_injectSSHPublicKeys(t *testing.T) {
+	h := New()
+	cfg := HatcheryConfiguration{
+		VSphereUser:             "user",
+		VSphereEndpoint:         "endpoint",
+		VSpherePassword:         "password",
+		VSphereDatacenterString: "datacenter",
+	}
+	cfg.Name = "hatchery"
+	cfg.API.HTTP.URL = "http://localhost:8081"
+	cfg.API.Token = "xxx"
+	cfg.Provision.MaxWorker = 1
+
+	key := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA op@example`
+
+	cfg.InjectSSHPublicKeys = []string{key}
+	require.Error(t, h.CheckConfiguration(cfg), "a key without a from= option must be rejected")
+
+	cfg.InjectSSHPublicKeys = []string{`from="10.0.0.0/24" ` + key}
+	require.NoError(t, h.CheckConfiguration(cfg))
+
+	// A malformed CIDR would produce a broken guest allowlist.
+	cfg.SSHAllowedCIDRs = []string{"10.0.0.0/24", "not-a-cidr"}
+	require.Error(t, h.CheckConfiguration(cfg))
+
+	cfg.SSHAllowedCIDRs = []string{"10.0.0.0/24"}
+	require.NoError(t, h.CheckConfiguration(cfg))
+}
+
+// A model that is not declared as guestinfo keeps the guest customization path,
+// with no guestinfo key emitted.
+func TestHatcheryVSphere_prepareCloneSpec_linuxUnchanged(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	h := newGuestInfoCloneHatchery(t)
+	h.Config.InjectSSHPublicKeys = []string{`from="10.0.0.0/24" ssh-ed25519 AAAAC3Nza op@example`}
+
+	annot := annotation{VMwareModelPath: "debian12", WorkerName: "provision-v2-worker"}
+	ip := &ipResult{ip: "192.168.0.3", gateway: "192.168.0.254", subnetMask: "255.255.255.0"}
+	cloneSpec, err := h.prepareCloneSpec(context.Background(), &object.VirtualMachine{}, &annot, ip)
+	require.NoError(t, err)
+
+	require.NotNil(t, cloneSpec.Customization)
+	assert.IsType(t, &types.CustomizationLinuxPrep{}, cloneSpec.Customization.Identity)
+	assert.Equal(t, "192.168.0.3", cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp).IpAddress)
+	assert.Equal(t, "192.168.0.254", cloneSpec.Customization.NicSettingMap[0].Adapter.Gateway[0])
+	assert.Empty(t, cloneSpec.Config.ExtraConfig, "a Linux clone must emit no guestinfo key")
+	assert.Equal(t, "192.168.0.3", annot.IPAddress)
+}
+
+// Spawning a guestinfo worker pushes the bootstrap through ReconfigureVirtualMachine
+// before power-on and never touches the guest-operations channel. The mock
+// controller fails the test on any unexpected ProcessManager/StartProgramInGuest.
+func TestHatcheryVSphere_SpawnWorkerGuestInfo(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+
+	c := NewVSphereClientTest(t)
+	h := HatcheryVSphere{
+		vSphereClient: c,
+		Config: HatcheryConfiguration{
+			// No credentials anywhere: a guestinfo model must need none.
+			Models: []ModelConfig{{ModelVMWare: "freebsd14", GuestInfo: true}},
+		},
+	}
+	h.Config.Provision.InjectEnvVars = []string{"SOME_SECRET=s3cr3t"}
+
+	var ctx = context.Background()
+	var vmProvisionned = object.VirtualMachine{
+		Common: object.Common{InventoryPath: "provision-v2-worker"},
+	}
+
+	c.EXPECT().ListVirtualMachines(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]mo.VirtualMachine, error) {
+		return []mo.VirtualMachine{
+			{
+				ManagedEntity: mo.ManagedEntity{Name: "provision-v2-worker"},
+				Summary: types.VirtualMachineSummary{
+					Runtime: types.VirtualMachineRuntimeInfo{
+						PowerState: types.VirtualMachinePowerStatePoweredOff,
+					},
+				},
+				Config: &types.VirtualMachineConfigInfo{
+					Annotation: `{"provisioning": true, "vmware_model_path": "freebsd14", "ip_address": "192.168.0.1"}`,
+				},
+			},
+		}, nil
+	}).Times(2)
+
+	c.EXPECT().LoadVirtualMachine(gomock.Any(), "provision-v2-worker").Return(&vmProvisionned, nil)
+
+	c.EXPECT().LoadVirtualMachineEvents(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine, eventTypes ...string) ([]types.BaseEvent, error) {
+			return []types.BaseEvent{
+				&types.VmPoweredOffEvent{VmEvent: types.VmEvent{Event: types.Event{
+					CreatedTime: time.Now().Add(-10 * time.Minute),
+				}}},
+			}, nil
+		},
+	)
+
+	rename := c.EXPECT().RenameVirtualMachine(gomock.Any(), &vmProvisionned, "worker-name").Return(nil)
+
+	annotated := c.EXPECT().SetVirtualMachineAnnotation(gomock.Any(), &vmProvisionned, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine, annotStr string) error {
+			var a annotation
+			require.NoError(t, json.Unmarshal([]byte(annotStr), &a))
+			assert.Equal(t, "192.168.0.1", a.IPAddress, "reserved IP must be preserved")
+			return nil
+		},
+	)
+
+	bootstrapped := c.EXPECT().ReconfigureVirtualMachine(gomock.Any(), &vmProvisionned, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec) error {
+			extra := extraConfigMap(t, spec.ExtraConfig)
+
+			assert.Contains(t, extra["guestinfo.cds.cmd"], "./worker")
+			assert.Contains(t, extra["guestinfo.cds.cmd"], "1>/tmp/worker.log 2>&1;")
+			assert.Contains(t, extra["guestinfo.cds.cmd"], "shutdown -p now")
+
+			require.Contains(t, extra, "guestinfo.cds.config")
+			raw, err := base64.StdEncoding.DecodeString(extra["guestinfo.cds.config"])
+			require.NoError(t, err, "guestinfo.cds.config must be base64")
+			var cfg map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &cfg), "guestinfo.cds.config must decode to JSON")
+			assert.Equal(t, "worker-name", cfg["name"])
+
+			// The VM was renamed out of its provision name; the guest must apply
+			// the worker name on this boot.
+			assert.Equal(t, "worker-name", extra["guestinfo.cds.net.hostname"])
+
+			// Injected env vars travel inside the config, which the guest scrubs
+			// after use. A separate key would never be read and would outlive it.
+			assert.Equal(t, map[string]interface{}{"SOME_SECRET": "s3cr3t"}, cfg["inject_env_vars"])
+			for k, v := range extra {
+				assert.NotContains(t, v, "s3cr3t", "secret leaked in clear text into %q", k)
+			}
+			return nil
+		},
+	)
+
+	// The bootstrap is worthless if the guest boots before it lands.
+	started := c.EXPECT().StartVirtualMachine(gomock.Any(), &vmProvisionned).Return(nil)
+	gomock.InOrder(rename, annotated, bootstrapped, started)
+
+	// Only SpawnWorker waits for the IP: launchScriptWorker is skipped entirely.
+	c.EXPECT().WaitForVirtualMachineIP(gomock.Any(), &vmProvisionned, gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	err := h.SpawnWorker(ctx, hatchery.SpawnArguments{
+		WorkerName:  "worker-name",
+		WorkerToken: "worker.token.xxx",
+		Model: sdk.WorkerStarterWorkerModel{
+			ModelV2: &sdk.V2WorkerModel{
+				Name:   "cds-freebsd-model",
+				OSArch: "freebsd/amd64",
+				Spec:   json.RawMessage(`{"image":"freebsd14"}`),
+			},
+			VSphereSpec: sdk.V2WorkerModelVSphereSpec{Image: "freebsd14"},
+			Cmd:         "./worker",
+			PostCmd:     "shutdown -p now",
+		},
+		JobName:      "job_name",
+		JobID:        "666",
+		HatcheryName: "hatchery_name",
+	})
+	require.NoError(t, err)
+}

--- a/engine/hatchery/vsphere/hatchery.go
+++ b/engine/hatchery/vsphere/hatchery.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/ovh/cds/engine/api"
+	hatcheryCommon "github.com/ovh/cds/engine/hatchery"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
@@ -140,6 +142,19 @@ func (h *HatcheryVSphere) CheckConfiguration(cfg interface{}) error {
 
 	if hconfig.VSphereDatacenterString == "" {
 		return sdk.WithStack(fmt.Errorf("vsphere-datacenter is mandatory"))
+	}
+
+	if err := hatcheryCommon.CheckInjectSSHPublicKeys(hconfig.InjectSSHPublicKeys); err != nil {
+		return sdk.WithStack(fmt.Errorf("invalid inject SSH public keys: %v", err))
+	}
+
+	// A malformed CIDR would silently produce a broken guest allowlist, i.e. a
+	// worker unreachable for debug (or, depending on the guest, one that does not
+	// filter at all).
+	for _, cidr := range hconfig.SSHAllowedCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return sdk.WithStack(fmt.Errorf("invalid sshAllowedCIDRs entry %q: %v", cidr, err))
+		}
 	}
 
 	if hconfig.IPRange != "" {

--- a/engine/hatchery/vsphere/mock_vsphere/client_mock.go
+++ b/engine/hatchery/vsphere/mock_vsphere/client_mock.go
@@ -243,6 +243,20 @@ func (mr *MockVSphereClientMockRecorder) ProcessManager(ctx, vm any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessManager", reflect.TypeOf((*MockVSphereClient)(nil).ProcessManager), ctx, vm)
 }
 
+// ReconfigureVirtualMachine mocks base method.
+func (m *MockVSphereClient) ReconfigureVirtualMachine(ctx context.Context, vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconfigureVirtualMachine", ctx, vm, spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconfigureVirtualMachine indicates an expected call of ReconfigureVirtualMachine.
+func (mr *MockVSphereClientMockRecorder) ReconfigureVirtualMachine(ctx, vm, spec any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconfigureVirtualMachine", reflect.TypeOf((*MockVSphereClient)(nil).ReconfigureVirtualMachine), ctx, vm, spec)
+}
+
 // RenameVirtualMachine mocks base method.
 func (m *MockVSphereClient) RenameVirtualMachine(ctx context.Context, vm *object.VirtualMachine, newName string) error {
 	m.ctrl.T.Helper()

--- a/engine/hatchery/vsphere/spawn.go
+++ b/engine/hatchery/vsphere/spawn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
+	"github.com/ovh/cds/engine/worker/pkg/workerruntime"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/hatchery"
 	cdslog "github.com/ovh/cds/sdk/log"
@@ -66,6 +67,11 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 	if spawnArgs.Model.ModelV2 == nil {
 		return sdk.WithStack(fmt.Errorf("worker model v1 is no longer supported on vSphere"))
 	}
+
+	// ModelConfig.GuestInfo is the single gate: the clone and the spawn must agree
+	// on how the VM is driven, and the provisioning loop only ever knows the
+	// VMware template name.
+	guestInfo := h.isGuestInfoImage(spawnArgs.Model.GetVSphereImage())
 
 	// Amendment C: Resolve flavor before spawning
 	var flavor *VSphereFlavorConfig
@@ -175,6 +181,15 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 		return sdk.WrapError(err, "unable to set worker annotation on VM %q", spawnArgs.WorkerName)
 	}
 
+	// A guestinfo model starts its worker from the guest at boot, so the bootstrap
+	// has to be in place before power-on. On failure the deferred teardown above
+	// shuts the VM down and marks it for deletion, as for any other spawn step.
+	if guestInfo {
+		if err := h.setupGuestInfoBootstrap(ctx, provisionnedVMWorker, spawnArgs); err != nil {
+			return sdk.WrapError(err, "unable to push guestinfo bootstrap to VM %q", spawnArgs.WorkerName)
+		}
+	}
+
 	// Power on, tolerating a VM that is not immediately startable right after the
 	// reconfigure/annotation update.
 	if err := h.startVirtualMachineWithRetry(ctx, provisionnedVMWorker); err != nil {
@@ -186,8 +201,13 @@ func (h *HatcheryVSphere) SpawnWorker(ctx context.Context, spawnArgs hatchery.Sp
 		return sdk.WrapError(err, "unable to get VM %q IP Address", spawnArgs.WorkerName)
 	}
 
-	if err := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
-		return err
+	// The guest already has everything it needs; there is no guest-operations
+	// channel to drive (and no credentials to do so). A worker that fails to
+	// start surfaces as a CDS registration timeout, handled by killAwolServers.
+	if !guestInfo {
+		if err := h.launchScriptWorker(ctx, spawnArgs, provisionnedVMWorker, spawnArgs.WorkerName); err != nil {
+			return err
+		}
 	}
 
 	spawnOK = true
@@ -251,12 +271,11 @@ func (h *HatcheryVSphere) checkVirtualMachineIsReady(ctx context.Context, model 
 	return nil
 }
 
-// launchScriptWorker launch a script on the worker
-func (h *HatcheryVSphere) launchScriptWorker(ctx context.Context, spawnArgs hatchery.SpawnArguments, vm *object.VirtualMachine, vmName string) error {
-	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, vm, nil, vmName); err != nil {
-		return err
-	}
-
+// buildWorkerBootstrap renders the model's PreCmd/Cmd/PostCmd into the command
+// that starts the worker, along with the worker configuration it needs. It is
+// shared by the guest-operations bootstrap (launchScriptWorker) and the guestinfo
+// one (setupGuestInfoBootstrap), so both hand the guest the exact same command.
+func (h *HatcheryVSphere) buildWorkerBootstrap(ctx context.Context, spawnArgs hatchery.SpawnArguments) (string, workerruntime.WorkerConfig, error) {
 	workerConfig := h.GenerateWorkerConfig(ctx, h, spawnArgs)
 
 	udata := spawnArgs.Model.GetPreCmd() + "\n" + spawnArgs.Model.GetCmd()
@@ -267,7 +286,7 @@ func (h *HatcheryVSphere) launchScriptWorker(ctx context.Context, spawnArgs hatc
 
 	tmpl, err := template.New("udata").Parse(udata)
 	if err != nil {
-		return sdk.NewErrorFrom(err, "unable to parse template: %v", err)
+		return "", workerConfig, sdk.NewErrorFrom(err, "unable to parse template: %v", err)
 	}
 
 	udataParam := struct {
@@ -298,7 +317,48 @@ func (h *HatcheryVSphere) launchScriptWorker(ctx context.Context, spawnArgs hatc
 
 	var buffer bytes.Buffer
 	if err := tmpl.Execute(&buffer, udataParam); err != nil {
-		return sdk.NewErrorFrom(err, "unable to execute template: %v", err)
+		return "", workerConfig, sdk.NewErrorFrom(err, "unable to execute template: %v", err)
+	}
+
+	return buffer.String(), workerConfig, nil
+}
+
+// setupGuestInfoBootstrap pushes the per-worker bootstrap as guestinfo keys. It
+// must run while the VM is still powered off: the guest reads these keys at boot
+// and starts the worker itself, there being no guest-operations channel to drive
+// it. The image no-ops when guestinfo.cds.cmd is unset, which is what makes the
+// provision boot harmless.
+func (h *HatcheryVSphere) setupGuestInfoBootstrap(ctx context.Context, vm *object.VirtualMachine, spawnArgs hatchery.SpawnArguments) error {
+	cmd, workerConfig, err := h.buildWorkerBootstrap(ctx, spawnArgs)
+	if err != nil {
+		return err
+	}
+
+	// InjectEnvVars are deliberately not emitted as separate keys: the worker
+	// reads them from the config it decodes out of guestinfo.cds.config. A copy
+	// would never be read, and unlike the config — which the guest scrubs once
+	// consumed — it would linger in the VM config in clear text.
+	extraConfig := []types.BaseOptionValue{
+		&types.OptionValue{Key: "guestinfo.cds.config", Value: workerConfig.EncodeBase64()},
+		&types.OptionValue{Key: "guestinfo.cds.cmd", Value: cmd},
+		// The VM was renamed from its provision name just above; refresh the
+		// hostname the guest applies on this boot.
+		&types.OptionValue{Key: "guestinfo.cds.net.hostname", Value: spawnArgs.WorkerName},
+	}
+
+	log.Info(ctx, "pushing guestinfo bootstrap to %q", spawnArgs.WorkerName)
+	return h.vSphereClient.ReconfigureVirtualMachine(ctx, vm, types.VirtualMachineConfigSpec{ExtraConfig: extraConfig})
+}
+
+// launchScriptWorker launch a script on the worker
+func (h *HatcheryVSphere) launchScriptWorker(ctx context.Context, spawnArgs hatchery.SpawnArguments, vm *object.VirtualMachine, vmName string) error {
+	if err := h.vSphereClient.WaitForVirtualMachineIP(ctx, vm, nil, vmName); err != nil {
+		return err
+	}
+
+	script, workerConfig, err := h.buildWorkerBootstrap(ctx, spawnArgs)
+	if err != nil {
+		return err
 	}
 
 	if err := h.checkVirtualMachineIsReady(ctx, spawnArgs.Model, vm, spawnArgs.WorkerName); err != nil {
@@ -329,7 +389,7 @@ func (h *HatcheryVSphere) launchScriptWorker(ctx context.Context, spawnArgs hatc
 		env = append(env, k+"="+v)
 	}
 
-	if err := h.launchClientOp(ctx, vm, spawnArgs.Model, buffer.String(), env); err != nil {
+	if err := h.launchClientOp(ctx, vm, spawnArgs.Model, script, env); err != nil {
 		log.Warn(ctx, "launchScript> cannot start program %s", err)
 		log.Error(ctx, "cannot start program on virtual machine %q: %v", spawnArgs.WorkerName, err)
 		log.Warn(ctx, "shutdown virtual machine %q", spawnArgs.WorkerName)

--- a/engine/hatchery/vsphere/types.go
+++ b/engine/hatchery/vsphere/types.go
@@ -10,13 +10,13 @@ import (
 // HatcheryConfiguration is the configuration for hatchery
 type HatcheryConfiguration struct {
 	service.HatcheryCommonConfiguration `mapstructure:"commonConfiguration" toml:"commonConfiguration" json:"commonConfiguration"`
-	VSphereUser                         string                     `mapstructure:"user" toml:"user" default:"" commented:"false" comment:"VSphere User" json:"user"`
-	VSphereEndpoint                     string                     `mapstructure:"endpoint" toml:"endpoint" default:"" commented:"false" comment:"VShpere Endpoint, example:pcc-11-222-333-444.ovh.com" json:"endpoint"`
-	VSpherePassword                     string                     `mapstructure:"password" toml:"password" default:"" commented:"false" comment:"VShpere Password" json:"-"`
-	VSphereDatacenterString             string                     `mapstructure:"datacenterString" toml:"datacenterString" default:"" commented:"false" comment:"VSphere Datacenter" json:"datacenterString"`
-	VSphereDatastoreString              string                     `mapstructure:"datastoreString" toml:"datastoreString" default:"" commented:"false" comment:"VSphere Datastore" json:"datastoreString"`
-	VSphereNetworkString                string                     `mapstructure:"networkString" toml:"networkString" default:"" commented:"false" comment:"VShpere Network" json:"networkString"`
-	VSphereCardName                     string                     `mapstructure:"cardName" toml:"cardName" default:"e1000" commented:"false" comment:"Name of the virtual ethernet card" json:"cardName"`
+	VSphereUser                         string `mapstructure:"user" toml:"user" default:"" commented:"false" comment:"VSphere User" json:"user"`
+	VSphereEndpoint                     string `mapstructure:"endpoint" toml:"endpoint" default:"" commented:"false" comment:"VShpere Endpoint, example:pcc-11-222-333-444.ovh.com" json:"endpoint"`
+	VSpherePassword                     string `mapstructure:"password" toml:"password" default:"" commented:"false" comment:"VShpere Password" json:"-"`
+	VSphereDatacenterString             string `mapstructure:"datacenterString" toml:"datacenterString" default:"" commented:"false" comment:"VSphere Datacenter" json:"datacenterString"`
+	VSphereDatastoreString              string `mapstructure:"datastoreString" toml:"datastoreString" default:"" commented:"false" comment:"VSphere Datastore" json:"datastoreString"`
+	VSphereNetworkString                string `mapstructure:"networkString" toml:"networkString" default:"" commented:"false" comment:"VShpere Network" json:"networkString"`
+	VSphereCardName                     string `mapstructure:"cardName" toml:"cardName" default:"e1000" commented:"false" comment:"Name of the virtual ethernet card" json:"cardName"`
 	// Deprecated: Use Networks instead. Kept for backward compatibility.
 	IPRange    string `mapstructure:"iprange" toml:"iprange" default:"" commented:"false" comment:"Deprecated: use [[networks]] instead. Optional. IP Range for spawned workers. \n Format: a.a.a.a/b,c.c.c.c/e \n Hatchery will use an IP from this range to create Virtual Machine (Fixed IP Attribute).\nIf not set, you have to set it in your worker model template" json:"iprange,omitempty"`
 	Gateway    string `mapstructure:"gateway" toml:"gateway" default:"" commented:"false" comment:"Deprecated: use [[networks]] instead. Optional. Gateway IP for spawned workers." json:"gateway,omitempty"`
@@ -39,6 +39,14 @@ type HatcheryConfiguration struct {
 	Flavors                    []VSphereFlavorConfig      `mapstructure:"flavors" toml:"flavors" commented:"true" comment:"Optional. VM flavors for CPU/RAM sizing. List of available flavors." json:"flavors,omitempty"`
 	DefaultFlavor              string                     `mapstructure:"defaultFlavor" toml:"defaultFlavor" default:"" commented:"true" comment:"Optional. Default flavor to use when no flavor is specified in worker model or job requirements." json:"defaultFlavor,omitempty"`
 	CountSmallerFlavorToKeep   int                        `mapstructure:"countSmallerFlavorToKeep" toml:"countSmallerFlavorToKeep" default:"0" commented:"true" comment:"Optional. Reserve capacity for N smaller flavor workers when spawning large flavors. 0 disables starvation prevention." json:"countSmallerFlavorToKeep"`
+	// SSHAllowedCIDRs and InjectSSHPublicKeys grant debug access to guestinfo
+	// workers (see ModelConfig.GuestInfo), and are two distinct layers: the CIDRs
+	// feed a packet-filter allowlist in the guest, which drops inbound SSH from
+	// anywhere else, while the keys are what sshd then authenticates. Neither
+	// substitutes for the other. Both default to empty, which is the intended
+	// default: no inbound access at all, access being debug-only.
+	SSHAllowedCIDRs     []string `mapstructure:"sshAllowedCIDRs" toml:"sshAllowedCIDRs" default:"" commented:"true" comment:"Optional, guestinfo models only. CIDRs allowed to reach spawned workers over SSH, applied as a packet-filter allowlist in the guest. Empty means no inbound access." json:"sshAllowedCIDRs,omitempty"`
+	InjectSSHPublicKeys []string `mapstructure:"injectSSHPublicKeys" toml:"injectSSHPublicKeys" default:"" commented:"true" comment:"Optional, guestinfo models only. List of SSH public keys to inject into spawned workers. Each key must carry a from= option restricting the source addresses." json:"injectSSHPublicKeys,omitempty"`
 }
 
 // NetworkConfig defines a network with an IP range, gateway and subnet mask.
@@ -78,12 +86,24 @@ type ModelConfig struct {
 	// ModelVMWare is the VMware template name, used only by CDS Worker Model v2
 	ModelVMWare string `mapstructure:"modelVMWare" default:"" commented:"true" toml:"modelVMWare" json:"modelVMWare"`
 
-	// Guest credentials for executing scripts inside the VM
+	// Guest credentials for executing scripts inside the VM. Unused (and not
+	// required) when GuestInfo is set.
 	Username string `mapstructure:"username" commented:"true" toml:"username" json:"-"`
 	Password string `mapstructure:"password" commented:"true" toml:"password" json:"-"`
 
-	// Script executed inside the VM after boot but before the CDS worker starts
-	PreStartScript string `mapstructure:"preStartScript" toml:"preStartScript" commented:"true" comment:"Shell script executed inside the VM before the worker starts" json:"preStartScript"`
+	// Script executed inside the VM after boot but before the CDS worker starts.
+	// Ignored when GuestInfo is set: there is no guest-operations channel to run it.
+	PreStartScript string `mapstructure:"preStartScript" toml:"preStartScript" commented:"true" comment:"Shell script executed inside the VM before the worker starts. Ignored for guestinfo models." json:"preStartScript"`
+
+	// GuestInfo drives this model entirely through guestinfo keys instead of
+	// vSphere guest customization (GOSC) and guest operations: the network is
+	// pushed as guestinfo.cds.net.* at clone time and the worker bootstrap as
+	// guestinfo.cds.{cmd,config} at spawn time, both consumed in-guest at boot.
+	// Required for FreeBSD, which GOSC does not support and whose image is
+	// credential-less. This flag is the single gate for both the clone and the
+	// spawn path — the provisioning loop only knows the VMware template name, so
+	// it cannot be derived from the CDS model's OSArch.
+	GuestInfo bool `mapstructure:"guestInfo" toml:"guestInfo" default:"false" commented:"true" comment:"Drive this model through guestinfo instead of guest customization and guest operations (no credentials needed). Required for FreeBSD models." json:"guestInfo,omitempty"`
 }
 
 // this is used to run worker model v2 in a job v1

--- a/engine/hatchery/vsphere/vsphere.go
+++ b/engine/hatchery/vsphere/vsphere.go
@@ -21,6 +21,8 @@ import (
 
 var properties = []string{"name", "summary", "guest", "config"}
 
+//go:generate mockgen -source=vsphere.go -destination=mock_vsphere/client_mock.go -package mock_vsphere
+
 type VSphereClient interface {
 	ListVirtualMachines(ctx context.Context) ([]mo.VirtualMachine, error)
 	LoadVirtualMachine(ctx context.Context, name string) (*object.VirtualMachine, error)
@@ -33,6 +35,7 @@ type VSphereClient interface {
 	NewVirtualMachine(ctx context.Context, cloneSpec *types.VirtualMachineCloneSpec, ref *types.ManagedObjectReference, vmName string) (*object.VirtualMachine, error)
 	RenameVirtualMachine(ctx context.Context, vm *object.VirtualMachine, newName string) error
 	SetVirtualMachineAnnotation(ctx context.Context, vm *object.VirtualMachine, annotation string) error
+	ReconfigureVirtualMachine(ctx context.Context, vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec) error
 	WaitForVirtualMachineShutdown(ctx context.Context, vm *object.VirtualMachine) error
 	WaitForVirtualMachineIP(ctx context.Context, vm *object.VirtualMachine, IPAddress *string, vmName string) error
 	LoadFolder(ctx context.Context) (*object.Folder, error)
@@ -351,10 +354,13 @@ func (c *vSphereClient) NewVirtualMachine(ctx context.Context, cloneSpec *types.
 		}
 	}
 
+	// guestinfo clones carry no customization spec (the guest applies its network
+	// itself from guestinfo), so there is no IP to wait for specifically.
 	var expectedIP *string
-	customFixedIP, ok := cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp)
-	if ok {
-		expectedIP = &customFixedIP.IpAddress
+	if cloneSpec.Customization != nil && len(cloneSpec.Customization.NicSettingMap) > 0 {
+		if customFixedIP, ok := cloneSpec.Customization.NicSettingMap[0].Adapter.Ip.(*types.CustomizationFixedIp); ok {
+			expectedIP = &customFixedIP.IpAddress
+		}
 	}
 
 	if err := c.WaitForVirtualMachineIP(ctx, vm, expectedIP, vmName); err != nil {
@@ -417,6 +423,27 @@ func (c *vSphereClient) SetVirtualMachineAnnotation(ctx context.Context, vm *obj
 
 	if err := task.Wait(ctxTo); err != nil {
 		return sdk.WrapError(err, "annotation reconfigure task failed for vm %q", vm.Name())
+	}
+
+	return nil
+}
+
+// ReconfigureVirtualMachine applies an arbitrary config spec to a VM. It is used
+// to push the per-worker guestinfo bootstrap (guestinfo.cds.cmd / .config) before
+// power-on, for models that have no guest-operations channel.
+func (c *vSphereClient) ReconfigureVirtualMachine(ctx context.Context, vm *object.VirtualMachine, spec types.VirtualMachineConfigSpec) error {
+	ctxTo, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
+	task, err := vm.Reconfigure(ctxTo, spec)
+	if err != nil {
+		return sdk.WrapError(err, "unable to reconfigure vm %q", vm.Name())
+	}
+
+	ctxWait, cancelWait := context.WithTimeout(ctx, vmTaskTimeout)
+	defer cancelWait()
+	if err := task.Wait(ctxWait); err != nil {
+		return sdk.WrapError(err, "reconfigure task failed for vm %q", vm.Name())
 	}
 
 	return nil

--- a/sdk/hatchery/hatchery.go
+++ b/sdk/hatchery/hatchery.go
@@ -626,11 +626,19 @@ func canRunJobWithModelV2(ctx context.Context, h InterfaceWithModels, j workerSt
 		},
 	}
 
+	// The worker binary must match the model's OS, so the download path cannot
+	// assume linux. Fall back to the probed arch when a model declares no
+	// os/arch; the API normalizes uname's spelling (x86_64 -> amd64).
+	workerOSArch := "linux/$(uname -m)"
+	if model.OSArch != "" {
+		workerOSArch = model.OSArch
+	}
+
 	preCmd := `#!/bin/sh
 if [ ! -z ` + "`which curl`" + ` ]; then
-	curl -L "{{.API}}/download/worker/linux/$(uname -m)" -o /usr/local/bin/worker --retry 10 --retry-max-time 120 >> /tmp/cds-worker-setup.log 2>&1 && chmod +x /usr/local/bin/worker
+	curl -L "{{.API}}/download/worker/` + workerOSArch + `" -o /usr/local/bin/worker --retry 10 --retry-max-time 120 >> /tmp/cds-worker-setup.log 2>&1 && chmod +x /usr/local/bin/worker
 elif [ ! -z ` + "`which wget`" + ` ]; then
-	wget "{{.API}}/download/worker/linux/$(uname -m)" -O /usr/local/bin/worker >> /tmp/cds-worker-setup.log 2>&1 && chmod +x /usr/local/bin/worker
+	wget "{{.API}}/download/worker/` + workerOSArch + `" -O /usr/local/bin/worker >> /tmp/cds-worker-setup.log 2>&1 && chmod +x /usr/local/bin/worker
 else
 	echo "Missing requirements to download CDS worker binary.";
 	exit 1;
@@ -671,10 +679,18 @@ fi`
 			return nil, nil, sdk.WithStack(err)
 		}
 
+		// Powering the VM off is OS-specific: FreeBSD needs -p, since -h halts the
+		// OS but leaves the VM running as far as vSphere knows, and it has no
+		// sudo — the guest's boot script already runs the worker as root.
+		postCmd := "sudo shutdown -h now"
+		if strings.HasPrefix(model.OSArch, "freebsd") {
+			postCmd = "shutdown -p now"
+		}
+
 		workerStarterModelWithModelv2 := sdk.WorkerStarterWorkerModel{
 			Cmd:         "PATH=$PATH worker",
 			PreCmd:      preCmd,
-			PostCmd:     "sudo shutdown -h now",
+			PostCmd:     postCmd,
 			ModelV2:     model,
 			VSphereSpec: vsphereSpec,
 		}


### PR DESCRIPTION
Some guest OSes cannot be driven the default way: the vSphere customization engine does not support them, and a credential-less image offers no account for guest operations to authenticate against. A model whose [[models]] entry sets guestInfo = true is now driven entirely through guestinfo keys instead.

The network is pushed as guestinfo.cds.net.* in the clone spec, which carries no customization spec, and the worker bootstrap as guestinfo.cds.cmd and guestinfo.cds.config before power-on. The guest consumes them at boot and starts the worker itself, so the readiness probe, the pre-start script and the worker launch are skipped and the model needs no guest credentials. The assigned IP is still recorded in the VM annotation, leaving IP accounting unchanged.

Optional debug access is injected as guestinfo.cds.access.*, from two new settings: sshAllowedCIDRs for the guest's packet-filter allowlist and injectSSHPublicKeys for its authorized_keys. Both default to empty, meaning no inbound access. The public keys reuse the OpenStack hatchery's validation, moved to the shared hatchery package, which requires a from= option on every key.

Add ReconfigureVirtualMachine to the vSphere client interface and route the flavor reconfiguration through it, bounding its task wait.

Derive the worker download URL from the model's os/arch instead of assuming linux, and power FreeBSD models off with shutdown -p now: -h leaves the VM running as far as vSphere knows.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
