### PR TITLE
feat(ui): fix explore navigation, run share links and browse sources

### DIFF
--- a/ui/libs/workflow-graph/src/lib/node/job-node.scss
+++ b/ui/libs/workflow-graph/src/lib/node/job-node.scss
@@ -7,7 +7,10 @@
 }
 
 .node {
-    position: relative;
+    // WebKit ignores a foreignObject's x/y and its ancestor transform when the
+    // HTML inside it is positioned, painting the content at the top-left of the
+    // root svg instead. Nothing in here may use position. See react-d3-tree#284.
+    position: static;
     width: 100%;
     height: 100%;
     border: 2px solid common.$polar_grey_3;
@@ -127,6 +130,9 @@
         background-color: inherit;
 
         [nz-button] {
+            // ant sets position: relative for the wave effect, which WebKit
+            // mispaints inside a foreignObject. See react-d3-tree#284.
+            position: static;
             margin-left: 10px;
             border-width: 2px;
             box-shadow: 1px 1px 1px #a2a3a3ab;

--- a/ui/src/app/shared/entity-reference.utils.ts
+++ b/ui/src/app/shared/entity-reference.utils.ts
@@ -1,0 +1,90 @@
+export type EntityReferenceKind = 'action' | 'model';
+
+/** A `uses:` or `runs-on:` value located in an entity definition. */
+export class EntityReference {
+    line: number;
+    startColumn: number;
+    endColumn: number;
+    kind: EntityReferenceKind;
+    /** Value as written, ref suffix included. */
+    value: string;
+}
+
+/** Pieces of a CDS v2 entity path: <projectKey>/<vcsName>/<repoName>/<name>@<ref>. */
+export class EntityPath {
+    projectKey?: string;
+    vcs?: string;
+    repository?: string;
+    name: string;
+    ref?: string;
+}
+
+export class EntityReferenceUtils {
+    private static readonly LINE = /^(\s*(?:-\s*)?(?:uses|runs-on):\s*)(\S.*?)\s*$/;
+
+    /** Prefixes of a reference to a file of the current repository. */
+    private static readonly LOCAL_PREFIXES = [
+        '.cds/actions/',
+        '.cds/worker-models/',
+        '.cds/workflow-templates/'
+    ];
+
+    /** Locate the references of a YAML definition, with the columns of each value. */
+    static scan(content: string): Array<EntityReference> {
+        if (!content) {
+            return [];
+        }
+        const references: Array<EntityReference> = [];
+        content.split('\n').forEach((text, i) => {
+            const match = text.match(EntityReferenceUtils.LINE);
+            if (!match) {
+                return;
+            }
+            references.push(<EntityReference>{
+                line: i + 1,
+                startColumn: match[1].length + 1,
+                endColumn: match[1].length + match[2].length + 1,
+                kind: match[1].indexOf('runs-on') !== -1 ? 'model' : 'action',
+                value: match[2].replace(/^["']|["']$/g, '')
+            });
+        });
+        return references;
+    }
+
+    /**
+     * A repository name holds a slash, so the name is the last segment and the
+     * repository is everything between the vcs and it. Returns null for values
+     * that cannot denote a CDS entity, such as the `actions/checkout` plugins.
+     *
+     * `.cds/...` values point at a file of the current repository. The engine
+     * resolves those by path and takes the entity name from the file content, which
+     * is not readable from here, so the file name is used as a best guess.
+     */
+    static parse(raw: string): EntityPath {
+        const at = raw.indexOf('@');
+        const path = at === -1 ? raw : raw.substring(0, at);
+        const ref = at === -1 ? null : raw.substring(at + 1);
+
+        const localPrefix = EntityReferenceUtils.LOCAL_PREFIXES.find(p => path.startsWith(p));
+        if (localPrefix) {
+            const file = path.substring(localPrefix.length);
+            const name = file.substring(file.lastIndexOf('/') + 1).replace(/\.ya?ml$/, '');
+            return name ? <EntityPath>{ name, ref } : null;
+        }
+
+        const segments = path.split('/').filter(s => s.length > 0);
+        if (segments.length === 1) {
+            return <EntityPath>{ name: segments[0], ref };
+        }
+        if (segments.length >= 4) {
+            return <EntityPath>{
+                projectKey: segments[0],
+                vcs: segments[1],
+                repository: segments.slice(2, segments.length - 1).join('/'),
+                name: segments[segments.length - 1],
+                ref
+            };
+        }
+        return null;
+    }
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -256,6 +256,7 @@ import { NsAutoHeightTableDirective } from './directives/ns-auto-height-table.di
 import { NzTypographyModule } from 'ng-zorro-antd/typography';
 import { DateFromNowComponent } from './date-from-now/date-from-now';
 import { NzTreeModule } from 'ng-zorro-antd/tree';
+import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
 import { NzResultModule } from 'ng-zorro-antd/result';
 import { SearchableComponent } from './searchable/searchable.component';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
@@ -419,6 +420,7 @@ const icons: IconDefinition[] = [
         NzTagModule,
         NzTooltipModule,
         NzTreeModule,
+        NzTreeSelectModule,
         NzTreeViewModule,
         NzTypographyModule,
         NzUploadModule,
@@ -623,6 +625,7 @@ const icons: IconDefinition[] = [
         NzTagModule,
         NzTooltipModule,
         NzTreeModule,
+        NzTreeSelectModule,
         NzTreeViewModule,
         NzTypographyModule,
         NzUploadModule,

--- a/ui/src/app/views/projectv2/explore/explore-entity.component.ts
+++ b/ui/src/app/views/projectv2/explore/explore-entity.component.ts
@@ -17,6 +17,7 @@ import { JSONSchema } from "app/model/schema.model";
 import { PreferencesState } from "app/store/preferences.state";
 import { load } from "js-yaml";
 import { editor, } from 'monaco-editor';
+import { EntityReference, EntityReferenceUtils } from 'app/shared/entity-reference.utils';
 
 declare const monaco: any;
 
@@ -45,6 +46,10 @@ export class ProjectV2ExploreEntityComponent implements OnInit, OnDestroy {
 	resizingSubscription: Subscription;
 	showWorkflowPreview: boolean;
 	vcs: VCSProject;
+
+	private _editorInstance: editor.ICodeEditor;
+	private _decorations: editor.IEditorDecorationsCollection;
+	private _references: Array<EntityReference> = [];
 
 	constructor(
 		private _activatedRoute: ActivatedRoute,
@@ -144,7 +149,55 @@ export class ProjectV2ExploreEntityComponent implements OnInit, OnDestroy {
 				schema: JSONSchema.flat(this.jsonSchema)
 			}]
 		});
+		this._editorInstance = <editor.ICodeEditor>e;
+		// The editor is destroyed and rebuilt on every entity load, so the collection
+		// has to be rebound; the previous one belongs to a discarded editor.
+		this._decorations = this._editorInstance.createDecorationsCollection();
+		// Monaco drops decorations whenever the model value is replaced.
+		this._editorInstance.onDidChangeModelContent(() => this.applyDecorations());
+		this._editorInstance.onMouseDown(event => {
+			const position = event.target?.position;
+			if (!position) {
+				return;
+			}
+			const reference = this._references.find(r => r.line === position.lineNumber
+				&& position.column >= r.startColumn && position.column <= r.endColumn);
+			if (reference) {
+				this.openReference(reference);
+			}
+		});
 		this.editor.layout();
+		this.applyDecorations();
+	}
+
+	/** Follow a `uses:` / `runs-on:` value to the entity it denotes. */
+	openReference(reference: EntityReference): void {
+		const path = EntityReferenceUtils.parse(reference.value);
+		if (!path) {
+			return;
+		}
+		const entityType = reference.kind === 'model' ? EntityType.WorkerModel : EntityType.Action;
+		const ref = path.ref ?? this.currentRef;
+		this._router.navigate([
+			'/project', path.projectKey ?? this.projectKey,
+			'explore',
+			'vcs', path.vcs ?? this.vcs.name,
+			'repository', path.repository ?? this.repository.name,
+			EntityTypeUtil.toURLParam(entityType), path.name
+		], ref ? { queryParams: { ref } } : {});
+	}
+
+	private applyDecorations(): void {
+		if (!this._decorations) {
+			return;
+		}
+		// Only values that denote a CDS entity are offered as links.
+		this._references = EntityReferenceUtils.scan(this.entity?.data)
+			.filter(r => !!EntityReferenceUtils.parse(r.value));
+		this._decorations.set(this._references.map(r => ({
+			range: { startLineNumber: r.line, startColumn: r.startColumn, endLineNumber: r.line, endColumn: r.endColumn },
+			options: { inlineClassName: 'cds-source-link', hoverMessage: { value: 'Open definition' } }
+		})));
 	}
 
 	panelStartResize(): void {

--- a/ui/src/app/views/projectv2/explore/explore-sidebar.component.ts
+++ b/ui/src/app/views/projectv2/explore/explore-sidebar.component.ts
@@ -200,10 +200,13 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
             entities.push(entity);
             m.set(entity.type, entities);
         });
-        Object.keys(m).forEach(key => {
-            m[key].sort((a, b) => { a.name < b.name ? -1 : 1 });
-            if (Object.keys(this.treeExpandState).indexOf(vcs.name + '/' + repo.name + '/' + key) === -1) {
-                this.treeExpandState[vcs.name + '/' + repo.name + '/' + key] = true;
+        m.forEach((entities, type) => {
+            entities.sort((a, b) => a.name < b.name ? -1 : 1);
+            const typeKey = vcs.name + '/' + repo.name + '/' + type;
+            // Workflows are the usual entry point of a repository; opening every
+            // folder buries them, so the others stay closed until asked for.
+            if (Object.keys(this.treeExpandState).indexOf(typeKey) === -1) {
+                this.treeExpandState[typeKey] = type === EntityType.Workflow;
             }
         });
         this.entities[vcs.name + '/' + repo.name] = m;
@@ -286,10 +289,12 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
                 if (keys.indexOf(repoKey) !== -1) {
                     state[repoKey] = this.treeExpandState[repoKey];
                 }
-                // Persist entity folder that were closed
-                Object.keys(this.entities[vcs.name + '/' + repo.name] ?? {}).forEach(entityType => {
-                    if (keys.indexOf(vcs.name + '/' + repo.name + '/' + entityType) !== -1 && !this.treeExpandState[vcs.name + '/' + repo.name + '/' + entityType]) {
-                        state[vcs.name + '/' + repo.name + '/' + entityType] = false;
+                // Persist entity folders that were opened or closed. Both directions
+                // matter since the default is no longer "everything open".
+                (this.entities[repoKey] ?? new Map<EntityType, Array<Entity>>()).forEach((_, entityType) => {
+                    const typeKey = repoKey + '/' + entityType;
+                    if (keys.indexOf(typeKey) !== -1) {
+                        state[typeKey] = this.treeExpandState[typeKey];
                     }
                 });
             });
@@ -320,16 +325,13 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
         if (loadRepo) {
             await this.loadRepository(vcs, repo);
         }
-        let entityType: EntityType = null;
-        if (params['workflowName']) {
-            entityType = EntityType.Workflow;
-        } else if (params['actionName']) {
-            entityType = EntityType.Action;
-        } else if (params['workerModelName']) {
-            entityType = EntityType.WorkerModel;
-        }
-        if (entityType) {
-            this.treeExpandState[vcs.name + '/' + repo.name + '/' + entityType] = true;
+        if (params['entityType']) {
+            try {
+                const entityType = EntityTypeUtil.fromURLParam(params['entityType']);
+                this.treeExpandState[vcs.name + '/' + repo.name + '/' + entityType] = true;
+            } catch (e) {
+                // URL carries an unknown entity type, nothing to expand
+            }
         }
     }
 

--- a/ui/src/app/views/projectv2/run/run-sources.component.ts
+++ b/ui/src/app/views/projectv2/run/run-sources.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from "@angular/core";
 import { Store } from "@ngxs/store";
 import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { PreferencesState } from "app/store/preferences.state";
@@ -7,73 +7,294 @@ import { EditorOptions, NzCodeEditorComponent } from "ng-zorro-antd/code-editor"
 import { Subscription } from "rxjs";
 import { V2WorkflowRun } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
 import { dump } from "js-yaml";
+import { NzTreeNode, NzTreeNodeOptions } from "ng-zorro-antd/tree";
+import { EntityReferenceKind, EntityReferenceUtils } from "app/shared/entity-reference.utils";
+
+export type SourceFileKind = 'workflow' | 'action' | 'model';
+
+/**
+ * CDS v2 entity paths are <projectKey>/<vcsName>/<repoName>/<name>@<ref>, and the
+ * ref itself may hold slashes, so the name is read from the part before the '@'.
+ */
+export class SourceFile {
+    /** Raw key as held in the run snapshot, ref included. */
+    key: string;
+    /** Key without the @ref suffix. */
+    path: string;
+    /** Entity name, the last segment of the path. */
+    name: string;
+    /** Project, vcs and repository holding the entity. */
+    scope: string;
+    /** Ref the entity was resolved at, shortened for display. */
+    ref: string;
+    kind: SourceFileKind;
+    /** Human readable entity type, shown instead of an icon. */
+    kindLabel: string;
+    content: string;
+}
+
+/** A `uses:` or `runs-on:` value that resolves to another file of the snapshot. */
+class SourceReference {
+    line: number;
+    startColumn: number;
+    endColumn: number;
+    target: number;
+}
 
 @Component({
     standalone: false,
-	selector: 'app-run-sources',
-	templateUrl: './run-sources.html',
-	styleUrls: ['./run-sources.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush
+    selector: 'app-run-sources',
+    templateUrl: './run-sources.html',
+    styleUrls: ['./run-sources.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 @AutoUnsubscribe()
 export class RunSourcesComponent implements OnInit, OnChanges, OnDestroy {
-	@ViewChild('editor') editor: NzCodeEditorComponent;
+    @ViewChild('editor') editor: NzCodeEditorComponent;
 
-	@Input() run: V2WorkflowRun;
+    @Input() run: V2WorkflowRun;
+    /** Key of the file to open, so a shared link can target a precise source. */
+    @Input() selectedFileKey: string;
 
-	editorOption: EditorOptions;
-	resizingSubscription: Subscription;
-	filenames: Array<string> = [];
-	files: Array<string> = [];
-	selectedFileIndex: number = 0;
+    @Output() selectedFileKeyChange = new EventEmitter<string>();
 
-	constructor(
-		private _cd: ChangeDetectorRef,
-		private _store: Store
-	) { }
+    editorOption: EditorOptions;
+    resizingSubscription: Subscription;
 
-	ngOnChanges(): void {
-		let files = [dump(this.run.workflow_data.workflow, { lineWidth: -1 })];
-		let filenames = ['workflow - ' + this.run.workflow_name];
-		Object.keys(this.run.workflow_data.actions ?? []).sort().forEach((k) => {
-			files.push(dump(this.run.workflow_data.actions[k], { lineWidth: -1 }));
-			filenames.push('action - ' + k);
-		});
-		Object.keys(this.run.workflow_data.worker_models ?? []).sort().forEach((k) => {
-			files.push(dump(this.run.workflow_data.worker_models[k], { lineWidth: -1 }));
-			filenames.push('model - ' + k);
-		});
-		this.files = files;
-		this.filenames = filenames;
-		if (this.selectedFileIndex > this.files.length) { this.selectedFileIndex = 0; }
-		this._cd.markForCheck();
-	}
+    files: Array<SourceFile> = [];
+    /** Grouped file list rendered as a tree inside the path dropdown. */
+    treeNodes: Array<NzTreeNodeOptions> = [];
+    /** Visited files, as indexes in `files`. The last entry is the current file. */
+    history: Array<number> = [];
+    historyIndex: number = -1;
 
-	ngOnDestroy(): void { } // Should be set to use @AutoUnsubscribe with AOT
+    private _editorInstance: editor.ICodeEditor;
+    private _decorations: editor.IEditorDecorationsCollection;
+    private _references: Array<SourceReference> = [];
 
-	ngOnInit(): void {
-		this.editorOption = {
-			language: 'yaml',
-			minimap: { enabled: false },
-			readOnly: true,
-			scrollBeyondLastLine: false,
-			ariaLabel: 'Workflow sources viewer'
-		};
+    constructor(
+        private _cd: ChangeDetectorRef,
+        private _store: Store
+    ) { }
 
-		this.resizingSubscription = this._store.select(PreferencesState.resizing).subscribe(resizing => {
-			if (!resizing && this.editor) {
-				this.editor.layout();
-			}
-		});
-	}
+    get current(): SourceFile { return this.files[this.currentIndex] ?? null; }
+    get currentIndex(): number { return this.history[this.historyIndex] ?? 0; }
+    get canBack(): boolean { return this.historyIndex > 0; }
+    get canForward(): boolean { return this.historyIndex < this.history.length - 1; }
 
-	selectFile(index: number): void {
-		this.selectedFileIndex = index;
-		this._cd.markForCheck();
-	}
+    get selectedTreeKey(): string { return `${this.currentIndex}`; }
 
-	onEditorInit(e: editor.ICodeEditor | editor.IEditor): void {
-		this.editor.layout();
-	}
+    /** Closed control reads "Worker model · ubuntu-latest @ main"; full path in the tooltip. */
+    displayPath = (node: NzTreeNode): string => {
+        const file = this.files[parseInt(node.key, 10)];
+        if (!file) {
+            return node.title;
+        }
+        return `${file.kindLabel} · ${file.name}` + (file.ref ? ` @ ${file.ref}` : '');
+    };
 
+    onTreeSelect(key: string): void {
+        if (!key || key.startsWith('group:')) {
+            return;
+        }
+        this.openFile(parseInt(key, 10));
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        // The parent mirrors back the opened file, so only a new run rebuilds the
+        // list. Otherwise every navigation would reset the history.
+        if (!changes['run']) {
+            if (changes['selectedFileKey'] && this.selectedFileKey && this.selectedFileKey !== this.current?.key) {
+                this.openFile(this.files.findIndex(f => f.key === this.selectedFileKey));
+            }
+            return;
+        }
+
+        const previousKey = this.current?.key;
+
+        const workflowKey = `${this.run.vcs_server}/${this.run.repository}/${this.run.workflow_name}`;
+        this.files = [RunSourcesComponent.buildFile(workflowKey, 'workflow',
+            dump(this.run.workflow_data.workflow, { lineWidth: -1 }))];
+        Object.keys(this.run.workflow_data.actions ?? {}).sort().forEach(k => {
+            this.files.push(RunSourcesComponent.buildFile(k, 'action',
+                dump(this.run.workflow_data.actions[k], { lineWidth: -1 })));
+        });
+        Object.keys(this.run.workflow_data.worker_models ?? {}).sort().forEach(k => {
+            this.files.push(RunSourcesComponent.buildFile(k, 'model',
+                dump(this.run.workflow_data.worker_models[k], { lineWidth: -1 })));
+        });
+
+        const groups: Array<{ kind: SourceFileKind, title: string }> = [
+            { kind: 'workflow', title: 'Workflow' },
+            { kind: 'action', title: 'Actions' },
+            { kind: 'model', title: 'Worker models' }
+        ];
+        this.treeNodes = groups.map(g => (<NzTreeNodeOptions>{
+            title: g.title,
+            key: 'group:' + g.kind,
+            expanded: true,
+            selectable: false,
+            isGroup: true,
+            children: this.files
+                .map((f, index) => ({ f, index }))
+                .filter(entry => entry.f.kind === g.kind)
+                .map(entry => (<NzTreeNodeOptions>{
+                    title: entry.f.name,
+                    key: `${entry.index}`,
+                    isLeaf: true,
+                    name: entry.f.name,
+                    scope: entry.f.scope,
+                    ref: entry.f.ref
+                }))
+        })).filter(node => node.children.length > 0);
+
+        // Honour a shared link, else keep the reader where they were on refresh.
+        const wanted = this.selectedFileKey ?? previousKey;
+        const restored = wanted ? this.files.findIndex(f => f.key === wanted) : -1;
+        this.history = [restored !== -1 ? restored : 0];
+        this.historyIndex = 0;
+
+        this.refreshReferences();
+        this.selectedFileKeyChange.emit(this.current?.key);
+        this._cd.markForCheck();
+    }
+
+    ngOnDestroy(): void { } // Should be set to use @AutoUnsubscribe with AOT
+
+    ngOnInit(): void {
+        this.editorOption = {
+            language: 'yaml',
+            minimap: { enabled: false },
+            readOnly: true,
+            scrollBeyondLastLine: false,
+            ariaLabel: 'Workflow sources viewer'
+        };
+
+        this.resizingSubscription = this._store.select(PreferencesState.resizing).subscribe(resizing => {
+            if (!resizing && this.editor) {
+                this.editor.layout();
+            }
+        });
+    }
+
+    static readonly KIND_LABELS: { [kind: string]: string } = {
+        workflow: 'Workflow',
+        action: 'Action',
+        model: 'Worker model'
+    };
+
+    static buildFile(key: string, kind: SourceFileKind, content: string): SourceFile {
+        const at = key.indexOf('@');
+        const path = at === -1 ? key : key.substring(0, at);
+        const ref = at === -1 ? '' : key.substring(at + 1);
+        const separator = path.lastIndexOf('/');
+        return <SourceFile>{
+            key,
+            path,
+            name: separator === -1 ? path : path.substring(separator + 1),
+            scope: separator === -1 ? '' : path.substring(0, separator),
+            ref: ref.replace(/^refs\/(heads|tags)\//, ''),
+            kind,
+            kindLabel: RunSourcesComponent.KIND_LABELS[kind],
+            content
+        };
+    }
+
+    /** Open a file, dropping any forward history. */
+    openFile(index: number): void {
+        if (index < 0 || index >= this.files.length || index === this.currentIndex) {
+            return;
+        }
+        this.history = this.history.slice(0, this.historyIndex + 1);
+        this.history.push(index);
+        this.historyIndex = this.history.length - 1;
+        this.navigated();
+    }
+
+    back(): void {
+        if (this.canBack) {
+            this.historyIndex--;
+            this.navigated();
+        }
+    }
+
+    forward(): void {
+        if (this.canForward) {
+            this.historyIndex++;
+            this.navigated();
+        }
+    }
+
+    private navigated(): void {
+        this.refreshReferences();
+        this.selectedFileKeyChange.emit(this.current?.key);
+        this._cd.markForCheck();
+    }
+
+    onEditorInit(e: editor.ICodeEditor | editor.IEditor): void {
+        this._editorInstance = <editor.ICodeEditor>e;
+        // A rebuilt editor needs its own collection; the previous one belongs to a
+        // discarded editor and setting on it renders nothing.
+        this._decorations = this._editorInstance.createDecorationsCollection();
+        // Monaco drops every decoration when the model value is replaced, which
+        // happens after navigation pushes the new content through ngModel.
+        this._editorInstance.onDidChangeModelContent(() => this.applyDecorations());
+        this._editorInstance.onMouseDown(event => {
+            const position = event.target?.position;
+            if (!position) {
+                return;
+            }
+            const reference = this._references.find(r => r.line === position.lineNumber
+                && position.column >= r.startColumn && position.column <= r.endColumn);
+            if (reference) {
+                this.openFile(reference.target);
+            }
+        });
+        this.editor.layout();
+        this.applyDecorations();
+    }
+
+    /**
+     * Locate every `uses:` / `runs-on:` value of the current file that resolves to
+     * another file of the snapshot, so it can be rendered and clicked as a link.
+     */
+    private refreshReferences(): void {
+        this._references = [];
+        EntityReferenceUtils.scan(this.current?.content).forEach(reference => {
+            const target = this.resolve(reference.kind, reference.value);
+            if (target !== -1) {
+                this._references.push(<SourceReference>{
+                    line: reference.line,
+                    startColumn: reference.startColumn,
+                    endColumn: reference.endColumn,
+                    target
+                });
+            }
+        });
+        this.applyDecorations();
+    }
+
+    /** Snapshot keys are full paths; references may use a shorter form and an @ref suffix. */
+    private resolve(kind: EntityReferenceKind, reference: string): number {
+        const wanted = reference.split('@')[0].trim();
+        if (!wanted) {
+            return -1;
+        }
+        const wantedName = wanted.substring(wanted.lastIndexOf('/') + 1);
+        const candidates = this.files.filter(f => f.kind === kind);
+        const found = candidates.find(f => f.path === wanted)
+            ?? candidates.find(f => f.path.endsWith('/' + wanted))
+            ?? candidates.find(f => f.name === wantedName);
+        return found ? this.files.indexOf(found) : -1;
+    }
+
+    private applyDecorations(): void {
+        if (!this._decorations) {
+            return;
+        }
+        this._decorations.set(this._references.map(r => ({
+            range: { startLineNumber: r.line, startColumn: r.startColumn, endLineNumber: r.line, endColumn: r.endColumn },
+            options: { inlineClassName: 'cds-source-link', hoverMessage: { value: 'Open definition' } }
+        })));
+    }
 }

--- a/ui/src/app/views/projectv2/run/run-sources.html
+++ b/ui/src/app/views/projectv2/run/run-sources.html
@@ -1,10 +1,36 @@
-<nz-tabs nzType="card" nzSize="small" [nzSelectedIndex]="selectedFileIndex">
-  @for (f of filenames; track f; let i = $index) {
-    <nz-tab [nzTitle]="f" (nzSelect)="selectFile(i)"></nz-tab>
-  }
-</nz-tabs>
+<div class="toolbar" (dblclick)="$event.stopPropagation();">
+  <button nz-button nzType="text" nzSize="small" [disabled]="!canBack" (click)="back()"
+    title="Back" aria-label="Back">
+    <span nz-icon nzType="arrow-left" aria-hidden="true"></span>
+  </button>
+  <button nz-button nzType="text" nzSize="small" [disabled]="!canForward" (click)="forward()"
+    title="Forward" aria-label="Forward">
+    <span nz-icon nzType="arrow-right" aria-hidden="true"></span>
+  </button>
 
-@if (files.length > 0) {
-  <nz-code-editor #editor [ngModel]="files[selectedFileIndex]" [nzEditorOption]="editorOption"
+  <label class="cds-sr-only" for="cds-field-run-source">Opened source file</label>
+  <nz-tree-select class="path" nzId="cds-field-run-source" nzSize="small" nzShowSearch
+    nzPlaceHolder="Select a source" [nzNodes]="treeNodes" [nzDefaultExpandAll]="true"
+    [nzDisplayWith]="displayPath" [nzTreeTemplate]="nodeTemplate" [ngModel]="selectedTreeKey"
+    (ngModelChange)="onTreeSelect($event)" [nzDropdownMatchSelectWidth]="true"
+    [title]="current?.key"></nz-tree-select>
+</div>
+
+<ng-template #nodeTemplate let-node>
+  @if (node.origin.isGroup) {
+    <span class="tree-group">{{node.title}}</span>
+  } @else {
+    <span class="tree-leaf">
+      <span class="name">{{node.origin.name}}</span>
+      @if (node.origin.ref) {
+        <span class="ref">&#64;{{node.origin.ref}}</span>
+      }
+      <span class="scope">{{node.origin.scope}}</span>
+    </span>
+  }
+</ng-template>
+
+@if (current) {
+  <nz-code-editor #editor [ngModel]="current.content" [nzEditorOption]="editorOption"
   (nzEditorInitialized)="onEditorInit($event)" (dblclick)="$event.stopPropagation();"></nz-code-editor>
 }

--- a/ui/src/app/views/projectv2/run/run-sources.scss
+++ b/ui/src/app/views/projectv2/run/run-sources.scss
@@ -8,56 +8,64 @@
   position: relative;
 }
 
-app-tabs {
-  ::ng-deep {
-    .ant-menu {
-      background-color: common.$greyBackground !important;
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 2px 8px;
+  background-color: common.$greyBackground;
+  border-bottom: 1px solid #f0f0f0;
 
-      :host-context(.night) & {
-        background-color: common.$darkBackground !important;
-        color: common.$darkTheme_grey_6;
-      }
+  :host-context(.night) & {
+    background-color: common.$darkBackground;
+    border-bottom-color: #303030;
+  }
+
+  // The opened entity doubles as the file picker trigger.
+  .path {
+    flex: 1;
+    min-width: 0;
+    margin-left: 4px;
+
+    // nz-tree-select has no nzBorderless input, so the frame is removed here.
+    ::ng-deep .ant-select-selector {
+      border-color: transparent !important;
+      background-color: transparent !important;
+      box-shadow: none !important;
+      padding-left: 0 !important;
     }
   }
+
 }
 
+.tree-group {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #979797;
+}
 
-nz-tabset {
-  background-color: #1b1c1d;
+.tree-leaf {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
 
-  ::ng-deep {
-    .ant-tabs-tab {
-      padding: 3px 16px !important;
-      cursor: inherit !important;
+  .name {
+    font-weight: 500;
+  }
 
-      :host-context(.night) & {
-        background-color: #141414;
-      }
-    }
-
-    .ant-tabs-tab-active {
-      :host-context(.night) & {
-        background-color: #1e1e1e;
-        border-bottom-color: #1e1e1e !important;
-      }
-    }
-
-    .ant-tabs-tab-btn {
-      color: #979797;
-
-      :host-context(.night) & {
-        color: #828282;
-      }
-    }
-
-    nz-tabs-nav {
-      margin: 0 !important;
-    }
+  .ref,
+  .scope {
+    color: #979797;
+    font-size: 12px;
   }
 }
 
 nz-code-editor {
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   border-left: 1px solid #f0f0f0;
 
   :host-context(.night) & {
@@ -65,3 +73,4 @@ nz-code-editor {
     border-left: 1px solid #303030;
   }
 }
+

--- a/ui/src/app/views/projectv2/run/run.component.ts
+++ b/ui/src/app/views/projectv2/run/run.component.ts
@@ -65,6 +65,7 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     workflowRunInfo: Array<WorkflowRunInfo>;
     selectedItemType: string;
     selectedItemShareLink: string;
+    selectedSourceKey: string;
     selectedJobRun: V2WorkflowRunJob;
     selectedHookName: string;
     selectedRunResult: WorkflowRunResult;
@@ -108,6 +109,15 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     static INFO_PANEL_KEY = 'workflow-run-info';
     static JOB_PANEL_KEY = 'workflow-run-job';
 
+    /** Panels without a target are serialized as "type" alone, others as "type:encodedData". */
+    static parsePanelParam(value: string): { type: string, data: string } {
+        const separator = value.indexOf(':');
+        if (separator === -1) {
+            return { type: value, data: null };
+        }
+        return { type: value.substring(0, separator), data: decodeURIComponent(value.substring(separator + 1)) };
+    }
+
     private _cd = inject(ChangeDetectorRef);
     private _workflowService = inject(V2WorkflowRunService);
     private _store = inject(Store);
@@ -135,8 +145,8 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
                 return from(this.load(workflowRunID).then(() => {
                     const params = this._route.snapshot.queryParams;
                     if (params['panel']) {
-                        const splitted = params['panel'].split(':');
-                        this.openPanel(splitted[0], decodeURI(splitted[1]) ?? null);
+                        const panel = ProjectV2RunComponent.parsePanelParam(params['panel']);
+                        this.openPanel(panel.type, panel.data);
                     }
                 }));
             })
@@ -144,8 +154,8 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
         this.queryParamsSub = this._route.queryParams.subscribe(params => {
             if (params['panel'] && this.workflowRun && this.jobs) {
-                const splitted = params['panel'].split(':');
-                this.openPanel(splitted[0], splitted[1] ?? null);
+                const panel = ProjectV2RunComponent.parsePanelParam(params['panel']);
+                this.openPanel(panel.type, panel.data);
             }
         });
 
@@ -398,15 +408,31 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
             case 'test':
                 this.selectedTest = data;
                 break;
+            case 'sources':
+                this.selectedSourceKey = data;
+                break;
         }
 
         this.selectedItemType = type;
 
-        let params = new HttpParams();
-        params = params.append('panel', `${type}:${encodeURIComponent(data)}`);
-        this.selectedItemShareLink = `/project/${this.projectKey}/run/${this.workflowRun.id}?${params.toString()}`;
+        this.refreshShareLink(type, data);
 
         this._cd.markForCheck();
+    }
+
+    /** Keep the share link pointed at the source file currently opened in the panel. */
+    onSourceFileChange(key: string): void {
+        this.selectedSourceKey = key;
+        if (this.selectedItemType === 'sources') {
+            this.refreshShareLink('sources', key);
+            this._cd.markForCheck();
+        }
+    }
+
+    private refreshShareLink(type: string, data: string): void {
+        let params = new HttpParams();
+        params = params.append('panel', data === null || data === undefined ? type : `${type}:${encodeURIComponent(data)}`);
+        this.selectedItemShareLink = `/project/${this.projectKey}/run/${this.workflowRun.id}?${params.toString()}`;
     }
 
     async refreshPanel() {
@@ -444,6 +470,7 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         delete this.selectedRunResult;
         delete this.selectedJobRun;
         delete this.selectedTest;
+        delete this.selectedSourceKey;
     }
 
     async changeRunAttempt(value: number) {

--- a/ui/src/app/views/projectv2/run/run.html
+++ b/ui/src/app/views/projectv2/run/run.html
@@ -314,7 +314,7 @@ nzContent="{{workflowRun.contexts.cds.version}}" [nzCopyTooltips]="null"></span>
   <app-resizable-panel [minSize]="400" [initialSize]="jobPanelSize"
     (onGrabbingStart)="panelStartResize()" (onGrabbingEnd)="jobPanelEndResize($event)"
     (dblclick)="$event.stopPropagation(); dblClickOnPanel()">
-    <div class="controls">
+    <div class="controls" (dblclick)="$event.stopPropagation();">
       <div class="control" title="Close panel" appClickable aria-label="Close panel" (click)="clickClosePanel()">
         <span nz-icon nzType="close" nzTheme="outline" aria-hidden="true"></span>
       </div>
@@ -338,7 +338,8 @@ nzContent="{{workflowRun.contexts.cds.version}}" [nzCopyTooltips]="null"></span>
       <app-run-result [result]="selectedRunResult"></app-run-result>
     }
     @if (selectedItemType === 'sources') {
-      <app-run-sources [run]="workflowRun"></app-run-sources>
+      <app-run-sources [run]="workflowRun" [selectedFileKey]="selectedSourceKey"
+      (selectedFileKeyChange)="onSourceFileChange($event)"></app-run-sources>
     }
     @if (selectedItemType === 'contexts') {
       <app-run-contexts [run]="workflowRun"></app-run-contexts>

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -13,6 +13,14 @@ body {
     overflow-y: hidden;
 }
 
+// Monaco decoration marking a `uses:` / `runs-on:` value that can be followed to
+// its definition. Global because Monaco renders outside component styling.
+.cds-source-link {
+    color: #177ddc !important;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 // Screenreader-only content: visually hidden, still announced by AT.
 .cds-sr-only {
     position: absolute !important;


### PR DESCRIPTION
- Safari: workflow v2 graph nodes were painted at the corner of the svg, since WebKit ignores a foreignObject transform when its content is positioned.
- Explore: opening an entity did not expand the tree down to it, the sidebar looked up route params that no route declares.
- Explore: entity type folders ignored their stored state and never persisted it, iterating a Map with Object.keys. Only workflows now open by default.
- Run: the share link of a panel without a target held a literal ":null", and its data was encoded and decoded with mismatched functions.
- Run: the share link now targets the source file opened in the panel.
- Run: the sources panel replaces its overflowing tabs by an entity picker, with back and forward navigation over the visited files.
- Run and explore: `uses` and `runs-on` values are rendered as links opening the definition they point at, in the panel or through the router.
- Run: double clicking the panel controls no longer toggles the full screen.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
