### PR TITLE
fix(api): keep plugin binaries available while they are uploaded

### DIFF
--- a/engine/api/grpc_plugin.go
+++ b/engine/api/grpc_plugin.go
@@ -206,32 +206,41 @@ func (api *API) postGRPCluginBinaryHandler() service.Handler {
 			return sdk.WrapError(sdk.ErrWrongRequest, "postGRPCluginBinaryHandler")
 		}
 
+		if _, err := plugin.LoadByName(ctx, api.mustDB(), name); err != nil {
+			return sdk.WrapError(err, "postGRPCluginBinaryHandler")
+		}
+
+		// The binary is uploaded before the transaction is opened: the object is replaced only when
+		// the upload completes, so the plugin stays downloadable, and the binaries of a same plugin
+		// can still be uploaded in parallel without waiting for the row lock taken below.
+		buff := bytes.NewBuffer(b.FileContent)
+		if err := plugin.UploadBinary(ctx, api.SharedStorage, &b, io.NopCloser(buff)); err != nil {
+			return sdk.WrapError(err, "unable to upload plugin binary")
+		}
+
 		tx, err := api.mustDB().Begin()
 		if err != nil {
 			return sdk.WrapError(err, "unable to start tx")
 		}
 		defer tx.Rollback() // nolint
 
-		p, err := plugin.LoadByName(ctx, tx, name)
+		p, err := plugin.LoadByNameForUpdate(ctx, tx, name)
 		if err != nil {
 			return sdk.WrapError(err, "postGRPCluginBinaryHandler")
 		}
 
-		buff := bytes.NewBuffer(b.FileContent)
-
-		old := p.GetBinary(b.OS, b.Arch)
-		if old == nil {
-			if err := plugin.AddBinary(ctx, tx, api.SharedStorage, p, &b, io.NopCloser(buff)); err != nil {
-				return sdk.WrapError(err, "unable to add plugin binary")
-			}
-		} else {
-			if err := plugin.UpdateBinary(ctx, tx, api.SharedStorage, p, &b, io.NopCloser(buff)); err != nil {
-				return sdk.WrapError(err, "unable to add plugin binary")
-			}
+		staleBinary, err := plugin.SetBinary(tx, p, &b)
+		if err != nil {
+			return sdk.WrapError(err, "unable to add plugin binary")
 		}
 
 		if err := tx.Commit(); err != nil {
 			return sdk.WrapError(err, "unable to commit tx")
+		}
+
+		// the replaced binary had another name, its object is not referenced anymore
+		if staleBinary != nil {
+			plugin.DeleteStaleBinary(ctx, api.SharedStorage, p, staleBinary)
 		}
 
 		return service.WriteJSON(w, p, http.StatusOK)
@@ -323,18 +332,21 @@ func (api *API) deleteGRPCluginBinaryHandler() service.Handler {
 		}
 		defer tx.Rollback() // nolint
 
-		p, err := plugin.LoadByName(ctx, tx, name)
+		p, err := plugin.LoadByNameForUpdate(ctx, tx, name)
 		if err != nil {
 			return sdk.WrapError(err, "unable to load plugin")
 		}
 
-		if err := plugin.DeleteBinary(ctx, tx, api.SharedStorage, p, os, arch); err != nil {
+		deletedBinary, err := plugin.DeleteBinary(tx, p, os, arch)
+		if err != nil {
 			return err
 		}
 
 		if err := tx.Commit(); err != nil {
 			return sdk.WrapError(err, "unable to commit tx")
 		}
+
+		plugin.DeleteStaleBinary(ctx, api.SharedStorage, p, deletedBinary)
 
 		return service.WriteJSON(w, nil, http.StatusOK)
 	}

--- a/engine/api/objectstore/fs.go
+++ b/engine/api/objectstore/fs.go
@@ -49,21 +49,38 @@ func (fss *FilesystemStore) Status(ctx context.Context) sdk.MonitoringStatusLine
 	return sdk.MonitoringStatusLine{Component: "Object-Store", Value: "Filesystem Storage", Status: sdk.MonitoringStatusOK}
 }
 
-// Store store a object on disk
+// Store store a object on disk. The content is written in a temporary file then moved in place, so
+// that a reader never gets a partially written object and an object being replaced stays readable
+// for the whole write.
 func (fss *FilesystemStore) Store(o Object, data io.ReadCloser) (string, error) {
+	defer data.Close()
+
 	dst := path.Join(fss.basedir, o.GetPath())
 	if err := os.MkdirAll(dst, 0755); err != nil {
 		return "", err
 	}
 	distfile := path.Join(dst, o.GetName())
-	f, err := os.OpenFile(distfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+
+	f, err := os.CreateTemp(dst, "."+o.GetName()+".tmp")
 	if err != nil {
 		return "", err
 	}
+	tmpfile := f.Name()
+	defer os.Remove(tmpfile) // no-op once the file has been renamed
 
-	_, err = io.Copy(f, data)
-	defer data.Close()
-	return distfile, err
+	if _, err := io.Copy(f, data); err != nil {
+		_ = f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(tmpfile, distfile); err != nil {
+		return "", err
+	}
+
+	return distfile, nil
 }
 
 // Fetch lookup on disk for data

--- a/engine/api/objectstore/fs_test.go
+++ b/engine/api/objectstore/fs_test.go
@@ -1,0 +1,41 @@
+package objectstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func TestFilesystemStoreReplaceObject(t *testing.T) {
+	basedir := t.TempDir()
+
+	fss, err := newFilesystemStore(context.TODO(), sdk.ProjectIntegration{}, ConfigOptionsFilesystem{Basedir: basedir})
+	require.NoError(t, err)
+
+	o := sdk.GRPCPluginBinary{Name: "my-plugin", OS: "linux", Arch: "amd64"}
+
+	_, err = fss.Store(o, io.NopCloser(strings.NewReader("v1")))
+	require.NoError(t, err)
+
+	_, err = fss.Store(o, io.NopCloser(strings.NewReader("v2-longer-content")))
+	require.NoError(t, err)
+
+	f, err := fss.Fetch(context.TODO(), o)
+	require.NoError(t, err)
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.Equal(t, "v2-longer-content", string(content))
+
+	// the temporary file used to write the object must not be left behind
+	entries, err := os.ReadDir(basedir + "/" + o.GetPath())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, o.GetName(), entries[0].Name())
+}

--- a/engine/api/plugin/dao.go
+++ b/engine/api/plugin/dao.go
@@ -104,6 +104,15 @@ func LoadByName(ctx context.Context, db gorp.SqlExecutor, name string) (*sdk.GRP
 	return get(ctx, db, query, LoadOptions.WithIntegrationModelName)
 }
 
+// LoadByNameForUpdate retrieves in database the plugin with given name and locks its row until the
+// end of the transaction. All the binaries of a plugin are stored in a single row: concurrent
+// updates of the binaries of a same plugin have to be serialized, otherwise the last writer drops
+// the binaries referenced by the others.
+func LoadByNameForUpdate(ctx context.Context, db gorp.SqlExecutor, name string) (*sdk.GRPCPlugin, error) {
+	query := gorpmapping.NewQuery("SELECT * FROM grpc_plugin WHERE name = $1 FOR UPDATE").Args(name)
+	return get(ctx, db, query, LoadOptions.WithIntegrationModelName)
+}
+
 // LoadByIntegrationModelIDAndType retrieves in database a single plugin associated to a integration model id with a specified type.
 func LoadByIntegrationModelIDAndType(ctx context.Context, db gorp.SqlExecutor, integrationModelID int64, typePlugin string) (*sdk.GRPCPlugin, error) {
 	query := gorpmapping.NewQuery("SELECT * FROM grpc_plugin WHERE integration_model_id = $1 AND type = $2").Args(integrationModelID, typePlugin)

--- a/engine/api/plugin/plugin.go
+++ b/engine/api/plugin/plugin.go
@@ -11,68 +11,88 @@ import (
 	"github.com/ovh/cds/sdk"
 )
 
-// AddBinary add binary to the plugin, uploading it to objectsore and updates databases
-func AddBinary(ctx context.Context, db gorp.SqlExecutor, storage objectstore.Driver, p *sdk.GRPCPlugin, b *sdk.GRPCPluginBinary, r io.ReadCloser) error {
-	objectPath, err := storage.Store(b, r)
-	if err != nil {
-		return err
-	}
-
-	b.ObjectPath = objectPath
-	p.Binaries = append(p.Binaries, *b)
-
-	return Update(db, p)
-}
-
-// UpdateBinary updates binary for the plugin, uploading it to objectsore and updates databases
-func UpdateBinary(ctx context.Context, db gorp.SqlExecutor, storageDriver objectstore.Driver, p *sdk.GRPCPlugin, b *sdk.GRPCPluginBinary, r io.ReadCloser) error {
-	var oldBinary *sdk.GRPCPluginBinary
-	var index int
-	for i := range p.Binaries {
-		if p.Binaries[i].OS == b.OS && p.Binaries[i].Arch == b.Arch {
-			oldBinary = &p.Binaries[i]
-			index = i
-			break
-		}
-	}
-	if oldBinary == nil {
-		return sdk.WithStack(sdk.ErrUnsupportedOSArchPlugin)
-	}
-
-	if err := storageDriver.Delete(ctx, oldBinary); err != nil {
-		log.Error(ctx, "UpdateBinary> unable to delete %+v", oldBinary)
-	}
-
+// UploadBinary uploads the content of a plugin binary to the storage, without referencing it in
+// database. The object is written under a key derived from the binary name, os and arch: a binary
+// being replaced is only overwritten when the upload completes, so the plugin stays downloadable
+// for the whole upload.
+func UploadBinary(ctx context.Context, storageDriver objectstore.Driver, b *sdk.GRPCPluginBinary, r io.ReadCloser) error {
 	objectPath, err := storageDriver.Store(b, r)
 	if err != nil {
 		return err
 	}
-
 	b.ObjectPath = objectPath
-	p.Binaries[index] = *b
-
-	return Update(db, p)
+	return nil
 }
 
-// DeleteBinary remove a binary for the plugin from objectsore and updates databases.
-func DeleteBinary(ctx context.Context, db gorp.SqlExecutor, storageDriver objectstore.Driver, p *sdk.GRPCPlugin, os, arch string) error {
+// SetBinary references an uploaded binary in the plugin, replacing the binary for the same os and
+// arch if any, and updates the plugin in database.
+// When the replaced binary was not stored under the same key as the new one, its object is not
+// referenced anymore and is returned: the caller must delete it with DeleteStaleBinary, once the
+// transaction is committed.
+// The plugin must have been loaded with LoadByNameForUpdate: all the binaries of a plugin are
+// stored in a single row.
+func SetBinary(db gorp.SqlExecutor, p *sdk.GRPCPlugin, b *sdk.GRPCPluginBinary) (*sdk.GRPCPluginBinary, error) {
+	var staleBinary *sdk.GRPCPluginBinary
+	index := -1
+	for i := range p.Binaries {
+		if p.Binaries[i].OS == b.OS && p.Binaries[i].Arch == b.Arch {
+			index = i
+			if old := p.Binaries[i]; !sameStorageKey(old, *b) {
+				staleBinary = &old
+			}
+			break
+		}
+	}
+
+	if index >= 0 {
+		p.Binaries[index] = *b
+	} else {
+		p.Binaries = append(p.Binaries, *b)
+	}
+
+	if err := Update(db, p); err != nil {
+		return nil, err
+	}
+
+	return staleBinary, nil
+}
+
+// DeleteStaleBinary removes from the storage a binary that is not referenced anymore. It never
+// fails the caller: the object is only leaked in the storage.
+func DeleteStaleBinary(ctx context.Context, storageDriver objectstore.Driver, p *sdk.GRPCPlugin, b *sdk.GRPCPluginBinary) {
+	if err := storageDriver.Delete(ctx, b); err != nil {
+		log.ErrorWithStackTrace(ctx, sdk.WrapError(err, "unable to delete stale binary %s of plugin %s (%s/%s)", b.Name, p.Name, b.OS, b.Arch))
+	}
+}
+
+// sameStorageKey returns true when both binaries are stored as the same object, ie. when storing
+// one overwrites the other.
+func sameStorageKey(a, b sdk.GRPCPluginBinary) bool {
+	return a.GetPath() == b.GetPath() && a.GetName() == b.GetName()
+}
+
+// DeleteBinary removes a binary for the plugin in database and returns it, so that the caller can
+// delete its object with DeleteStaleBinary once the transaction is committed.
+// The plugin must have been loaded with LoadByNameForUpdate.
+func DeleteBinary(db gorp.SqlExecutor, p *sdk.GRPCPlugin, os, arch string) (*sdk.GRPCPluginBinary, error) {
 	var oldBinary *sdk.GRPCPluginBinary
 	filteredBinaries := make(sdk.GRPCPluginBinaries, 0, len(p.Binaries))
 	for i := range p.Binaries {
 		if p.Binaries[i].OS == os && p.Binaries[i].Arch == arch {
-			oldBinary = &p.Binaries[i]
+			old := p.Binaries[i]
+			oldBinary = &old
 		} else {
 			filteredBinaries = append(filteredBinaries, p.Binaries[i])
 		}
 	}
 	if oldBinary == nil {
-		return sdk.WithStack(sdk.ErrUnsupportedOSArchPlugin)
-	}
-
-	if err := storageDriver.Delete(ctx, oldBinary); err != nil {
-		log.ErrorWithStackTrace(ctx, sdk.WrapError(err, "unable to delete plugin %s binary %s/%s", p.Name, os, arch))
+		return nil, sdk.WithStack(sdk.ErrUnsupportedOSArchPlugin)
 	}
 
 	p.Binaries = filteredBinaries
-	return Update(db, p)
+	if err := Update(db, p); err != nil {
+		return nil, err
+	}
+
+	return oldBinary, nil
 }

--- a/engine/worker/internal/plugin/binary.go
+++ b/engine/worker/internal/plugin/binary.go
@@ -19,8 +19,9 @@ import (
 
 const (
 	binaryDownloadRetry = 20
-	// a checksum mismatch is deterministic: the descriptor has just been read from the API,
-	// so retrying more than once only delays a failure that will not resolve itself
+	// a checksum mismatch is only deterministic as long as the published descriptor does not
+	// change: retrying more than once with the very same checksum only delays a failure that
+	// will not resolve itself
 	binaryChecksumRetry = 2
 )
 
@@ -38,16 +39,9 @@ func DownloadBinary(ctx context.Context, w workerruntime.Runtime, pluginName, cu
 
 	// The descriptor carried by the job payload can be older than the binary actually served
 	// by the API: read the checksum from the same source as the binary itself.
-	p, err := w.PluginGet(pluginName)
+	b, err := readBinaryDescriptor(w, pluginName, currentOS, currentARCH)
 	if err != nil {
-		return nil, sdk.WrapError(err, "unable to get plugin %q", pluginName)
-	}
-	b := p.GetBinary(currentOS, currentARCH)
-	if b == nil {
-		return nil, sdk.NewErrorFrom(sdk.ErrNotFound, "unable to find plugin %q for %s/%s", pluginName, currentOS, currentARCH)
-	}
-	if b.SHA512sum == "" {
-		return nil, sdk.NewErrorFrom(sdk.ErrPluginInvalid, "plugin %q: binary %q has no published sha512sum, refusing to run it", pluginName, b.Name)
+		return nil, err
 	}
 
 	if _, err := w.BaseDir().Stat(b.Name); err == nil {
@@ -68,6 +62,22 @@ func DownloadBinary(ctx context.Context, w workerruntime.Runtime, pluginName, cu
 	for retry := 0; retry < binaryDownloadRetry; retry++ {
 		if retry > 0 {
 			time.Sleep(binaryDownloadRetryDelay)
+
+			// A binary can be replaced while the job runs: its checksum, and the name it is
+			// published under, are only valid for the content served when the descriptor was read.
+			// Reading the descriptor again is what makes a download that raced with an upload
+			// recoverable, instead of failing on a checksum that will never match again.
+			previous := b
+			refreshed, err := readBinaryDescriptor(w, pluginName, currentOS, currentARCH)
+			if err != nil {
+				log.Warn(ctx, "plugin %q: unable to read the descriptor of binary %q again (try %d): %v", pluginName, b.Name, retry+1, err)
+			} else {
+				b = refreshed
+				if !strings.EqualFold(b.SHA512sum, previous.SHA512sum) {
+					log.Info(ctx, "plugin %q: binary %q has been replaced, retrying with the checksum now published", pluginName, b.Name)
+					checksumFailures = 0
+				}
+			}
 		}
 
 		lastErr = downloadBinary(w, b)
@@ -88,6 +98,22 @@ func DownloadBinary(ctx context.Context, w workerruntime.Runtime, pluginName, cu
 	}
 
 	return nil, sdk.NewErrorFrom(sdk.ErrPluginInvalid, "unable to get a valid binary %q for plugin %q after %d tries: %v", b.Name, pluginName, binaryDownloadRetry, lastErr)
+}
+
+// readBinaryDescriptor reads from the API the binary currently published for the given os and arch.
+func readBinaryDescriptor(w workerruntime.Runtime, pluginName, currentOS, currentARCH string) (*sdk.GRPCPluginBinary, error) {
+	p, err := w.PluginGet(pluginName)
+	if err != nil {
+		return nil, sdk.WrapError(err, "unable to get plugin %q", pluginName)
+	}
+	b := p.GetBinary(currentOS, currentARCH)
+	if b == nil {
+		return nil, sdk.NewErrorFrom(sdk.ErrNotFound, "unable to find plugin %q for %s/%s", pluginName, currentOS, currentARCH)
+	}
+	if b.SHA512sum == "" {
+		return nil, sdk.NewErrorFrom(sdk.ErrPluginInvalid, "plugin %q: binary %q has no published sha512sum, refusing to run it", pluginName, b.Name)
+	}
+	return b, nil
 }
 
 // downloadBinary writes the plugin binary in the worker basedir and checks its integrity

--- a/engine/worker/internal/plugin/binary_test.go
+++ b/engine/worker/internal/plugin/binary_test.go
@@ -104,7 +104,7 @@ func TestDownloadBinary_RefusesBinaryWithoutSHA512(t *testing.T) {
 func TestDownloadBinary_RefusesTamperedDownload(t *testing.T) {
 	w, _ := setupBinaryTest(t)
 
-	w.EXPECT().PluginGet(testPluginName).Return(pluginServing(t, "the published binary"), nil)
+	w.EXPECT().PluginGet(testPluginName).Return(pluginServing(t, "the published binary"), nil).Times(binaryChecksumRetry)
 	w.EXPECT().
 		PluginGetBinary(testPluginName, testOS, testARCH, gomock.Any()).
 		DoAndReturn(serve("a tampered binary")).
@@ -114,6 +114,61 @@ func TestDownloadBinary_RefusesTamperedDownload(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, sdk.ErrorIs(err, sdk.ErrPluginInvalid), "got %v", err)
 	require.Contains(t, err.Error(), "sha512 mismatch")
+}
+
+// Uploading a binary replaces the stored object before the new checksum is committed: a download
+// landing in that window gets the new content with the old checksum. The mismatch is not
+// deterministic, the descriptor read again carries the checksum of the content now served.
+func TestDownloadBinary_RetriesWithTheChecksumPublishedAfterAnUpload(t *testing.T) {
+	w, fs := setupBinaryTest(t)
+
+	gomock.InOrder(
+		w.EXPECT().PluginGet(testPluginName).Return(pluginServing(t, "the previous binary"), nil),
+		w.EXPECT().PluginGet(testPluginName).Return(pluginServing(t, "the binary just uploaded"), nil),
+	)
+	// the storage serves the new content for both tries
+	w.EXPECT().
+		PluginGetBinary(testPluginName, testOS, testARCH, gomock.Any()).
+		DoAndReturn(serve("the binary just uploaded")).
+		Times(2)
+
+	b, err := DownloadBinary(context.TODO(), w, testPluginName, testOS, testARCH)
+	require.NoError(t, err)
+	require.Equal(t, pluginServing(t, "the binary just uploaded").Binaries[0].SHA512sum, b.SHA512sum)
+
+	content, err := afero.ReadFile(fs, testBinaryName)
+	require.NoError(t, err)
+	require.Equal(t, "the binary just uploaded", string(content))
+}
+
+// A binary published under a new name, the previous object having been deleted, must not keep the
+// worker downloading the object that will never come back.
+func TestDownloadBinary_RetriesWithTheNamePublishedAfterAnUpload(t *testing.T) {
+	w, fs := setupBinaryTest(t)
+
+	renamed := pluginServing(t, "the binary just uploaded")
+	renamed.Binaries[0].Name = testBinaryName + "-v2"
+
+	gomock.InOrder(
+		w.EXPECT().PluginGet(testPluginName).Return(pluginServing(t, "the previous binary"), nil),
+		w.EXPECT().PluginGet(testPluginName).Return(renamed, nil),
+	)
+	gomock.InOrder(
+		w.EXPECT().
+			PluginGetBinary(testPluginName, testOS, testARCH, gomock.Any()).
+			Return(sdk.NewErrorFrom(sdk.ErrNotFound, "object not found")),
+		w.EXPECT().
+			PluginGetBinary(testPluginName, testOS, testARCH, gomock.Any()).
+			DoAndReturn(serve("the binary just uploaded")),
+	)
+
+	b, err := DownloadBinary(context.TODO(), w, testPluginName, testOS, testARCH)
+	require.NoError(t, err)
+	require.Equal(t, testBinaryName+"-v2", b.Name)
+
+	content, err := afero.ReadFile(fs, testBinaryName+"-v2")
+	require.NoError(t, err)
+	require.Equal(t, "the binary just uploaded", string(content))
 }
 
 // The worker basedir defaults to os.TempDir() and can be shared between workers: a binary


### PR DESCRIPTION
Uploading a plugin binary deleted the stored object before uploading the new one, and did so inside the transaction: the binary was missing for the whole upload. The storage key is derived from the binary name, os and arch, so storing already replaces the previous content in place and the delete was both harmful and useless. It is now only done, after the commit, when the new binary landed on another key.

The upload is also moved out of the transaction. It shortens the window during which the new content is served with the checksum of the old one down to a single row update, which matters since a worker only retries a checksum mismatch twice, and it keeps the binaries of a same plugin uploadable in parallel although the row is now locked: they all live in the same column, so concurrent updates have to be serialized, otherwise the last writer drops the binaries referenced by the others.

Finally, the filesystem driver writes objects through a temporary file so that replacing one never exposes a partially written binary.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
