### PR TITLE
feat(ui): rework project settings lists with search and creation modals

### DIFF
--- a/ui/src/app/shared/input/input-filter.component.ts
+++ b/ui/src/app/shared/input/input-filter.component.ts
@@ -38,7 +38,8 @@ export class InputFilterComponent<T> implements AfterViewInit, AfterViewChecked,
 	@Input() filterText: string = '';
 	@Input() filters: Array<Filter> = [];
 	@Input() suggestions: Array<Suggestion<T>> = [];
-	@Input() suggestionTemplate: TemplateRef<unknown> | undefined; cds
+	@Input() suggestionTemplate: TemplateRef<unknown> | undefined;
+	@Input() autofocus: boolean = false;
 	@Output() changeFilter: EventEmitter<string> = new EventEmitter();
 	@Output() selectSuggestion: EventEmitter<T> = new EventEmitter();
 	@Output() submit: EventEmitter<void> = new EventEmitter();
@@ -99,6 +100,15 @@ export class InputFilterComponent<T> implements AfterViewInit, AfterViewChecked,
 				return;
 			}
 			doBackfill();
+		}
+
+		if (this.autofocus) {
+			// Focusing opens the autocomplete panel; close it back so the page stays
+			// readable until the user actually types or clicks.
+			setTimeout(() => {
+				this.filterInput.nativeElement.focus({ preventScroll: true });
+				this.filterInputDirective.closePanel();
+			});
 		}
 	}
 

--- a/ui/src/app/shared/list-toolbar/list-toolbar.component.ts
+++ b/ui/src/app/shared/list-toolbar/list-toolbar.component.ts
@@ -1,0 +1,29 @@
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+
+@Component({
+    standalone: false,
+    selector: 'app-list-toolbar',
+    templateUrl: './list-toolbar.html',
+    styleUrls: ['./list-toolbar.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ListToolbarComponent implements AfterViewInit {
+    @ViewChild('searchInput') searchInput: ElementRef<HTMLInputElement>;
+
+    @Input() searchPlaceholder: string = 'Search';
+    @Input() searchValue: string = '';
+    @Input() itemLabel: string = '';
+    @Input() count: number;
+    @Input() total: number;
+    @Input() addLabel: string;
+    @Input() autofocus: boolean = true;
+
+    @Output() searchChange: EventEmitter<string> = new EventEmitter();
+    @Output() add: EventEmitter<void> = new EventEmitter();
+
+    ngAfterViewInit(): void {
+        if (this.autofocus) {
+            setTimeout(() => this.searchInput?.nativeElement.focus({ preventScroll: true }));
+        }
+    }
+}

--- a/ui/src/app/shared/list-toolbar/list-toolbar.html
+++ b/ui/src/app/shared/list-toolbar/list-toolbar.html
@@ -1,0 +1,33 @@
+<div class="toolbar">
+  <nz-input-group class="search" [nzPrefix]="searchPrefix" [nzSuffix]="searchSuffix">
+    <input #searchInput nz-input type="text" [placeholder]="searchPlaceholder" [attr.aria-label]="searchPlaceholder"
+      [ngModel]="searchValue" (ngModelChange)="searchChange.emit($event)">
+  </nz-input-group>
+  <ng-template #searchPrefix>
+    <span nz-icon nzType="search" nzTheme="outline" aria-hidden="true"></span>
+  </ng-template>
+  <ng-template #searchSuffix>
+    @if (searchValue) {
+      <button type="button" class="clear" title="Clear the search" aria-label="Clear the search"
+        (click)="searchChange.emit('')">
+        <span nz-icon nzType="close-circle" nzTheme="outline" aria-hidden="true"></span>
+      </button>
+    }
+  </ng-template>
+
+  @if (total !== undefined && total !== null) {
+    <span class="count" aria-live="polite">
+      @if (searchValue) {
+        {{ count }} / {{ total }} {{ itemLabel }}
+      } @else {
+        {{ total }} {{ itemLabel }}
+      }
+    </span>
+  }
+
+  @if (addLabel) {
+    <button nz-button nzType="primary" class="add" (click)="add.emit()">
+      <span nz-icon nzType="plus" nzTheme="outline" aria-hidden="true"></span><span>{{ addLabel }}</span>
+    </button>
+  }
+</div>

--- a/ui/src/app/shared/list-toolbar/list-toolbar.scss
+++ b/ui/src/app/shared/list-toolbar/list-toolbar.scss
@@ -1,0 +1,39 @@
+@use '../../../common' as common;
+
+:host {
+  display: block;
+  margin-bottom: 15px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.search {
+  flex: 1;
+  min-width: 0;
+}
+
+.count {
+  color: common.$polar_grey_2;
+  white-space: nowrap;
+
+  :host-context(.night) & {
+    color: common.$polar_grey_3;
+  }
+}
+
+.clear {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  display: flex;
+}
+
+.add {
+  flex: none;
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -195,6 +195,7 @@ import {
     RocketOutline,
     SafetyCertificateOutline,
     SaveOutline,
+    SearchOutline,
     SettingFill,
     SettingOutline,
     ShareAltOutline,
@@ -263,6 +264,7 @@ import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { RepositoryRefSelectComponent } from './repository-ref-selector/repository-ref-select.component';
 import { InputFilterComponent } from './input/input-filter.component';
+import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
 
 const ngZorroConfig: NzConfig = {
     notification: {
@@ -348,6 +350,7 @@ const icons: IconDefinition[] = [
     RocketOutline,
     SafetyCertificateOutline,
     SaveOutline,
+    SearchOutline,
     SettingFill,
     SettingOutline,
     ShareAltOutline,
@@ -461,6 +464,7 @@ const icons: IconDefinition[] = [
         KeysListComponent,
         KeysPipe,
         LabelsEditComponent,
+        ListToolbarComponent,
         NgForNumber,
         NgxAutoScrollDirective,
         NsAutoHeightTableDirective,
@@ -579,6 +583,7 @@ const icons: IconDefinition[] = [
         KeysListComponent,
         KeysPipe,
         LabelsEditComponent,
+        ListToolbarComponent,
         MarkdownModule,
         MomentModule,
         NgForNumber,

--- a/ui/src/app/views/home/home.html
+++ b/ui/src/app/views/home/home.html
@@ -3,7 +3,7 @@
     <img src="assets/images/cds.png" alt="CDS logo" title="{{'navbar_home' | translate}}" />
   </div>
 
-  <app-search-bar #searchBar></app-search-bar>
+  <app-search-bar #searchBar [autofocus]="true"></app-search-bar>
 
   <div class="controls">
     <button nz-button nzSize="large" title="Search in CDS" (click)="clickSearch()">

--- a/ui/src/app/views/project/settings/concurrency/concurrencies.components.ts
+++ b/ui/src/app/views/project/settings/concurrency/concurrencies.components.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
-import { Router } from "@angular/router";
 import { Concurrency, ProjectConcurrencyRuns } from "app/model/project.concurrency.model";
 import { Project } from "app/model/project.model";
 import { V2ProjectService } from "app/service/projectv2/project.service";
@@ -20,13 +19,15 @@ export class ProjectConcurrenciesComponent implements OnInit {
     loading = { list: false, action: false };
     selectedConcurrency: Concurrency;
     concurrencies: Array<Concurrency> = [];
+    filteredConcurrencies: Array<Concurrency> = [];
     concurrencyRuns: Array<ProjectConcurrencyRuns> = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
 
     constructor(
         private _cd: ChangeDetectorRef,
         private _messageService: NzMessageService,
-        private _v2ProjectService: V2ProjectService,
-        private _router: Router
+        private _v2ProjectService: V2ProjectService
     ) { }
 
     ngOnInit(): void {
@@ -38,6 +39,7 @@ export class ProjectConcurrenciesComponent implements OnInit {
         this._cd.markForCheck();
         try {
             this.concurrencies = await lastValueFrom(this._v2ProjectService.getConcurrencies(this.project.key));
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to load concurrencies: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -51,6 +53,10 @@ export class ProjectConcurrenciesComponent implements OnInit {
         try {
             await lastValueFrom(this._v2ProjectService.deleteConcurrency(this.project.key, c.name))
             this.concurrencies = this.concurrencies.filter(s => s.name !== c.name);
+            this.applyFilter();
+            if (this.selectedConcurrency?.name === c.name) {
+                this.unselectConcurrency();
+            }
             this._messageService.success(`Concurrency ${c.name} deleted`, { nzDuration: 2000 });
         } catch (e) {
             this._messageService.error(`Unable to delete concurrency: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
@@ -59,19 +65,49 @@ export class ProjectConcurrenciesComponent implements OnInit {
         this._cd.markForCheck();
     }
 
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredConcurrencies = search === '' ? this.concurrencies :
+            this.concurrencies.filter(c => [c.name, c.description, c.order, c.if]
+                .some(field => (field ?? '').toLowerCase().indexOf(search) !== -1));
+    }
+
+    openCreateModal(): void {
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
+        this._cd.markForCheck();
+    }
+
+    onConcurrencyCreated(): void {
+        this.closeCreateModal();
+        this.load();
+    }
+
     async selectConcurrency(c: Concurrency) {
         this.selectedConcurrency = c;
-       
+        this._cd.markForCheck();
+
         try {
             this.concurrencyRuns = await lastValueFrom(this._v2ProjectService.getConcurrencyRuns(this.project.key, this.selectedConcurrency.name))
         } catch (e) {
-            this._messageService.error(`Unable to delete concurrency: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            this._messageService.error(`Unable to load concurrency runs: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
-        this._cd.markForCheck;
+        this._cd.markForCheck();
     }
 
     unselectConcurrency(): void {
         delete this.selectedConcurrency;
+        this._cd.markForCheck();
     }
 
     sortByDate(a: ProjectConcurrencyRuns, b: ProjectConcurrencyRuns): number {

--- a/ui/src/app/views/project/settings/concurrency/concurrencies.html
+++ b/ui/src/app/views/project/settings/concurrency/concurrencies.html
@@ -1,35 +1,47 @@
-<h3>Create a concurrency</h3>
-<app-project-concurrency-form [project]="project" (refresh)="load()"></app-project-concurrency-form>
+<app-list-toolbar searchPlaceholder="Search a concurrency by name, description, order or condition"
+  itemLabel="concurrencies" [searchValue]="filter"
+  [count]="filteredConcurrencies.length" [total]="concurrencies.length" addLabel="New concurrency"
+  (searchChange)="updateFilter($event)" (add)="openCreateModal()"></app-list-toolbar>
 
-<h3>Concurrencies list:</h3>
 <div class="list">
-  <nz-table #table [nzData]="concurrencies" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
-    [nzLoading]="loading.list">
+  <nz-table #table [nzData]="filteredConcurrencies" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
+    [nzLoading]="loading.list" [nzNoResult]="empty">
     <thead>
       <tr>
-        <th>Name</th>
+        <th nzWidth="250px">Name</th>
         <th>Description</th>
-        <th>Deletion</th>
+        <th nzWidth="80px">Pool</th>
+        <th nzWidth="140px">Order</th>
+        <th nzWidth="80px" nzAlign="right">Actions</th>
       </tr>
     </thead>
     <tbody>
-      @for (data of table.data; track data) {
+      @for (data of table.data; track data.name) {
         <tr>
           <td appClickable (click)="selectConcurrency(data)">{{data.name}}</td>
           <td appClickable (click)="selectConcurrency(data)">{{data.description}}</td>
-          <td>
-            <button nz-button nzDanger nzType="primary" [nzLoading]="loading.action" nz-popconfirm
-              nzPopconfirmTitle="Are you sure you want to delete this variableset ? it will remove all items"
-            (nzOnConfirm)="deleteConcurrency(data)">Delete</button>
+          <td>{{data.pool}}</td>
+          <td>{{data.order}}</td>
+          <td nzAlign="right">
+            <button nz-button nzDanger nzType="text" [nzLoading]="loading.action" nz-popconfirm
+              nzPopconfirmTitle="Are you sure you want to delete this concurrency?" (nzOnConfirm)="deleteConcurrency(data)"
+              title="Delete the concurrency {{data.name}}" [attr.aria-label]="'Delete the concurrency ' + data.name">
+              <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+            </button>
           </td>
         </tr>
       }
     </tbody>
   </nz-table>
-  <nz-drawer class="toto" nzPlacement="right" [nzWidth]="1000" [nzTitle]="selectedConcurrency?.name"
+
+  <ng-template #empty>
+    <nz-empty [nzNotFoundContent]="concurrencies.length === 0 ? 'No concurrency yet' : 'No concurrency matches your search'"></nz-empty>
+  </ng-template>
+
+  <nz-drawer nzPlacement="right" [nzWidth]="1000" [nzTitle]="selectedConcurrency?.name" [nzExtra]="drawerExtra"
     [nzVisible]="selectedConcurrency" (nzOnClose)="unselectConcurrency()">
     <ng-container *nzDrawerContent>
-      <app-project-concurrency-form [project]="project" [concurrency]="selectedConcurrency" [verticalOrientation]="true" (refresh)="load()"></app-project-concurrency-form>
+      <app-project-concurrency-form [project]="project" [concurrency]="selectedConcurrency" (refresh)="load()"></app-project-concurrency-form>
       <div class="runs">
         <h3>Workflow/Job running with this concurrency:</h3>
         <nz-table [nzData]="concurrencyRuns"
@@ -58,4 +70,20 @@
       </div>
     </ng-container>
   </nz-drawer>
+
+  <ng-template #drawerExtra>
+    <button nz-button nzDanger [nzLoading]="loading.action" nz-popconfirm
+      nzPopconfirmTitle="Are you sure you want to delete this concurrency?"
+      (nzOnConfirm)="deleteConcurrency(selectedConcurrency)">
+      <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span><span>Delete this concurrency</span>
+    </button>
+  </ng-template>
 </div>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New concurrency" [nzFooter]="null" [nzWidth]="720"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <app-project-concurrency-form [project]="project" [cancellable]="true" (refresh)="onConcurrencyCreated()"
+      (cancel)="closeCreateModal()"></app-project-concurrency-form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/concurrency/concurrency.form.component.html
+++ b/ui/src/app/views/project/settings/concurrency/concurrency.form.component.html
@@ -1,128 +1,63 @@
-@if (!verticalOrientation) {
-  <form nz-form (ngSubmit)="createConcurrency()">
-    <nz-row>
-      <nz-col [nzSpan]="10">
-        <nz-form-item>
-          <nz-form-label nzFor="cds-field-concurrency-name">
-            Name
-          </nz-form-label>
-          <nz-form-control>
-            <input nz-input name="name" id="cds-field-concurrency-name" [(ngModel)]="concurrency.name">
-            @if (errorName) {
-              <nz-alert nzType="warning" nzMessage="Name cannot be empty and must match pattern `^[a-zA-Z0-9_-]{1,}$`"></nz-alert>
-            }
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-      <nz-col [nzSpan]="13" [nzOffset]="1">
-        <nz-form-item>
-          <nz-form-label nzFor="cds-field-concurrency-description">
-            Description
-          </nz-form-label>
-          <nz-form-control>
-            <input nz-input name="description" id="cds-field-concurrency-description" [(ngModel)]="concurrency.description">
-            @if (errorDescription) {
-              <nz-alert nzType="warning" nzMessage="Description cannot be empty"></nz-alert>
-            }
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-    </nz-row>
-    <nz-row>
-      <nz-col [nzSpan]="3">
-        <nz-form-item>
-          <nz-form-label nzFor="cds-field-concurrency-order">Order</nz-form-label>
-          <nz-form-control>
-            <nz-select id="cds-field-concurrency-order" [(ngModel)]="concurrency.order" name="order">
-              @for (o of orders; track o) {
-                <nz-option [nzLabel]="o" [nzValue]="o"></nz-option>
-              }
-            </nz-select>
-            @if (errorOrder) {
-              <nz-alert nzType="warning" nzMessage="Order must be equal to oldest_first or newest_first"></nz-alert>
-            }
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-      <nz-col [nzSpan]="3" [nzOffset]="1">
-        <nz-form-item>
-          <nz-form-label [nzSpan]="6" nzFor="cds-field-concurrency-pool">Pool</nz-form-label>
-          <nz-form-control>
-            <input nz-input type="number" name="pool" id="cds-field-concurrency-pool" [(ngModel)]="concurrency.pool">
-            @if (errorPool) {
-              <nz-alert nzType="warning" nzMessage="Pool must be greater than 0"></nz-alert>
-            }
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-      <nz-col [nzSpan]="3" [nzOffset]="1">
-        <nz-form-item>
-          <nz-form-label>Cancel-in-progress</nz-form-label>
-          <nz-form-control>
-            <label nz-checkbox [(ngModel)]="concurrency.cancel_in_progress" name="cancel"></label>
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-      <nz-col [nzSpan]="9">
-        <nz-form-item>
-          <nz-form-label [nzSpan]="6" nzFor="cds-field-concurrency-if">If</nz-form-label>
-          <nz-form-control>
-            <input nz-input name="if" id="cds-field-concurrency-if" [(ngModel)]="concurrency.if">
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-      <nz-col [nzSpan]="4" class="alignEnd">
-        <button nz-button nzType="primary" [nzLoading]="loading">Create</button>
-      </nz-col>
-    </nz-row>
-  </form>
-}
-
-@if (verticalOrientation) {
-  <form nz-form (ngSubmit)="createConcurrency()">
+<form nz-form (ngSubmit)="createConcurrency()">
+  @if (!isEdition) {
     <nz-form-item>
-      <nz-form-label [nzSpan]="4" nzFor="cds-field-concurrency-v-description">Description</nz-form-label>
-      <nz-form-control>
-        <input nz-input name="description" id="cds-field-concurrency-v-description" [(ngModel)]="concurrency.description">
-        @if (errorDescription) {
-          <nz-alert nzType="warning" nzMessage="Description cannot be empty"></nz-alert>
+      <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-name" nzRequired>Name</nz-form-label>
+      <nz-form-control [nzSpan]="19">
+        <input nz-input name="name" id="cds-field-concurrency-name" [(ngModel)]="concurrency.name">
+        @if (errorName) {
+          <nz-alert nzType="warning" nzMessage="Name cannot be empty and must match pattern `^[a-zA-Z0-9_-]{1,}$`"></nz-alert>
         }
       </nz-form-control>
     </nz-form-item>
-    <nz-form-item>
-      <nz-form-label [nzSpan]="4" nzFor="cds-field-concurrency-v-order">Order</nz-form-label>
-      <nz-form-control>
-        <nz-select id="cds-field-concurrency-v-order" [(ngModel)]="concurrency.order" name="order">
-          @for (o of orders; track o) {
-            <nz-option [nzLabel]="o" [nzValue]="o"></nz-option>
-          }
-        </nz-select>
-        @if (errorOrder) {
-          <nz-alert nzType="warning" nzMessage="Order must be equal to oldest_first or newest_first"></nz-alert>
+  }
+  <nz-form-item>
+    <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-description" nzRequired>Description</nz-form-label>
+    <nz-form-control [nzSpan]="19">
+      <input nz-input name="description" id="cds-field-concurrency-description" [(ngModel)]="concurrency.description">
+      @if (errorDescription) {
+        <nz-alert nzType="warning" nzMessage="Description cannot be empty"></nz-alert>
+      }
+    </nz-form-control>
+  </nz-form-item>
+  <nz-form-item>
+    <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-order">Order</nz-form-label>
+    <nz-form-control [nzSpan]="19">
+      <nz-select id="cds-field-concurrency-order" [(ngModel)]="concurrency.order" name="order">
+        @for (o of orders; track o) {
+          <nz-option [nzLabel]="o" [nzValue]="o"></nz-option>
         }
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label [nzSpan]="4" nzFor="cds-field-concurrency-v-pool">Pool</nz-form-label>
-      <nz-form-control>
-        <input nz-input type="number" name="pool" id="cds-field-concurrency-v-pool" [(ngModel)]="concurrency.pool">
-        @if (errorPool) {
-          <nz-alert nzType="warning" nzMessage="Pool must be greater than 0"></nz-alert>
-        }
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label [nzSpan]="4" nzFor="cds-field-concurrency-v-if">If</nz-form-label>
-      <nz-form-control>
-        <input nz-input name="if" id="cds-field-concurrency-v-if" [(ngModel)]="concurrency.if">
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label [nzSpan]="4">Cancel-in-progress</nz-form-label>
-      <nz-form-control>
-        <label nz-checkbox [(ngModel)]="concurrency.cancel_in_progress" name="cancel"></label>
-      </nz-form-control>
-    </nz-form-item>
-    <button nz-button nzType="primary" nzBlock [nzLoading]="loading">Update</button>
-  </form>
-}
+      </nz-select>
+      @if (errorOrder) {
+        <nz-alert nzType="warning" nzMessage="Order must be equal to oldest_first or newest_first"></nz-alert>
+      }
+    </nz-form-control>
+  </nz-form-item>
+  <nz-form-item>
+    <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-pool">Pool</nz-form-label>
+    <nz-form-control [nzSpan]="19">
+      <input nz-input type="number" min="1" name="pool" id="cds-field-concurrency-pool" [(ngModel)]="concurrency.pool">
+      @if (errorPool) {
+        <nz-alert nzType="warning" nzMessage="Pool must be greater than 0"></nz-alert>
+      }
+    </nz-form-control>
+  </nz-form-item>
+  <nz-form-item>
+    <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-if">If</nz-form-label>
+    <nz-form-control [nzSpan]="19">
+      <input nz-input name="if" id="cds-field-concurrency-if" [(ngModel)]="concurrency.if">
+    </nz-form-control>
+  </nz-form-item>
+  <nz-form-item>
+    <nz-form-label [nzSpan]="5" nzFor="cds-field-concurrency-cancel">Cancel-in-progress</nz-form-label>
+    <nz-form-control [nzSpan]="19">
+      <label nz-checkbox nzId="cds-field-concurrency-cancel" [(ngModel)]="concurrency.cancel_in_progress"
+        name="cancel"></label>
+    </nz-form-control>
+  </nz-form-item>
+  <div class="cds-modal-footer">
+    @if (cancellable) {
+      <button nz-button type="button" (click)="cancel.emit()">Cancel</button>
+    }
+    <button nz-button nzType="primary" [nzLoading]="loading">{{ isEdition ? 'Update' : 'Create' }}</button>
+  </div>
+</form>

--- a/ui/src/app/views/project/settings/concurrency/concurrency.form.component.scss
+++ b/ui/src/app/views/project/settings/concurrency/concurrency.form.component.scss
@@ -1,4 +1,4 @@
-
-.alignEnd {
-  text-align: end;
+// Keeps the fields readable when the form is hosted in the wide edition drawer.
+form {
+  max-width: 700px;
 }

--- a/ui/src/app/views/project/settings/concurrency/concurrency.form.component.ts
+++ b/ui/src/app/views/project/settings/concurrency/concurrency.form.component.ts
@@ -17,9 +17,10 @@ import { lastValueFrom } from "rxjs";
 export class ProjectConcurrencyFormComponent implements OnInit {
     @Input() project: Project;
     @Input() concurrency: Concurrency
-    @Input() verticalOrientation: boolean;
+    @Input() cancellable: boolean;
 
     @Output() refresh: EventEmitter<boolean> = new EventEmitter();
+    @Output() cancel: EventEmitter<void> = new EventEmitter();
 
     loading: boolean;
     errorName: boolean;
@@ -34,9 +35,13 @@ export class ProjectConcurrencyFormComponent implements OnInit {
         private _v2ProjectService: V2ProjectService
     ) { }
 
+    get isEdition(): boolean {
+        return !!this.concurrency?.id;
+    }
+
     ngOnInit(): void {
         if (!this.concurrency) {
-            this.concurrency = <Concurrency>{ pool: 1, order: ConcurrencyOrder.OLDEST_FIRST }
+            this.concurrency = new Concurrency();
         }
     }
 

--- a/ui/src/app/views/project/settings/integrations/project.integrations.component.ts
+++ b/ui/src/app/views/project/settings/integrations/project.integrations.component.ts
@@ -30,6 +30,9 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
     codeMirrorConfigRO: any;
     themeSubscription: Subscription;
     integrations: Array<ProjectIntegration> = [];
+    filteredIntegrations: Array<ProjectIntegration> = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
     models: Array<IntegrationModel> = [];
     newIntegration: ProjectIntegration;
 
@@ -76,6 +79,7 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
             this.integrations = await lastValueFrom(this._v2ProjectService.getIntegrations(this.project.key));
             this.integrations = this.integrations.map(integ => this.setDefaultConfig(integ));
             this.integrations.sort((a, b) => a.name < b.name ? -1 : 1);
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to load integrations: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -89,6 +93,7 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
         try {
             await lastValueFrom(this._v2ProjectService.deleteIntegration(this.project.key, p.name));
             this.integrations = this.integrations.filter(i => i.name !== p.name);
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to delete integration: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -102,6 +107,7 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
         try {
             const integration = await lastValueFrom(this._v2ProjectService.putIntegration(this.project.key, p));
             this.integrations = this.integrations.map(i => i.name === integration.name ? integration : i);
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to update integration: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -116,7 +122,8 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
             const integration = await lastValueFrom(this._v2ProjectService.postIntegration(this.project.key, this.newIntegration));
             this.integrations = this.integrations.concat(this.setDefaultConfig(integration));
             this.integrations.sort((a, b) => a.name < b.name ? -1 : 1);
-            this.newIntegration = new ProjectIntegration();
+            this.applyFilter();
+            this.closeCreateModal();
             if (this.autoHeightDirective) { this.autoHeightDirective.onResize(null); }
         } catch (e) {
             this._messageService.error(`Unable to create integration: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
@@ -125,9 +132,40 @@ export class ProjectIntegrationsComponent implements OnInit, OnDestroy {
         this._cd.markForCheck();
     }
 
-    cancel(): void {
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredIntegrations = search === '' ? this.integrations :
+            this.integrations.filter(i => [i.name, i.model?.name, ...this.modelTypes(i.model)]
+                .some(field => (field ?? '').toLowerCase().indexOf(search) !== -1));
+    }
+
+    modelTypes(model: IntegrationModel): Array<string> {
+        if (!model) {
+            return [];
+        }
+        return [
+            model.storage ? 'storage' : null,
+            model.hook ? 'hook' : null,
+            model.event ? 'event' : null,
+            model.deployment ? 'deployment' : null
+        ].filter(t => !!t);
+    }
+
+    openCreateModal(): void {
         this.newIntegration = new ProjectIntegration();
-        if (this.autoHeightDirective) { this.autoHeightDirective.onResize(null); }
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
+        this.newIntegration = new ProjectIntegration();
         this._cd.markForCheck();
     }
 

--- a/ui/src/app/views/project/settings/integrations/project.integrations.html
+++ b/ui/src/app/views/project/settings/integrations/project.integrations.html
@@ -1,94 +1,22 @@
-@if (project.permissions.writable) {
-  <h3>Create an integration:</h3>
-  <form nz-form>
-    <nz-form-item>
-      <nz-form-label nzFor="cds-field-integration-model">Model</nz-form-label>
-      <nz-form-control>
-        <nz-select nzShowSearch id="cds-field-integration-model" name="model" [ngModel]="newIntegration.model" (ngModelChange)="updateConfig($event)">
-          @for (m of models; track m) {
-            <nz-option [nzLabel]="m.name" nzCustomContent [nzValue]="m">
-              <div>{{ m.name }}</div>
-              @if (m.storage) {
-                <nz-tag nzColor="success">storage</nz-tag>
-              }
-              @if (m.hook) {
-                <nz-tag nzColor="success">hook</nz-tag>
-              }
-              @if (m.event) {
-                <nz-tag nzColor="success">event</nz-tag>
-              }
-              @if (m.deployment) {
-                <nz-tag nzColor="success">deployment</nz-tag>
-              }
-            </nz-option>
-          }
-        </nz-select>
-      </nz-form-control>
-    </nz-form-item>
-    @if (newIntegration.model) {
-      <nz-form-item>
-        <nz-form-label [nzSpan]="5" nzFor="cds-field-integration-name">Integration name</nz-form-label>
-        <nz-form-control>
-          <input nz-input id="cds-field-integration-name" name="name" type="text" [(ngModel)]="newIntegration.name">
-        </nz-form-control>
-      </nz-form-item>
-      @for (k of newIntegration.model.default_config | keys; track k) {
-        <nz-form-item>
-          <nz-form-label [nzSpan]="5" nzFor="cds-field-new-{{k}}">
-            {{k}}
-            @if (newIntegration.config[k].description) {
-              <span nz-tooltip
-                [nzTooltipTitle]="newIntegration.config[k].description" nzTooltipPlacement="right">
-                <i nz-icon nzType="info-circle" nzTheme="outline"></i>
-              </span>
-            }
-          </nz-form-label>
-          <nz-form-control>
-            @if (newIntegration.config[k].type === 'boolean') {
-              <label nz-checkbox name="{{k}}"
-              [(ngModel)]="newIntegration.config[k].value"></label>
-            }
-            @if (newIntegration.config[k].type === 'string') {
-              <input nz-input type="text" id="cds-field-new-{{k}}" name="{{k}}" [(ngModel)]="newIntegration.config[k].value"
-                >
-            }
-            @if (newIntegration.config[k].type === 'text') {
-              <codemirror aria-label="{{k}}" [(ngModel)]="newIntegration.config[k].value" [config]="codeMirrorConfig" #codeMirror>
-              </codemirror>
-            }
-            @if (newIntegration.config[k].type === 'password') {
-              <input nz-input type="password" id="cds-field-new-{{k}}" name="{{k}}" [(ngModel)]="newIntegration.config[k].value"
-                >
-            }
-          </nz-form-control>
-        </nz-form-item>
-      }
-      <nz-form-item>
-        <nz-form-control class="controls">
-          <button nz-button nzType="primary" type="button" (click)="create()" [nzLoading]="loading.action"
-          [disabled]="loading.action || !newIntegration.name || newIntegration.name === '' || !newIntegration.model">Add</button>
-          <button nz-button type="button" (click)="cancel()" [nzLoading]="loading.action"
-          [disabled]="loading.action">Cancel</button>
-        </nz-form-control>
-      </nz-form-item>
-    }
-  </form>
-}
+<app-list-toolbar searchPlaceholder="Search an integration by name, model or type" itemLabel="integrations"
+  [searchValue]="filter"
+  [count]="filteredIntegrations.length" [total]="integrations.length"
+  [addLabel]="project.permissions.writable ? 'New integration' : null" (searchChange)="updateFilter($event)"
+  (add)="openCreateModal()"></app-list-toolbar>
 
-<h3>Integrations list:</h3>
 <div class="list">
-  <nz-table [nzData]="this.integrations" #integList [nsAutoHeightTable]="39" #autoHeightDirective="nsAutoHeightTable"
-    [nzFrontPagination]="false" nzSize="small" [nzLoading]="loading.list">
+  <nz-table [nzData]="filteredIntegrations" #integList [nsAutoHeightTable]="39" #autoHeightDirective="nsAutoHeightTable"
+    [nzFrontPagination]="false" nzSize="small" [nzLoading]="loading.list" [nzNoResult]="empty">
     <thead>
       <tr>
-        <th nzWidth="100px">Name</th>
-        <th nzWidth="100px">Model</th>
-        <th nzWidth="300px">Configuration</th>
-        <th nzWidth="25px"></th>
+        <th nzWidth="200px">Name</th>
+        <th nzWidth="200px">Model</th>
+        <th>Configuration</th>
+        <th nzWidth="100px" nzAlign="right">Actions</th>
       </tr>
     </thead>
     <tbody>
-      @for (p of integList.data; track p) {
+      @for (p of integList.data; track p.name) {
         <tr>
           <td>
             {{ p.name }}
@@ -100,12 +28,17 @@
           </td>
           <td>
             {{ p.model.name}}
+            <div class="types">
+              @for (t of modelTypes(p.model); track t) {
+                <nz-tag nzColor="success">{{t}}</nz-tag>
+              }
+            </div>
           </td>
           <td>
             <form nz-form>
               @for (k of p.config | keys; track k) {
                 <nz-form-item>
-                  <nz-form-label [nzSpan]="12" nzFor="cds-field-{{p.name}}-{{k}}">
+                  <nz-form-label [nzSpan]="8" nzFor="cds-field-{{p.name}}-{{k}}">
                     {{k}}
                     @if (p.config[k].description) {
                       <span nz-tooltip [nzTooltipTitle]="p.config[k].description"
@@ -114,7 +47,7 @@
                       </span>
                     }
                   </nz-form-label>
-                  <nz-form-control>
+                  <nz-form-control [nzSpan]="16">
                     @if (p.config[k].static) {
                       @if (p.config[k].type !== 'password') {
                         <input nz-input type="text" id="cds-field-{{p.name}}-{{k}}" name="{{k}}-value"
@@ -128,28 +61,28 @@
                     @if (!p.config[k].static) {
                       @if (p.config[k].type === 'boolean') {
                         <input type="checkbox" id="cds-field-{{p.name}}-{{k}}" name="{{k}}-value" [(ngModel)]="p.config[k].value"
-                          (keydown)="p.hasChanged = true"
-                          [readonly]="p.model.public" />
+                          (ngModelChange)="p.hasChanged = true"
+                          [disabled]="p.model.public" />
                       }
                       @if (p.config[k].type === 'string') {
                         <input nz-input type="text" id="cds-field-{{p.name}}-{{k}}" name="{{k}}-value" [(ngModel)]="p.config[k].value"
-                          (keydown)="p.hasChanged = true" [readonly]="p.model.public">
+                          (ngModelChange)="p.hasChanged = true" [readonly]="p.model.public">
                       }
                       @if (p.config[k].type === 'text') {
                         @if (p.model.public) {
                           <codemirror aria-label="{{k}}" name="{{k}}-value" [(ngModel)]="p.config[k].value"
-                            [config]="codeMirrorConfigRO" #codeMirror (keydown)="p.hasChanged = true">
+                            [config]="codeMirrorConfigRO" #codeMirror (ngModelChange)="p.hasChanged = true">
                           </codemirror>
                         }
                         @if (!p.model.public) {
                           <codemirror aria-label="{{k}}" name="{{k}}-value" [(ngModel)]="p.config[k].value"
-                            [config]="codeMirrorConfig" #codeMirror (keydown)="p.hasChanged = true">
+                            [config]="codeMirrorConfig" #codeMirror (ngModelChange)="p.hasChanged = true">
                           </codemirror>
                         }
                       }
                       @if (p.config[k].type === 'password') {
                         <input nz-input type="password" id="cds-field-{{p.name}}-{{k}}" name="{{k}}-value" [(ngModel)]="p.config[k].value"
-                          (keydown)="p.hasChanged = true" [readonly]="p.model.public">
+                          (ngModelChange)="p.hasChanged = true" [readonly]="p.model.public">
                       }
                     }
                   </nz-form-control>
@@ -157,24 +90,91 @@
               }
             </form>
           </td>
-          <td>
+          <td nzAlign="right">
             @if (project.permissions.writable && !p.model.public) {
-              @if (!p.hasChanged) {
-                <button nz-button nzDanger nzType="primary" [nzLoading]="loading.action"
-                  [disabled]="loading.action" nz-popconfirm
-                  nzPopconfirmTitle="Are you sure you want to delete this integration ?"
-                  (nzOnConfirm)="deleteIntegration(p)">
-                  Delete
-                </button>
-              }
               @if (p.hasChanged) {
-                <button nz-button nzType="primary" type="button" [nzLoading]="loading.action"
+                <button nz-button nzType="primary" nzSize="small" type="button" [nzLoading]="loading.action"
                 (click)="updateIntegration(p)">Save</button>
               }
+              <button nz-button nzDanger nzType="text" [nzLoading]="loading.action" [disabled]="loading.action"
+                nz-popconfirm nzPopconfirmTitle="Are you sure you want to delete this integration?"
+                (nzOnConfirm)="deleteIntegration(p)" title="Delete the integration {{p.name}}"
+                [attr.aria-label]="'Delete the integration ' + p.name">
+                <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+              </button>
             }
           </td>
         </tr>
       }
     </tbody>
   </nz-table>
+
+  <ng-template #empty>
+    <nz-empty [nzNotFoundContent]="integrations.length === 0 ? 'No integration yet' : 'No integration matches your search'"></nz-empty>
+  </ng-template>
 </div>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New integration" [nzFooter]="null" [nzWidth]="720"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <form nz-form>
+      <nz-form-item>
+        <nz-form-label [nzSpan]="6" nzFor="cds-field-integration-model" nzRequired>Model</nz-form-label>
+        <nz-form-control [nzSpan]="18">
+          <nz-select nzShowSearch id="cds-field-integration-model" name="model" [ngModel]="newIntegration.model" (ngModelChange)="updateConfig($event)">
+            @for (m of models; track m) {
+              <nz-option [nzLabel]="m.name" nzCustomContent [nzValue]="m">
+                <div>{{ m.name }}</div>
+                @for (t of modelTypes(m); track t) {
+                  <nz-tag nzColor="success">{{t}}</nz-tag>
+                }
+              </nz-option>
+            }
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      @if (newIntegration.model) {
+        <nz-form-item>
+          <nz-form-label [nzSpan]="6" nzFor="cds-field-integration-name" nzRequired>Integration name</nz-form-label>
+          <nz-form-control [nzSpan]="18">
+            <input nz-input id="cds-field-integration-name" name="name" type="text" [(ngModel)]="newIntegration.name">
+          </nz-form-control>
+        </nz-form-item>
+        @for (k of newIntegration.model.default_config | keys; track k) {
+          <nz-form-item>
+            <nz-form-label [nzSpan]="6" nzFor="cds-field-new-{{k}}">
+              {{k}}
+              @if (newIntegration.config[k].description) {
+                <span nz-tooltip
+                  [nzTooltipTitle]="newIntegration.config[k].description" nzTooltipPlacement="right">
+                  <i nz-icon nzType="info-circle" nzTheme="outline"></i>
+                </span>
+              }
+            </nz-form-label>
+            <nz-form-control [nzSpan]="18">
+              @if (newIntegration.config[k].type === 'boolean') {
+                <label nz-checkbox nzId="cds-field-new-{{k}}" name="{{k}}"
+                [(ngModel)]="newIntegration.config[k].value"></label>
+              }
+              @if (newIntegration.config[k].type === 'string') {
+                <input nz-input type="text" id="cds-field-new-{{k}}" name="{{k}}" [(ngModel)]="newIntegration.config[k].value">
+              }
+              @if (newIntegration.config[k].type === 'text') {
+                <codemirror aria-label="{{k}}" [(ngModel)]="newIntegration.config[k].value" [config]="codeMirrorConfig" #codeMirror>
+                </codemirror>
+              }
+              @if (newIntegration.config[k].type === 'password') {
+                <input nz-input type="password" id="cds-field-new-{{k}}" name="{{k}}" [(ngModel)]="newIntegration.config[k].value">
+              }
+            </nz-form-control>
+          </nz-form-item>
+        }
+      }
+      <div class="cds-modal-footer">
+        <button nz-button type="button" (click)="closeCreateModal()" [disabled]="loading.action">Cancel</button>
+        <button nz-button nzType="primary" type="button" (click)="create()" [nzLoading]="loading.action"
+          [disabled]="loading.action || !newIntegration.name || newIntegration.name === '' || !newIntegration.model">Add</button>
+      </div>
+    </form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/integrations/project.integrations.scss
+++ b/ui/src/app/views/project/settings/integrations/project.integrations.scss
@@ -8,16 +8,6 @@
   padding: 20px;
 }
 
-form {
-  .controls {
-    text-align: right;
-
-    button {
-      margin-left: 8px;
-    }
-  }
-}
-
 .list {
   flex: 1;
   overflow: hidden;
@@ -30,4 +20,8 @@ i {
 
 .green {
   color: common.$cds_color_green;
+}
+
+.types nz-tag {
+  margin-top: 4px;
 }

--- a/ui/src/app/views/project/settings/keys/project.keys.component.ts
+++ b/ui/src/app/views/project/settings/keys/project.keys.component.ts
@@ -17,7 +17,10 @@ import { lastValueFrom } from 'rxjs';
 export class ProjectKeysComponent implements OnInit {
     @Input() project: Project;
 
-    keys: Array<Key>;
+    keys: Array<Key> = [];
+    filteredKeys: Array<Key> = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
     loading = { list: false, action: false };
 
     constructor(
@@ -35,8 +38,9 @@ export class ProjectKeysComponent implements OnInit {
         this._cd.markForCheck();
         try {
             this.keys = await lastValueFrom(this._v2ProjectService.getKeys(this.project.key));
+            this.applyFilter();
         } catch (e) {
-            this._messageService.error(`Unable to load variables sets: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            this._messageService.error(`Unable to load keys: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
         this.loading.list = false;
         this._cd.markForCheck();
@@ -49,6 +53,8 @@ export class ProjectKeysComponent implements OnInit {
             const key = await lastValueFrom(this._v2ProjectService.postKey(this.project.key, event.key));
             this.keys = this.keys.concat(key);
             this.keys.sort((a, b) => a.name < b.name ? -1 : 1);
+            this.applyFilter();
+            this.closeCreateModal();
         } catch (e) {
             this._messageService.error(`Unable to add key: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -62,10 +68,34 @@ export class ProjectKeysComponent implements OnInit {
         try {
             await lastValueFrom(this._v2ProjectService.deleteKey(this.project.key, key.name));
             this.keys = this.keys.filter(k => k.name !== key.name);
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to delete key: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
         this.loading.action = false;
+        this._cd.markForCheck();
+    }
+
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredKeys = search === '' ? this.keys :
+            this.keys.filter(k => k.name.toLowerCase().indexOf(search) !== -1
+                || (k.type ?? '').toLowerCase().indexOf(search) !== -1);
+    }
+
+    openCreateModal(): void {
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
         this._cd.markForCheck();
     }
 }

--- a/ui/src/app/views/project/settings/keys/project.keys.html
+++ b/ui/src/app/views/project/settings/keys/project.keys.html
@@ -1,50 +1,62 @@
-@if (project.permissions.writable) {
-  <h3>Create a key:</h3>
-  <app-keys-form [loading]="loading.action" (keyEvent)="addKey($event)" prefix="proj-"></app-keys-form>
-}
+<app-list-toolbar searchPlaceholder="Search a key by name or type" itemLabel="keys" [searchValue]="filter"
+  [count]="filteredKeys.length" [total]="keys.length"
+  [addLabel]="project.permissions.writable ? 'New key' : null" (searchChange)="updateFilter($event)"
+  (add)="openCreateModal()"></app-list-toolbar>
 
-<h3>Keys list:</h3>
 <div class="list">
-  <nz-table [nzData]="keys" #keylist [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
-    [nzLoading]="loading.list">
+  <nz-table [nzData]="filteredKeys" #keylist [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
+    [nzLoading]="loading.list" [nzNoResult]="empty">
     <thead>
       <tr>
-        <th nzWidth="50px">Key name</th>
-        <th nzWidth="50px">Key type</th>
-        <th nzWidth="400px">Public key</th>
+        <th nzWidth="250px">Key name</th>
+        <th nzWidth="100px">Key type</th>
+        <th>Public key</th>
         @if (project.permissions.writable) {
-          <th nzWidth="25px"></th>
+          <th nzWidth="80px" nzAlign="right">Actions</th>
         }
       </tr>
     </thead>
-    @for (k of keylist.data; track k) {
-      <tbody>
+    <tbody>
+      @for (k of keylist.data; track k.name) {
         <tr>
           <td>
-            {{ k.name }} @if (k.disabled) {
-            <span class="disabledKey">(disabled)</span>
-          }
-        </td>
-        <td>
-          {{ k.type }}
-        </td>
-        <td nzBreakWord>
-          @if (k.type === 'ssh') {
-            <input nz-input readonly aria-label="Public key of {{k.name}}" [ngModel]="k.public">
-          }
-          @if (k.type === 'pgp') {
-            <textarea nz-input aria-label="Public key of {{k.name}}" [ngModel]="k.public" readonly rows="29"></textarea>
-          }
-        </td>
-        @if (project.permissions.writable) {
-          <td>
-            <button nz-button nzDanger nzType="primary" [nzLoading]="loading.action" nz-popconfirm
-              nzPopconfirmTitle="Are you sure you want to delete this key ?"
-            (nzOnConfirm)="deleteKey(k)">Delete</button>
+            {{ k.name }}
+            @if (k.disabled) {
+              <span class="disabledKey">(disabled)</span>
+            }
           </td>
-        }
-      </tr>
+          <td>{{ k.type }}</td>
+          <td nzBreakWord>
+            @if (k.type === 'ssh') {
+              <input nz-input readonly aria-label="Public key of {{k.name}}" [ngModel]="k.public">
+            }
+            @if (k.type === 'pgp') {
+              <textarea nz-input aria-label="Public key of {{k.name}}" [ngModel]="k.public" readonly
+                [nzAutosize]="{ minRows: 3, maxRows: 12 }"></textarea>
+            }
+          </td>
+          @if (project.permissions.writable) {
+            <td nzAlign="right">
+              <button nz-button nzDanger nzType="text" [nzLoading]="loading.action" nz-popconfirm
+                nzPopconfirmTitle="Are you sure you want to delete this key?" (nzOnConfirm)="deleteKey(k)"
+                title="Delete the key {{k.name}}" [attr.aria-label]="'Delete the key ' + k.name">
+                <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+              </button>
+            </td>
+          }
+        </tr>
+      }
     </tbody>
-  }
-</nz-table>
+  </nz-table>
+
+  <ng-template #empty>
+    <nz-empty [nzNotFoundContent]="keys.length === 0 ? 'No key yet' : 'No key matches your search'"></nz-empty>
+  </ng-template>
 </div>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New key" [nzFooter]="null" [nzWidth]="800"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <app-keys-form [loading]="loading.action" (keyEvent)="addKey($event)" prefix="proj-"></app-keys-form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/keys/project.keys.scss
+++ b/ui/src/app/views/project/settings/keys/project.keys.scss
@@ -14,3 +14,8 @@
 nz-alert {
   margin: 10px;
 }
+
+.disabledKey {
+  font-style: italic;
+  opacity: 0.65;
+}

--- a/ui/src/app/views/project/settings/variablesets/items/variableset.item.component.ts
+++ b/ui/src/app/views/project/settings/variablesets/items/variableset.item.component.ts
@@ -17,7 +17,10 @@ export class ProjectVariableSetItemsComponent implements OnChanges {
     @Input() project: Project;
     @Input() variableSet: VariableSet
 
-    items: VariableSetItem[];
+    items: VariableSetItem[] = [];
+    filteredItems: VariableSetItem[] = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
     loading: boolean;
     itemFormLoading: boolean;
     newItem: VariableSetItem;
@@ -37,6 +40,7 @@ export class ProjectVariableSetItemsComponent implements OnChanges {
         if (!this.variableSet || !this.project) {
             return
         }
+        this.filter = '';
         this.loadVariableSet();
     }
 
@@ -46,7 +50,8 @@ export class ProjectVariableSetItemsComponent implements OnChanges {
 
         try {
             const res = await lastValueFrom(this._v2ProjectService.getVariableSet(this.project.key, this.variableSet.name));
-            this.items = res.items
+            this.items = res.items ?? [];
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to load variable set: ${ErrorUtils.print(e)}`);
         }
@@ -85,7 +90,33 @@ export class ProjectVariableSetItemsComponent implements OnChanges {
             this._cd.markForCheck();
         }
 
+        this.closeCreateModal();
         this.loadVariableSet();
+    }
+
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredItems = search === '' ? this.items :
+            this.items.filter(i => i.name.toLowerCase().indexOf(search) !== -1 || (i.type ?? '').toLowerCase().indexOf(search) !== -1);
+    }
+
+    openCreateModal(): void {
+        this.newItem = new VariableSetItem();
+        this.errorItemName = false;
+        this.errorItemValue = false;
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
+        this._cd.markForCheck();
     }
 
     async updateVariableSetItem(i: VariableSetItem) {

--- a/ui/src/app/views/project/settings/variablesets/items/variableset.item.html
+++ b/ui/src/app/views/project/settings/variablesets/items/variableset.item.html
@@ -1,92 +1,86 @@
-<h2> Create a new variableset item</h2>
-<form nz-form (ngSubmit)="createVariableSetItem()">
-  <nz-row>
-    <nz-col [nzSpan]="16">
+<app-list-toolbar searchPlaceholder="Search an item by name or type" itemLabel="items" [searchValue]="filter"
+  [count]="filteredItems.length" [total]="items.length" addLabel="New item" [autofocus]="false"
+  (searchChange)="updateFilter($event)" (add)="openCreateModal()"></app-list-toolbar>
+
+<nz-table #table [nzData]="filteredItems" [nzLoading]="loading" [nzNoResult]="empty" nzSize="small">
+  <thead>
+    <tr>
+      <th nzWidth="220px">Item name</th>
+      <th nzWidth="90px">Type</th>
+      <th>Value</th>
+      <th nzWidth="120px" nzAlign="right">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (data of table.data; track data.name) {
+      <tr>
+        <td>{{data.name}}</td>
+        <td>{{data.type}}</td>
+        <td>
+          <textarea nz-input name="value" id="cds-field-item-{{data.name}}" aria-label="Value of item {{data.name}}"
+            [nzAutosize]="{ minRows: 1, maxRows: 6 }" [(ngModel)]="data.value"
+            (ngModelChange)="data.changed = true"></textarea>
+        </td>
+        <td nzAlign="right">
+          @if (data.changed) {
+            <button nz-button nzType="primary" nzSize="small" [nzLoading]="loading"
+            (click)="updateVariableSetItem(data)">Update</button>
+          }
+          <button nz-button nzDanger nzType="text" [nzLoading]="loading" nz-popconfirm
+            nzPopconfirmTitle="Are you sure you want to delete this item?" (nzOnConfirm)="deleteVariableSetItem(data)"
+            title="Delete the item {{data.name}}" [attr.aria-label]="'Delete the item ' + data.name">
+            <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+          </button>
+        </td>
+      </tr>
+    }
+  </tbody>
+</nz-table>
+
+<ng-template #empty>
+  <nz-empty [nzNotFoundContent]="items.length === 0 ? 'No item yet' : 'No item matches your search'"></nz-empty>
+</ng-template>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New variable set item" [nzFooter]="null"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <form nz-form (ngSubmit)="createVariableSetItem()">
       <nz-form-item>
-        <nz-form-label [nzSpan]="3" nzFor="cds-field-itemname">
-          Item name
-        </nz-form-label>
-        <nz-form-control>
+        <nz-form-label [nzSpan]="5" nzFor="cds-field-itemname" nzRequired>Item name</nz-form-label>
+        <nz-form-control [nzSpan]="19">
           <input nz-input name="name" id="cds-field-itemname" [(ngModel)]="newItem.name">
           @if (errorItemName) {
             <nz-alert nzType="warning" nzMessage="Name must respect pattern ^[a-zA-Z0-9_-]{1,}$"></nz-alert>
           }
         </nz-form-control>
       </nz-form-item>
-    </nz-col>
-  </nz-row>
-  <nz-row>
-    <nz-col [nzSpan]="16">
       <nz-form-item>
-        <nz-form-label [nzSpan]="3" nzFor="cds-field-itemtype">
-          Item Type
-        </nz-form-label>
-        <nz-form-control>
+        <nz-form-label [nzSpan]="5" nzFor="cds-field-itemtype">Item type</nz-form-label>
+        <nz-form-control [nzSpan]="19">
           <nz-select id="cds-field-itemtype" [(ngModel)]="newItem.type" name="type">
             <nz-option nzValue="string" nzLabel="string"></nz-option>
             <nz-option nzValue="secret" nzLabel="secret"></nz-option>
           </nz-select>
         </nz-form-control>
       </nz-form-item>
-    </nz-col>
-  </nz-row>
-  <nz-row>
-    <nz-col [nzSpan]="16">
       <nz-form-item>
-        <nz-form-label [nzSpan]="3" nzFor="cds-field-itemvalue">
-          Item value
-        </nz-form-label>
-        <nz-form-control>
+        <nz-form-label [nzSpan]="5" nzFor="cds-field-itemvalue" nzRequired>Item value</nz-form-label>
+        <nz-form-control [nzSpan]="19">
           @if (newItem.type === 'secret') {
             <input nz-input type="password" id="cds-field-itemvalue" name="value" [(ngModel)]="newItem.value">
-          }
-          @if (newItem.type !== 'secret') {
-            <textarea nz-input  name="value" id="cds-field-itemvalue" [(ngModel)]="newItem.value"></textarea>
+          } @else {
+            <textarea nz-input name="value" id="cds-field-itemvalue" [nzAutosize]="{ minRows: 3, maxRows: 10 }"
+              [(ngModel)]="newItem.value"></textarea>
           }
           @if (errorItemValue) {
             <nz-alert nzType="warning" nzMessage="Value must not be empty"></nz-alert>
           }
         </nz-form-control>
       </nz-form-item>
-    </nz-col>
-  </nz-row>
-  <nz-row>
-    <nz-col [nzSpan]="16">
-      <nz-form-item>
-        <button nz-button nzType="primary" nzBlock [nzLoading]="itemFormLoading">Create</button>
-      </nz-form-item>
-    </nz-col>
-  </nz-row>
-</form>
-<h2> List of existing variablesets</h2>
-<nz-table #table [nzData]="items" [nzLoading]="loading">
-  <thead>
-    <tr>
-      <th>Item name</th>
-      <th>Type</th>
-      <th nzWidth="200">Value</th>
-      <th>Deletion</th>
-    </tr>
-  </thead>
-  <tbody>
-    @for (data of table.data; track data) {
-      <tr>
-        <td>{{data.name}}</td>
-        <td>{{data.type}}</td>
-        <td>
-          <textarea nz-input  name="value" id="cds-field-item-{{data.name}}" aria-label="Value of item {{data.name}}" [(ngModel)]="data.value" (ngModelChange)="data.changed = true"></textarea>
-        </td>
-        <td>
-          @if (data.changed) {
-            <button nz-button nzType="primary" [nzLoading]="loading"
-            (click)="updateVariableSetItem(data)">Update</button>
-          }
-          @if (!data.changed) {
-            <button nz-button nzDanger nzType="primary" [nzLoading]="loading" nz-popconfirm nzPopconfirmTitle="Are you sure you want to delete this item ?"
-            (nzOnConfirm)="deleteVariableSetItem(data)">Delete</button>
-          }
-        </td>
-      </tr>
-    }
-  </tbody>
-</nz-table>
+      <div class="cds-modal-footer">
+        <button nz-button type="button" (click)="closeCreateModal()">Cancel</button>
+        <button nz-button nzType="primary" [nzLoading]="itemFormLoading">Create</button>
+      </div>
+    </form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/variablesets/variablesets.component.ts
+++ b/ui/src/app/views/project/settings/variablesets/variablesets.component.ts
@@ -20,6 +20,9 @@ export class ProjectVariableSetsComponent implements OnInit {
     newVariableSetName: string;
     selectedVariableSet: VariableSet;
     variableSets: Array<VariableSet> = [];
+    filteredVariableSets: Array<VariableSet> = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
 
     constructor(
         private _cd: ChangeDetectorRef,
@@ -36,6 +39,7 @@ export class ProjectVariableSetsComponent implements OnInit {
         this._cd.markForCheck();
         try {
             this.variableSets = await lastValueFrom(this._v2ProjectService.getVariableSets(this.project.key));
+            this.applyFilter();
         } catch (e) {
             this._messageService.error(`Unable to load variables sets: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -44,12 +48,17 @@ export class ProjectVariableSetsComponent implements OnInit {
     }
 
     async createVariableSet() {
+        if (!this.newVariableSetName) {
+            return;
+        }
         this.loading.action = true;
         this._cd.markForCheck();
         try {
             const set = await lastValueFrom(this._v2ProjectService.createVariableSet(this.project.key, <VariableSet>{ name: this.newVariableSetName }))
             this.variableSets = this.variableSets.concat(set)
             this.variableSets.sort((v1, v2) => v1.name < v2.name ? -1 : 1);
+            this.applyFilter();
+            this.closeCreateModal();
         } catch (e) {
             this._messageService.error(`Unable to set variables set: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -63,6 +72,10 @@ export class ProjectVariableSetsComponent implements OnInit {
         try {
             await lastValueFrom(this._v2ProjectService.deleteVariableSet(this.project.key, v.name))
             this.variableSets = this.variableSets.filter(s => s.name !== v.name);
+            this.applyFilter();
+            if (this.selectedVariableSet?.name === v.name) {
+                this.unselectVariableSet();
+            }
         } catch (e) {
             this._messageService.error(`Unable to delete variables set: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -70,12 +83,36 @@ export class ProjectVariableSetsComponent implements OnInit {
         this._cd.markForCheck();
     }
 
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredVariableSets = search === '' ? this.variableSets :
+            this.variableSets.filter(v => v.name.toLowerCase().indexOf(search) !== -1);
+    }
+
+    openCreateModal(): void {
+        this.newVariableSetName = '';
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
+        this._cd.markForCheck();
+    }
+
     selectVariableSet(v: VariableSet): void {
         this.selectedVariableSet = v;
-        this._cd.markForCheck;
+        this._cd.markForCheck();
     }
 
     unselectVariableSet(): void {
         delete this.selectedVariableSet;
+        this._cd.markForCheck();
     }
 }

--- a/ui/src/app/views/project/settings/variablesets/variablesets.html
+++ b/ui/src/app/views/project/settings/variablesets/variablesets.html
@@ -1,50 +1,68 @@
-<h3>Create a variables set</h3>
-<form nz-form (ngSubmit)="createVariableSet()">
-  <nz-row>
-    <nz-col [nzSpan]="12">
-      <nz-form-item>
-        <nz-form-label nzFor="cds-field-vsname">Name</nz-form-label>
-        <nz-form-control>
-          <input nz-input name="name" id="cds-field-vsname" [(ngModel)]="newVariableSetName">
-        </nz-form-control>
-      </nz-form-item>
-    </nz-col>
-    <nz-col [nzOffset]="1">
-      <nz-form-item>
-        <button nz-button nzType="primary" [nzLoading]="loading.action">Create</button>
-      </nz-form-item>
-    </nz-col>
-  </nz-row>
-</form>
+<app-list-toolbar searchPlaceholder="Search a variable set" itemLabel="variable sets" [searchValue]="filter"
+  [count]="filteredVariableSets.length" [total]="variableSets.length" addLabel="New variable set"
+  (searchChange)="updateFilter($event)" (add)="openCreateModal()"></app-list-toolbar>
 
-<h3>Variables sets list:</h3>
 <div class="list">
-  <nz-table #table [nzData]="variableSets" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
-    [nzLoading]="loading.list">
+  <nz-table #table [nzData]="filteredVariableSets" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
+    [nzLoading]="loading.list" [nzNoResult]="empty">
     <thead>
       <tr>
         <th>Name</th>
-        <th>Deletion</th>
+        <th nzWidth="80px" nzAlign="right">Actions</th>
       </tr>
     </thead>
     <tbody>
-      @for (data of table.data; track data) {
+      @for (data of table.data; track data.name) {
         <tr>
           <td appClickable (click)="selectVariableSet(data)">{{data.name}}</td>
-          <td>
-            <button nz-button nzDanger nzType="primary" [nzLoading]="loading.action" nz-popconfirm
-              nzPopconfirmTitle="Are you sure you want to delete this variableset ? it will remove all items"
-            (nzOnConfirm)="deleteVariableSet(data)">Delete</button>
+          <td nzAlign="right">
+            <button nz-button nzDanger nzType="text" [nzLoading]="loading.action" nz-popconfirm
+              nzPopconfirmTitle="Are you sure you want to delete this variable set? It will remove all its items."
+              (nzOnConfirm)="deleteVariableSet(data)" title="Delete the variable set {{data.name}}"
+              [attr.aria-label]="'Delete the variable set ' + data.name">
+              <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+            </button>
           </td>
         </tr>
       }
     </tbody>
   </nz-table>
-  <nz-drawer class="toto" nzPlacement="right" [nzWidth]="1000" [nzTitle]="selectedVariableSet?.name"
+
+  <ng-template #empty>
+    <nz-empty [nzNotFoundContent]="variableSets.length === 0 ? 'No variable set yet' : 'No variable set matches your search'"></nz-empty>
+  </ng-template>
+
+  <nz-drawer nzPlacement="right" [nzWidth]="1000" [nzTitle]="selectedVariableSet?.name" [nzExtra]="drawerExtra"
     [nzVisible]="selectedVariableSet" (nzOnClose)="unselectVariableSet()">
     <ng-container *nzDrawerContent>
       <app-project-variable-set-items [project]="project"
       [variableSet]="selectedVariableSet"></app-project-variable-set-items>
     </ng-container>
   </nz-drawer>
+
+  <ng-template #drawerExtra>
+    <button nz-button nzDanger [nzLoading]="loading.action" nz-popconfirm
+      nzPopconfirmTitle="Are you sure you want to delete this variable set? It will remove all its items."
+      (nzOnConfirm)="deleteVariableSet(selectedVariableSet)">
+      <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span><span>Delete this variable set</span>
+    </button>
+  </ng-template>
 </div>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New variable set" [nzFooter]="null"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <form nz-form (ngSubmit)="createVariableSet()">
+      <nz-form-item>
+        <nz-form-label nzFor="cds-field-vsname" nzRequired>Name</nz-form-label>
+        <nz-form-control>
+          <input nz-input name="name" id="cds-field-vsname" [(ngModel)]="newVariableSetName">
+        </nz-form-control>
+      </nz-form-item>
+      <div class="cds-modal-footer">
+        <button nz-button type="button" (click)="closeCreateModal()">Cancel</button>
+        <button nz-button nzType="primary" [nzLoading]="loading.action" [disabled]="!newVariableSetName">Create</button>
+      </div>
+    </form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/webhooks/webhooks.component.ts
+++ b/ui/src/app/views/project/settings/webhooks/webhooks.component.ts
@@ -21,6 +21,9 @@ export class ProjectWebhooksComponent implements OnInit {
     loading = { list: false, action: false };
     vcss: Array<VCSProject>;
     webhooks: Array<ProjectWebHook> = [];
+    filteredWebhooks: Array<ProjectWebHook> = [];
+    filter: string = '';
+    createModalVisible: boolean = false;
     newWebhook: PostProjectWebHook = new PostProjectWebHook();
     createdHook: PostResponseCreateHook;
     errorRepository: boolean;
@@ -43,6 +46,7 @@ export class ProjectWebhooksComponent implements OnInit {
         this._cd.markForCheck();
         try {
             this.webhooks = await lastValueFrom(this._v2ProjectService.getWebhooks(this.project.key));
+            this.applyFilter();
             this.vcss = await lastValueFrom(this._projectService.listVCSProject(this.project.key));
             if (this.vcss.length > 0) {
                 this.newWebhook.vcs_server = this.vcss[0].name;
@@ -60,6 +64,7 @@ export class ProjectWebhooksComponent implements OnInit {
         try {
             await lastValueFrom(this._v2ProjectService.deleteWebhook(this.project.key, h.id))
             this.webhooks = this.webhooks.filter(s => s.id !== h.id);
+            this.applyFilter();
             this._messageService.success(`WebHook ${h.id} deleted`, { nzDuration: 2000 });
         } catch (e) {
             this._messageService.error(`Unable to delete webhook: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
@@ -85,6 +90,7 @@ export class ProjectWebhooksComponent implements OnInit {
         this._cd.markForCheck();
         try {
             this.createdHook = await lastValueFrom(this._v2ProjectService.createWebhook(this.project.key, this.newWebhook))
+            this.closeCreateModal();
             this.load();
             this.newWebhook = new PostProjectWebHook();
         } catch (e) {
@@ -96,5 +102,35 @@ export class ProjectWebhooksComponent implements OnInit {
 
     closeAlert() {
         delete this.createdHook;
+        this._cd.markForCheck();
+    }
+
+    updateFilter(value: string): void {
+        this.filter = value;
+        this.applyFilter();
+        this._cd.markForCheck();
+    }
+
+    applyFilter(): void {
+        const search = (this.filter ?? '').trim().toLowerCase();
+        this.filteredWebhooks = search === '' ? this.webhooks : this.webhooks.filter(h =>
+            [h.id, h.type, h.vcs_server, h.repository, h.workflow, h.username]
+                .some(field => (field ?? '').toLowerCase().indexOf(search) !== -1));
+    }
+
+    openCreateModal(): void {
+        this.errorRepository = false;
+        this.errorWorkflow = false;
+        this.newWebhook = new PostProjectWebHook();
+        if (this.vcss?.length > 0) {
+            this.newWebhook.vcs_server = this.vcss[0].name;
+        }
+        this.createModalVisible = true;
+        this._cd.markForCheck();
+    }
+
+    closeCreateModal(): void {
+        this.createModalVisible = false;
+        this._cd.markForCheck();
     }
 }

--- a/ui/src/app/views/project/settings/webhooks/webhooks.html
+++ b/ui/src/app/views/project/settings/webhooks/webhooks.html
@@ -1,4 +1,3 @@
-<h3>Create a Webhook</h3>
 @if (createdHook) {
   <nz-alert nzType="info" nzCloseable [nzMessage]="hookCreation" (nzOnClose)="closeAlert()"></nz-alert>
 }
@@ -6,86 +5,27 @@
   Hook URL: {{createdHook.url}}<br/>
   Hook secret: {{createdHook.hook_sign_key}}
 </ng-template>
-<form nz-form (ngSubmit)="createHook()">
-  <nz-row>
-    <nz-col [nzSpan]="newWebhook.type === 'repository' ? 6: 4">
-      <nz-form-item>
-        <nz-form-label nzFor="cds-field-hooktype">
-          Hook Type
-        </nz-form-label>
-        <nz-form-control>
-          <nz-select name="type" id="cds-field-hooktype" [(ngModel)]="newWebhook.type">
-            @for (n of hookTypes; track n) {
-              <nz-option [nzLabel]="n" [nzValue]="n"></nz-option>
-            }
-          </nz-select>
-        </nz-form-control>
-      </nz-form-item>
-    </nz-col>
-    <nz-col [nzSpan]="newWebhook.type === 'repository' ? 6: 4" [nzOffset]="1">
-      <nz-form-item>
-        <nz-form-label nzFor="cds-field-vcs">
-          Vcs server
-        </nz-form-label>
-        <nz-form-control>
-          <nz-select name="vcs" id="cds-field-vcs" [(ngModel)]="newWebhook.vcs_server">
-            @for (n of vcss; track n) {
-              <nz-option [nzLabel]="n.name" [nzValue]="n.name"></nz-option>
-            }
-          </nz-select>
-        </nz-form-control>
-      </nz-form-item>
-    </nz-col>
-    <nz-col [nzSpan]="newWebhook.type === 'repository' ? 6: 4" [nzOffset]="1">
-      <nz-form-item>
-        <nz-form-label nzFor="cds-field-repository">
-          Repository
-        </nz-form-label>
-        <nz-form-control>
-          <input nz-input name="repository" id="cds-field-repository" [(ngModel)]="newWebhook.repository">
-          @if (errorRepository) {
-            <nz-alert nzType="warning" nzMessage="Repository cannot be empty"></nz-alert>
-          }
-        </nz-form-control>
-      </nz-form-item>
-    </nz-col>
-    @if (newWebhook.type === 'workflow') {
-      <nz-col [nzSpan]="5" [nzOffset]="1">
-        <nz-form-item>
-          <nz-form-label nzFor="cds-field-workflow">
-            Workflow
-          </nz-form-label>
-          <nz-form-control>
-            <input nz-input name="workflow" id="cds-field-workflow" [(ngModel)]="newWebhook.workflow">
-            @if (errorWorkflow) {
-              <nz-alert nzType="warning" nzMessage="Workflow cannot be empty"></nz-alert>
-            }
-          </nz-form-control>
-        </nz-form-item>
-      </nz-col>
-    }
-    <nz-col [nzSpan]="4" class="alignEnd">
-      <button nz-button nzType="primary" [nzLoading]="loading.action">Create</button>
-    </nz-col>
-  </nz-row>
-</form>
 
-<h3>Webhooks :</h3>
+<app-list-toolbar searchPlaceholder="Search a webhook by id, type, VCS, repository, workflow or user"
+  itemLabel="webhooks" [searchValue]="filter"
+  [count]="filteredWebhooks.length" [total]="webhooks.length" addLabel="New webhook"
+  (searchChange)="updateFilter($event)" (add)="openCreateModal()"></app-list-toolbar>
+
 <div class="list">
-  <nz-table #table [nzData]="webhooks" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
-    [nzLoading]="loading.list">
+  <nz-table #table [nzData]="filteredWebhooks" [nsAutoHeightTable]="39" [nzFrontPagination]="false" nzSize="small"
+    [nzLoading]="loading.list" [nzNoResult]="empty">
     <thead>
       <tr>
-        <th>ID</th>
-        <th>Type</th>
+        <th nzWidth="290px">ID</th>
+        <th nzWidth="120px">Type</th>
         <th>Target</th>
-        <th>Created</th>
-        <th>Username</th>
-        <th>Action</th>
+        <th nzWidth="180px">Created</th>
+        <th nzWidth="150px">Username</th>
+        <th nzWidth="80px" nzAlign="right">Actions</th>
       </tr>
     </thead>
     <tbody>
-      @for (data of table.data; track data) {
+      @for (data of table.data; track data.id) {
         <tr>
           <td>{{data.id}}</td>
           <td>{{data.type}}</td>
@@ -94,9 +34,71 @@
           }</td>
           <td>{{data.created}}</td>
           <td>{{data.username}}</td>
-          <td class="alignEnd"><button nz-button nzDanger [nzLoading]="loading.action" nz-popconfirm="Are you sure you want to revoke this webhook?" (nzOnConfirm)="deleteWebhook(data)">Delete</button></td>
+          <td nzAlign="right">
+            <button nz-button nzDanger nzType="text" [nzLoading]="loading.action"
+              nz-popconfirm="Are you sure you want to revoke this webhook?" (nzOnConfirm)="deleteWebhook(data)"
+              title="Revoke the webhook {{data.id}}" [attr.aria-label]="'Revoke the webhook ' + data.id">
+              <span nz-icon nzType="delete" nzTheme="outline" aria-hidden="true"></span>
+            </button>
+          </td>
         </tr>
       }
     </tbody>
   </nz-table>
+
+  <ng-template #empty>
+    <nz-empty [nzNotFoundContent]="webhooks.length === 0 ? 'No webhook yet' : 'No webhook matches your search'"></nz-empty>
+  </ng-template>
 </div>
+
+<nz-modal [nzVisible]="createModalVisible" nzTitle="New webhook" [nzFooter]="null" [nzWidth]="640"
+  (nzOnCancel)="closeCreateModal()">
+  <ng-container *nzModalContent>
+    <form nz-form (ngSubmit)="createHook()">
+      <nz-form-item>
+        <nz-form-label [nzSpan]="6" nzFor="cds-field-hooktype">Hook type</nz-form-label>
+        <nz-form-control [nzSpan]="18">
+          <nz-select name="type" id="cds-field-hooktype" [(ngModel)]="newWebhook.type">
+            @for (n of hookTypes; track n) {
+              <nz-option [nzLabel]="n" [nzValue]="n"></nz-option>
+            }
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label [nzSpan]="6" nzFor="cds-field-vcs">VCS server</nz-form-label>
+        <nz-form-control [nzSpan]="18">
+          <nz-select name="vcs" id="cds-field-vcs" [(ngModel)]="newWebhook.vcs_server">
+            @for (n of vcss; track n) {
+              <nz-option [nzLabel]="n.name" [nzValue]="n.name"></nz-option>
+            }
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label [nzSpan]="6" nzFor="cds-field-repository" nzRequired>Repository</nz-form-label>
+        <nz-form-control [nzSpan]="18">
+          <input nz-input name="repository" id="cds-field-repository" [(ngModel)]="newWebhook.repository">
+          @if (errorRepository) {
+            <nz-alert nzType="warning" nzMessage="Repository cannot be empty"></nz-alert>
+          }
+        </nz-form-control>
+      </nz-form-item>
+      @if (newWebhook.type === 'workflow') {
+        <nz-form-item>
+          <nz-form-label [nzSpan]="6" nzFor="cds-field-workflow" nzRequired>Workflow</nz-form-label>
+          <nz-form-control [nzSpan]="18">
+            <input nz-input name="workflow" id="cds-field-workflow" [(ngModel)]="newWebhook.workflow">
+            @if (errorWorkflow) {
+              <nz-alert nzType="warning" nzMessage="Workflow cannot be empty"></nz-alert>
+            }
+          </nz-form-control>
+        </nz-form-item>
+      }
+      <div class="cds-modal-footer">
+        <button nz-button type="button" (click)="closeCreateModal()">Cancel</button>
+        <button nz-button nzType="primary" [nzLoading]="loading.action">Create</button>
+      </div>
+    </form>
+  </ng-container>
+</nz-modal>

--- a/ui/src/app/views/project/settings/webhooks/webhooks.scss
+++ b/ui/src/app/views/project/settings/webhooks/webhooks.scss
@@ -11,7 +11,3 @@
     overflow: hidden;
   }
 
-  .alignEnd {
-    text-align: right;
-  }
-

--- a/ui/src/app/views/search/search-bar.component.ts
+++ b/ui/src/app/views/search/search-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { Router } from "@angular/router";
 import { SearchResult, SearchResultType } from "app/model/search.model";
 import { SearchService } from "app/service/search.service";
@@ -20,6 +20,8 @@ import { DisplaySearchResult } from "./search.component";
 @AutoUnsubscribe()
 export class SearchBarComponent implements OnInit, OnDestroy {
 	@ViewChild('searchBar') searchBar: InputFilterComponent<Suggestion<SearchResult>>;
+
+	@Input() autofocus: boolean = false;
 
 	searchFilterText: string = '';
 	searchFilters: Array<Filter> = [];

--- a/ui/src/app/views/search/search-bar.html
+++ b/ui/src/app/views/search/search-bar.html
@@ -1,4 +1,4 @@
-<app-input-filter placeholder="Search..." [filters]="searchFilters" (changeFilter)="searchChange($event)"
+<app-input-filter placeholder="Search..." [filters]="searchFilters" [autofocus]="autofocus" (changeFilter)="searchChange($event)"
   [suggestions]="searchSuggestions" [suggestionTemplate]="suggestionTemplate"
   (selectSuggestion)="selectSuggestion($event)" (submit)="submitSearch()" #searchBar>
   <ng-template #suggestionTemplate let-option="option">

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -57,6 +57,14 @@ body {
     outline: none;
 }
 
+// Action row of a form rendered inside a nz-modal that opts out of the default footer.
+.cds-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 24px;
+}
+
 .app-loader {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
The variable sets, concurrencies, integrations, keys and webhooks tabs all put their creation form directly above their list, which read like a search box rather than an "add" form.

Each tab now starts with a shared app-list-toolbar: a full width search field (autofocused when the tab opens), a filtered/total counter and an "Add" button opening the creation form in a modal. Lists get sized columns, a compact icon action column and contextual empty states.

Also fix a few incoherences spotted along the way:
- expose the delete action in the variable set and concurrency edition drawers, not only in the list;
- keep delete visible next to save/update on integrations and variable set items instead of replacing it;
- mark an integration dirty on ngModelChange instead of keydown, so toggling a checkbox or pasting a value enables save;
- disable, not readonly, the config checkbox of public integrations;
- merge the two divergent layouts of the concurrency form into one.

The home page search box gets the same autofocus behaviour, opt-in so the navbar search bar keeps its current behaviour.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
