### PR TITLE
feat(api,ui,cli): free text search on workflow runs

### DIFF
--- a/cli/cdsctl/experimental_workflow.go
+++ b/cli/cdsctl/experimental_workflow.go
@@ -127,6 +127,7 @@ var workflowRunSearchCmd = cli.Command{
 		{Name: "branch"},
 		{Name: "status"},
 		{Name: "actor"},
+		{Name: "query", Usage: "free text search, all given words must match"},
 		{Name: "offset"},
 		{Name: "limit"},
 	},
@@ -140,6 +141,7 @@ func workflowRunSearchFunc(v cli.Values) (cli.ListResult, error) {
 	branch := v.GetString("branch")
 	status := v.GetString("status")
 	actor := v.GetString("actor")
+	query := v.GetString("query")
 
 	offset, err := v.GetInt64("offset")
 	if err != nil {
@@ -177,6 +179,9 @@ func workflowRunSearchFunc(v cli.Values) (cli.ListResult, error) {
 	}
 	if repository != "" {
 		mods = append(mods, cdsclient.WithQueryParameter("repository", repository))
+	}
+	if query != "" {
+		mods = append(mods, cdsclient.WithQueryParameter("query", query))
 	}
 
 	var runs []sdk.V2WorkflowRun

--- a/engine/api/search.go
+++ b/engine/api/search.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/ovh/cds/engine/api/project"
 	"github.com/ovh/cds/engine/api/rbac"
@@ -25,7 +26,7 @@ func parseSearchQuery(values url.Values) (search.SearchFilters, uint, uint) {
 		case "type":
 			filters.Types = v
 		case "query":
-			filters.Query = v[0]
+			filters.Query = strings.Join(v, " ")
 		case "offset":
 			value, _ := strconv.ParseUint(v[0], 10, 0)
 			offset = uint(value)

--- a/engine/api/search/dao.go
+++ b/engine/api/search/dao.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 	"database/sql"
-	"strings"
 
 	"github.com/go-gorp/gorp"
 	"github.com/lib/pq"
@@ -16,6 +15,10 @@ type SearchFilters struct {
 	Types    []string
 	Query    string
 }
+
+// queryFilter keeps a result when every word of the free text search matches its label or its id,
+// so words can be given in any order. An empty search keeps everything.
+const queryFilter = `(array_length(:query::text[], 1) IS NULL OR LOWER(CONCAT_WS(' ', label, id)) LIKE ALL(:query::text[]))`
 
 func CountAll(ctx context.Context, db gorp.SqlExecutor, filters SearchFilters) (int64, error) {
 	_, next := telemetry.Span(ctx, "CountAll")
@@ -56,13 +59,13 @@ func CountAll(ctx context.Context, db gorp.SqlExecutor, filters SearchFilters) (
 			)
 		SELECT COUNT(1)
 		FROM results
-		WHERE LOWER(label) LIKE :query OR LOWER(id) LIKE :query
+		WHERE ` + queryFilter + `
 	`
 
 	count, err := db.SelectInt(query, map[string]interface{}{
 		"projects": pq.StringArray(filters.Projects),
 		"types":    pq.StringArray(filters.Types),
-		"query":    "%" + strings.ToLower(filters.Query) + "%",
+		"query":    pq.StringArray(sdk.SearchQueryLikePatterns(filters.Query)),
 	})
 	return count, sdk.WithStack(err)
 }
@@ -118,15 +121,15 @@ func SearchAll(ctx context.Context, db gorp.SqlExecutor, filters SearchFilters, 
 				)
 			)
 		SELECT id, label, description, variants, CASE
-				WHEN LOWER(label) LIKE :query THEN 1
-				WHEN LOWER(id) LIKE :query THEN 2
+				WHEN LOWER(label) LIKE ALL(:query::text[]) THEN 1
+				WHEN LOWER(id) LIKE ALL(:query::text[]) THEN 2
 			END AS priority, CASE
 				WHEN type_int = 0 THEN 'project'
 				WHEN type_int = 1 THEN 'workflow'
 				WHEN type_int = 2 THEN 'workflow-legacy'
 			END AS type
 		FROM results
-		WHERE LOWER(label) LIKE :query OR LOWER(id) LIKE :query
+		WHERE ` + queryFilter + `
 		ORDER BY priority ASC, CHAR_LENGTH(label) ASC, type_int ASC
 		LIMIT :limit OFFSET :offset
 	`
@@ -136,7 +139,7 @@ func SearchAll(ctx context.Context, db gorp.SqlExecutor, filters SearchFilters, 
 	if _, err := db.Select(&res, query, map[string]interface{}{
 		"projects": pq.StringArray(filters.Projects),
 		"types":    pq.StringArray(filters.Types),
-		"query":    "%" + strings.ToLower(filters.Query) + "%",
+		"query":    pq.StringArray(sdk.SearchQueryLikePatterns(filters.Query)),
 		"limit":    limit,
 		"offset":   offset,
 	}); err != nil {

--- a/engine/api/search_test.go
+++ b/engine/api/search_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/ovh/cds/engine/api/test"
+	"github.com/ovh/cds/engine/api/test/assets"
+	"github.com/ovh/cds/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchFreeTextQuery(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+
+	admin, pwd := assets.InsertAdminUser(t, db)
+
+	// Every project shares a unique token so that the assertions cannot be disturbed by the
+	// projects inserted by the other tests, an admin being allowed to search all of them.
+	token := sdk.RandomString(10)
+	projAlpha := assets.InsertTestProject(t, db, api.Cache, "aaa"+token, "alpha"+token)
+	projBeta := assets.InsertTestProject(t, db, api.Cache, "bbb"+token, "beta"+token)
+
+	uri := api.Router.GetRouteV2("GET", api.getSearchHandler, map[string]string{})
+	test.NotEmpty(t, uri)
+
+	search := func(t *testing.T, query string) []string {
+		req := assets.NewAuthentifiedRequest(t, admin, pwd, "GET", uri+"?query="+url.QueryEscape(query), nil)
+		w := httptest.NewRecorder()
+		api.Router.Mux.ServeHTTP(w, req)
+		require.Equal(t, 200, w.Code)
+
+		var results sdk.SearchResults
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+		require.Equal(t, strconv.Itoa(len(results)), w.Header().Get("X-Total-Count"))
+
+		ids := make([]string, 0, len(results))
+		for i := range results {
+			ids = append(ids, results[i].ID)
+		}
+		return ids
+	}
+
+	for _, tc := range []struct {
+		name     string
+		query    string
+		expected []string
+	}{
+		{"single word", token, []string{projAlpha.Key, projBeta.Key}},
+		{"single word on the label", "alpha" + token, []string{projAlpha.Key}},
+		{"all words must match", token + " alpha", []string{projAlpha.Key}},
+		{"words can be given in any order", "alpha " + token, []string{projAlpha.Key}},
+		{"words can match different fields", "aaa" + token + " alpha", []string{projAlpha.Key}},
+		{"extra spaces are ignored", "  alpha   " + token + " ", []string{projAlpha.Key}},
+		{"words are case insensitive", "ALPHA" + token, []string{projAlpha.Key}},
+		{"unmatched word excludes the result", token + " gamma", []string{}},
+		{"like wildcards are escaped", token + "%", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ElementsMatch(t, tc.expected, search(t, tc.query))
+		})
+	}
+}

--- a/engine/api/v2_workflow_run.go
+++ b/engine/api/v2_workflow_run.go
@@ -705,6 +705,8 @@ func parseWorkflowRunsSearchV2Query(query url.Values) (workflow_v2.SearchRunsFil
 			filters.Commits = v
 		case "template":
 			filters.Templates = v
+		case "query":
+			filters.Query = strings.Join(v, " ")
 		case "offset":
 			value, _ := strconv.ParseUint(v[0], 10, 0)
 			offset = uint(value)

--- a/engine/api/v2_workflow_run_test.go
+++ b/engine/api/v2_workflow_run_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -78,6 +79,103 @@ func TestSearchAllWorkflow(t *testing.T) {
 	require.Len(t, runs, 1)
 	require.Equal(t, wr.ID, runs[0].ID)
 
+}
+
+func TestSearchWorkflowRunsFreeTextQuery(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+
+	admin, pwd := assets.InsertAdminUser(t, db)
+	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
+	vcsServer := assets.InsertTestVCSProject(t, db, proj.ID, "github", "github")
+	repo := assets.InsertTestProjectRepository(t, db, proj.Key, vcsServer.ID, sdk.RandomString(10))
+
+	newRun := func(workflowName string, gitRepo, ref, author string, annotations map[string]string) sdk.V2WorkflowRun {
+		wr := sdk.V2WorkflowRun{
+			ProjectKey:   proj.Key,
+			VCSServerID:  vcsServer.ID,
+			VCSServer:    vcsServer.Name,
+			RepositoryID: repo.ID,
+			Repository:   repo.Name,
+			WorkflowName: workflowName,
+			WorkflowSha:  "123",
+			WorkflowRef:  "refs/heads/master",
+			RunAttempt:   0,
+			RunNumber:    1,
+			Started:      time.Now(),
+			LastModified: time.Now(),
+			Status:       sdk.V2WorkflowRunStatusSuccess,
+			Initiator: &sdk.V2Initiator{
+				UserID: admin.ID,
+				User:   admin.Initiator(),
+			},
+			RunEvent: sdk.V2WorkflowRunEvent{},
+			Contexts: sdk.WorkflowRunContext{
+				Git: sdk.GitContext{
+					Server:     "github",
+					Repository: gitRepo,
+					Ref:        ref,
+					Sha:        "abcdef123456",
+					Author:     author,
+				},
+			},
+			Annotations:  annotations,
+			WorkflowData: sdk.V2WorkflowRunData{Workflow: sdk.V2Workflow{}},
+		}
+		require.NoError(t, workflow_v2.InsertRun(context.Background(), db, &wr))
+		return wr
+	}
+
+	runAwesome := newRun("my-awesome-workflow", "ovh/cds", "refs/heads/main", "jdoe", map[string]string{"release": "1.2.3"})
+	runOther := newRun("other-workflow", "ovh/other-repo", "refs/heads/dev", "asmith", nil)
+
+	uri := api.Router.GetRouteV2("GET", api.getWorkflowRunsSearchV2Handler, map[string]string{"projectKey": proj.Key})
+	test.NotEmpty(t, uri)
+
+	search := func(t *testing.T, query string) []string {
+		req := assets.NewAuthentifiedRequest(t, admin, pwd, "GET", uri+"?"+query, nil)
+		w := httptest.NewRecorder()
+		api.Router.Mux.ServeHTTP(w, req)
+		require.Equal(t, 200, w.Code)
+
+		var runs []sdk.V2WorkflowRun
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &runs))
+		require.Equal(t, strconv.Itoa(len(runs)), w.Header().Get("X-Total-Count"))
+
+		ids := make([]string, 0, len(runs))
+		for i := range runs {
+			ids = append(ids, runs[i].ID)
+		}
+		return ids
+	}
+
+	for _, tc := range []struct {
+		name     string
+		query    string
+		expected []string
+	}{
+		{"no query returns everything", "", []string{runOther.ID, runAwesome.ID}},
+		{"workflow name", "query=awesome", []string{runAwesome.ID}},
+		{"workflow name is case insensitive", "query=AWESOME", []string{runAwesome.ID}},
+		{"workflow path", "query=" + url.QueryEscape(vcsServer.Name+"/"+repo.Name), []string{runOther.ID, runAwesome.ID}},
+		{"run number", "query=" + url.QueryEscape("other-workflow#1"), []string{runOther.ID}},
+		{"git ref", "query=" + url.QueryEscape("refs/heads/dev"), []string{runOther.ID}},
+		{"git repository", "query=" + url.QueryEscape("ovh/other-repo"), []string{runOther.ID}},
+		{"git author", "query=jdoe", []string{runAwesome.ID}},
+		{"initiator", "query=" + url.QueryEscape(admin.Username), []string{runOther.ID, runAwesome.ID}},
+		{"annotation value", "query=" + url.QueryEscape("1.2.3"), []string{runAwesome.ID}},
+		{"annotation filter", "release=" + url.QueryEscape("1.2.3"), []string{runAwesome.ID}},
+		{"annotation filter combined with query", "release=" + url.QueryEscape("1.2.3") + "&query=awesome", []string{runAwesome.ID}},
+		{"unmatched annotation filter", "release=" + url.QueryEscape("9.9.9"), []string{}},
+		{"all words must match", "query=" + url.QueryEscape("awesome main"), []string{runAwesome.ID}},
+		{"words can be given in any order", "query=" + url.QueryEscape("main awesome"), []string{runAwesome.ID}},
+		{"unmatched word excludes the run", "query=" + url.QueryEscape("awesome dev"), []string{}},
+		{"like wildcards are escaped", "query=" + url.QueryEscape("%"), []string{}},
+		{"query combines with filters", "query=workflow&status=Success&ref=" + url.QueryEscape("refs/heads/main"), []string{runAwesome.ID}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ElementsMatch(t, tc.expected, search(t, tc.query))
+		})
+	}
 }
 
 func TestRunManualJob_WrongGateReviewer(t *testing.T) {

--- a/engine/api/workflow_v2/dao_run.go
+++ b/engine/api/workflow_v2/dao_run.go
@@ -324,21 +324,58 @@ const runQueryFilters = `
 	AND (array_length(:commits::text[], 1) IS NULL OR contexts -> 'git' ->> 'sha' = ANY(:commits))
 	AND (array_length(:templates::text[], 1) IS NULL OR ((contexts -> 'cds' ->> 'workflow_template_vcs_server') || '/' || (contexts -> 'cds' ->> 'workflow_template_repository') || '/' || (contexts -> 'cds' ->> 'workflow_template')) = ANY(:templates))
 	AND (array_length(:annotations::text[], 1) IS NULL OR annotation_strings @> :annotations)
+	AND (array_length(:query::text[], 1) IS NULL OR LOWER(` + runQuerySearchableText + `) LIKE ALL(:query::text[]))
 `
+
+// runQuerySearchableText concatenates the run fields exposed to the free text search. NULL parts
+// are skipped by CONCAT_WS and treated as empty strings by CONCAT.
+const runQuerySearchableText = `CONCAT_WS(' ',
+		project_key,
+		CONCAT(vcs_server, '/', repository, '/', workflow_name),
+		CONCAT(workflow_name, '#', run_number),
+		workflow_ref,
+		status,
+		CONCAT(contexts -> 'git' ->> 'server', '/', contexts -> 'git' ->> 'repository'),
+		contexts -> 'git' ->> 'ref',
+		contexts -> 'git' ->> 'sha',
+		contexts -> 'git' ->> 'author',
+		contexts -> 'git' ->> 'commit_message',
+		contexts -> 'cds' ->> 'version',
+		initiator -> 'user' ->> 'username',
+		initiator ->> 'vcs_username',
+		array_to_string(annotation_strings, ' ')
+	)`
+
+// runAnnotationsJoin flattens the run annotations jsonb into a text[] of "key:value" values, so that
+// they can be filtered and searched.
+const runAnnotationsJoin = `
+	LEFT JOIN (
+		SELECT run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
+		FROM v2_workflow_run run, jsonb_each_text(COALESCE(run.annotations, '{}'::jsonb)) as annotation_object
+		GROUP BY run.id
+	) v2_workflow_run_annotations
+	ON
+		v2_workflow_run.id = v2_workflow_run_annotations.id`
+
+// runAnnotationsJoinByProject is runAnnotationsJoin bounded to a single project. The planner cannot
+// push the outer project filter into a grouped subquery, so without this the aggregate would be
+// computed over every run of every project on each search.
+const runAnnotationsJoinByProject = `
+	LEFT JOIN (
+		SELECT run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
+		FROM v2_workflow_run run, jsonb_each_text(COALESCE(run.annotations, '{}'::jsonb)) as annotation_object
+		WHERE run.project_key = :projKey
+		GROUP BY run.id
+	) v2_workflow_run_annotations
+	ON
+		v2_workflow_run.id = v2_workflow_run_annotations.id`
 
 func CountAllRuns(ctx context.Context, db gorp.SqlExecutor, filters SearchRunsFilters) (int64, error) {
 	_, next := telemetry.Span(ctx, "CountAllRuns")
 	defer next()
 
 	query := `SELECT COUNT(1)
-	FROM v2_workflow_run
-	LEFT JOIN (
-		SELECT v2_workflow_run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
-		FROM v2_workflow_run, jsonb_each_text(COALESCE(annotations, '{}'::jsonb)) as annotation_object
-		GROUP BY v2_workflow_run.id
-	) v2_workflow_run_annotations
-	ON
-		v2_workflow_run.id = v2_workflow_run_annotations.id
+	FROM v2_workflow_run` + runAnnotationsJoin + `
 	WHERE ` + runQueryFilters
 
 	params := map[string]interface{}{
@@ -353,6 +390,7 @@ func CountAllRuns(ctx context.Context, db gorp.SqlExecutor, filters SearchRunsFi
 		"commits":               pq.StringArray(filters.Commits),
 		"templates":             pq.StringArray(filters.Templates),
 		"annotations":           pq.StringArray(filters.Annotations),
+		"query":                 filters.queryPatterns(),
 	}
 
 	count, err := db.SelectInt(query, params)
@@ -364,14 +402,7 @@ func CountRuns(ctx context.Context, db gorp.SqlExecutor, projKey string, filters
 	defer next()
 
 	query := `SELECT COUNT(1)
-	FROM v2_workflow_run
-	LEFT JOIN (
-		SELECT v2_workflow_run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
-		FROM v2_workflow_run, jsonb_each_text(COALESCE(annotations, '{}'::jsonb)) as annotation_object
-		GROUP BY v2_workflow_run.id
-	) v2_workflow_run_annotations
-	ON
-		v2_workflow_run.id = v2_workflow_run_annotations.id
+	FROM v2_workflow_run` + runAnnotationsJoinByProject + `
 	WHERE
 		project_key = :projKey AND ` + runQueryFilters
 
@@ -388,6 +419,7 @@ func CountRuns(ctx context.Context, db gorp.SqlExecutor, projKey string, filters
 		"commits":               pq.StringArray(filters.Commits),
 		"templates":             pq.StringArray(filters.Templates),
 		"annotations":           pq.StringArray(filters.Annotations),
+		"query":                 filters.queryPatterns(),
 	}
 
 	count, err := db.SelectInt(query, params)
@@ -406,12 +438,17 @@ type SearchRunsFilters struct {
 	Commits              []string
 	Templates            []string
 	Annotations          []string
+	Query                string
 }
 
 func (s SearchRunsFilters) Lower() {
 	for i := range s.Repositories {
 		s.Repositories[i] = strings.ToLower(s.Repositories[i])
 	}
+}
+
+func (s SearchRunsFilters) queryPatterns() pq.StringArray {
+	return pq.StringArray(sdk.SearchQueryLikePatterns(s.Query))
 }
 
 func parseSortFilter(sort string) (string, error) {
@@ -443,14 +480,7 @@ func SearchAllRuns(ctx context.Context, db gorp.SqlExecutor, filters SearchRunsF
 
 	query := gorpmapping.NewQuery(`
     SELECT v2_workflow_run.*
-    FROM v2_workflow_run
-		LEFT JOIN (
-			SELECT v2_workflow_run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
-			FROM v2_workflow_run, jsonb_each_text(COALESCE(annotations, '{}'::jsonb)) as annotation_object
-			GROUP BY v2_workflow_run.id
-		) v2_workflow_run_annotations
-		ON
-			v2_workflow_run.id = v2_workflow_run_annotations.id
+    FROM v2_workflow_run` + runAnnotationsJoin + `
 		WHERE ` + runQueryFilters + `
 		ORDER BY
 			CASE WHEN :sort = 'last_modified:asc' THEN last_modified END asc,
@@ -471,6 +501,7 @@ func SearchAllRuns(ctx context.Context, db gorp.SqlExecutor, filters SearchRunsF
 			"commits":               pq.StringArray(filters.Commits),
 			"templates":             pq.StringArray(filters.Templates),
 			"annotations":           pq.StringArray(filters.Annotations),
+			"query":                 filters.queryPatterns(),
 			"sort":                  sort,
 			"limit":                 limit,
 			"offset":                offset,
@@ -497,14 +528,7 @@ func SearchRuns(ctx context.Context, db gorp.SqlExecutor, projKey string, filter
 
 	query := gorpmapping.NewQuery(`
     SELECT v2_workflow_run.*
-    FROM v2_workflow_run
-		LEFT JOIN (
-			SELECT v2_workflow_run.id, array_agg(concat(annotation_object.key, ':', annotation_object.value)) as "annotation_strings"
-			FROM v2_workflow_run, jsonb_each_text(COALESCE(annotations, '{}'::jsonb)) as annotation_object
-			GROUP BY v2_workflow_run.id
-		) v2_workflow_run_annotations
-		ON
-			v2_workflow_run.id = v2_workflow_run_annotations.id
+    FROM v2_workflow_run` + runAnnotationsJoinByProject + `
 		WHERE project_key = :projKey AND ` + runQueryFilters + `
 		ORDER BY
 			CASE WHEN :sort = 'last_modified:asc' THEN last_modified END asc,
@@ -525,6 +549,7 @@ func SearchRuns(ctx context.Context, db gorp.SqlExecutor, projKey string, filter
 		"commits":               pq.StringArray(filters.Commits),
 		"templates":             pq.StringArray(filters.Templates),
 		"annotations":           pq.StringArray(filters.Annotations),
+		"query":                 filters.queryPatterns(),
 		"sort":                  sort,
 		"limit":                 limit,
 		"offset":                offset,

--- a/sdk/search.go
+++ b/sdk/search.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type SearchResultType string
@@ -46,4 +47,30 @@ type SearchFilter struct {
 	Key     string   `json:"key"`
 	Options []string `json:"options"`
 	Example string   `json:"example"`
+}
+
+var searchQueryLikeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// SearchQueryMaxWords bounds the number of words kept from a free text search. Every word costs one
+// more LIKE comparison per scanned row, so an oversized query must not be able to multiply the cost
+// of a search. Extra words are dropped.
+const SearchQueryMaxWords = 20
+
+// SearchQueryLikePatterns turns a free text search into one lowered SQL LIKE pattern per word.
+// All the returned patterns have to match, so words can be given in any order, and the LIKE
+// wildcards are escaped to be matched literally. An empty query returns no pattern at all.
+func SearchQueryLikePatterns(query string) []string {
+	patterns := make([]string, 0, SearchQueryMaxWords)
+	seen := make(map[string]struct{})
+	for _, w := range strings.Fields(strings.ToLower(query)) {
+		if _, ok := seen[w]; ok {
+			continue
+		}
+		seen[w] = struct{}{}
+		patterns = append(patterns, "%"+searchQueryLikeEscaper.Replace(w)+"%")
+		if len(patterns) == SearchQueryMaxWords {
+			break
+		}
+	}
+	return patterns
 }

--- a/sdk/search_test.go
+++ b/sdk/search_test.go
@@ -1,0 +1,43 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchQueryLikePatterns(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		query    string
+		expected []string
+	}{
+		{"empty query gives no pattern", "", []string{}},
+		{"blank query gives no pattern", "   ", []string{}},
+		{"one word", "awesome", []string{"%awesome%"}},
+		{"one pattern per word", "awesome main", []string{"%awesome%", "%main%"}},
+		{"extra spaces are ignored", "  awesome   main  ", []string{"%awesome%", "%main%"}},
+		{"words are lowered", "AwEsOme MAIN", []string{"%awesome%", "%main%"}},
+		{"percent is escaped", "50%", []string{`%50\%%`}},
+		{"underscore is escaped", "my_run", []string{`%my\_run%`}},
+		{"backslash is escaped", `a\b`, []string{`%a\\b%`}},
+		{"repeated words are deduplicated", "main main MAIN", []string{"%main%"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, SearchQueryLikePatterns(tc.query))
+		})
+	}
+}
+
+func TestSearchQueryLikePatternsIsBounded(t *testing.T) {
+	var words []string
+	for i := 0; i < SearchQueryMaxWords*10; i++ {
+		words = append(words, fmt.Sprintf("word%d", i))
+	}
+	patterns := SearchQueryLikePatterns(strings.Join(words, " "))
+	require.Len(t, patterns, SearchQueryMaxWords)
+	require.Equal(t, "%word0%", patterns[0])
+	require.Equal(t, fmt.Sprintf("%%word%d%%", SearchQueryMaxWords-1), patterns[SearchQueryMaxWords-1])
+}

--- a/ui/specs/global-search.md
+++ b/ui/specs/global-search.md
@@ -1,0 +1,127 @@
+# Specification: Global Search
+
+## Overview
+
+The global search is the cross-project entry point of CDS. It answers "where is that thing?" by
+matching a free text query against the **names and paths** of the objects a user can read, and
+returns them ranked by how well they match. It is reachable from two places sharing the same
+behaviour:
+
+- the **navbar search bar**, present on every page, which shows live suggestions and can jump
+  straight to a result;
+- the **search page** (`/search`), which lists the full paginated results.
+
+It deliberately searches *definitions*, not runtime data. Looking for workflow runs is the job of
+the project run list, see [workflow-run-search.md](./workflow-run-search.md).
+
+---
+
+## 1 — Searched Objects
+
+Three kinds of results, each identified by a path-like id and displayed with a label:
+
+| Type | Id | Label |
+|---|---|---|
+| `project` | project key | project name |
+| `workflow` | `project/vcs/repository/name` | workflow name |
+| `workflow-legacy` | `project/name` | workflow name |
+
+Only the **head** version of an as-code workflow is searched, so a workflow is returned once even
+when it exists on many git refs. Its known refs are attached to the result as **variants**, which
+lets the UI offer a per-ref link.
+
+Projects also carry a description, shown alongside the result.
+
+---
+
+## 2 — Query Syntax
+
+The search box is the shared filter input, so the query is a space separated list of tokens where a
+token is either a `key:value` filter or a free text word.
+
+### 2.1 Filters
+
+| Key | Restricts to |
+|---|---|
+| `project` | one or more project keys |
+| `type` | one or more result types (`project`, `workflow`, `workflow-legacy`) |
+
+Several values for the same key are OR-ed. The available keys and their possible values are provided
+by the API, the project options being limited to the projects the user can read.
+
+### 2.2 Free Text
+
+- A word matches, case-insensitively and anywhere inside the value, the **label or the id** of a
+  result.
+- **All words must match**, so words can be given in any order and each one narrows the results
+  further. `ovh cds` finds the objects whose name or path contains both.
+- The `%`, `_` and `\` characters are matched literally, they are not wildcards.
+- An empty query returns everything the user can read, subject to the filters.
+- A bounded number of words is taken into account, so an oversized query cannot multiply the cost of
+  a search. Extra words are ignored.
+
+### 2.3 URL
+
+A search lives in the URL: filters under their own key, free text under `query`, and the page number
+under `page`. Searches are therefore shareable and survive a reload. When rebuilt from the URL, the
+search box is written in a canonical order — filters first, free text last.
+
+---
+
+## 3 — Result Prioritisation
+
+Results are ordered by three criteria, applied in turn:
+
+1. **Match quality** — a result whose **label** matches all the words comes first, then one whose
+   **id** matches all the words, then one that only matches when label and id are considered
+   together (for instance one word matching the project key and another the workflow name). The
+   intent is that typing a name surfaces the thing itself before the things whose *path* happens to
+   contain it.
+2. **Label length**, shortest first — with an exact-ish match, the shorter name is the more likely
+   target. Searching `cds` puts `cds` ahead of `cds-workers`.
+3. **Type**, projects first, then as-code workflows, then legacy workflows.
+
+Ordering is independent of the number of matched words: the words only decide *whether* a result
+matches, never how high it ranks.
+
+---
+
+## 4 — Authorization
+
+The search never widens what a user can see:
+
+- an **administrator or maintainer** searches every project;
+- any other user searches only the projects they have the read role on.
+
+A `project:` filter is intersected with that allowed set, so naming a project the user cannot read
+yields nothing rather than an error. Authorization is enforced when building the searched project
+list, not by filtering results afterwards.
+
+---
+
+## 5 — Navbar Search Bar
+
+- Suggestions are refreshed as the user types, debounced so that a burst of keystrokes triggers a
+  single request, and limited to a short list.
+- A suggestion is labelled `label - id` and navigates directly to the object's default destination:
+  the project page for a project, the run list filtered on that workflow for an as-code workflow,
+  and the workflow page for a legacy workflow.
+- Submitting instead of picking a suggestion opens the search page with the same query.
+
+---
+
+## 6 — Search Page
+
+- Each result shows its type, label, id and description, with links to the destinations that make
+  sense for it: explore the definition, or list the runs. As-code workflows can additionally be
+  opened per git ref through their variants. Legacy workflows only offer their own page.
+- Results are paginated, the total number of matches being returned next to the page so that the
+  count and the pager can be displayed.
+
+---
+
+## 7 — Bookmarks
+
+The home page pairs the search with the user's **bookmarks**, the objects they starred. Bookmarks
+cover the same three kinds of objects but are a separate, curated list — they are not search
+results and are not ranked.

--- a/ui/specs/workflow-run-search.md
+++ b/ui/specs/workflow-run-search.md
@@ -1,0 +1,176 @@
+# Specification: Workflow Run Search
+
+## Overview
+
+The project run list (`/project/:key/run`) lets users find workflow runs through a single search
+box. That box accepts two kinds of input, freely mixed:
+
+- **Filters** — `key:value` tokens that constrain a specific field to an exact value.
+- **Free text** — bare words that are matched as a case-insensitive substring against the most
+  useful run fields at once, in the spirit of the CDS global search available from the home page.
+
+The search box is also used by the global search; the shared behaviour lives in the
+`app-input-filter` component.
+
+---
+
+## 1 — Search Box
+
+### 1.1 Tokens
+
+The raw search text is a space separated list of tokens. A token containing exactly one `:` is a
+filter; any other token is a free text word. Spaces inside a filter key or value are encoded with a
+non-breaking space so that a filter stays a single token.
+
+### 1.2 Autocomplete
+
+While typing, the box suggests:
+
+- the current text as a "submit" entry,
+- the available filter keys with an example value, when the caret is not inside a filter value,
+- the known values of a filter, filtered by what has been typed, when the caret is inside a filter
+  value.
+
+Available filter keys and their known values are provided by the API, computed from the runs that
+already exist in the project. Annotation keys used by the project's runs are exposed as filter keys
+too.
+
+### 1.3 Submission
+
+The search never runs on keystroke. Submitting (Enter, or picking a suggestion) writes the search
+into the URL query params, and the URL is the single source of truth that triggers the request. A
+dedicated button re-runs the current search without touching the URL.
+
+---
+
+## 2 — Filters
+
+| Key | Matches |
+|---|---|
+| `workflow` | workflow path `vcs/repository/name` |
+| `workflow_repository` | repository holding the workflow, `vcs/repository` |
+| `workflow_ref` | git ref of the workflow definition |
+| `repository` | repository the run operates on, `vcs/repository` |
+| `ref` | git ref of the run |
+| `commit` | full commit sha |
+| `actor` | user or VCS user that triggered the run |
+| `author` | commit author |
+| `status` | run status |
+| `template` | workflow template path |
+| *anything else* | run annotation, by `key:value` |
+
+Semantics: several values for the same key are OR-ed, different keys are AND-ed, and annotations
+are all required.
+
+---
+
+## 3 — Free Text Search
+
+### 3.1 Fields
+
+A free text word matches, case-insensitively and anywhere inside the value, any of:
+
+- project key
+- workflow path (`vcs/repository/name`) and `name#run_number`
+- workflow ref
+- run status
+- run repository (`vcs/repository`), git ref, commit sha, commit author, commit message
+- run version
+- the user or VCS username that triggered the run
+- the run annotations (`key:value`)
+
+### 3.2 Semantics
+
+- **All words must match**, each one independently, so words can be given in any order and each
+  narrows the result set further. `awesome main` matches a run whose workflow name contains
+  "awesome" and whose ref contains "main".
+- Free text is AND-ed with the `key:value` filters.
+- The `%`, `_` and `\` characters are matched literally, they are not wildcards.
+- Free text is carried by the `query` URL param, so a search is shareable and can be saved like
+  any other search.
+- When a search is reloaded from the URL, the search box is rewritten in a canonical order: the
+  `key:value` filters first, the free text last, so the filters in effect stay easy to spot.
+
+These free text rules — all words required, order free, wildcards matched literally — are shared
+with the CDS global search, which applies them to the label and the id of its results.
+
+Consequence: an annotation whose key is literally `query` cannot be filtered with `query:value`,
+since that token is read as free text.
+
+### 3.3 Ordering
+
+Free text does not influence ordering; results keep the sort selected by the user (started or last
+modified, ascending or descending). This differs from the global search, which ranks results by
+match relevance.
+
+---
+
+## 4 — Saved Searches
+
+A search can be saved under a name, either privately (stored in user preferences) or shared at
+project level. A saved search stores the raw search text and the sort, so it keeps both its filters
+and its free text. Saved searches appear in the run list sidebar as links carrying the search as URL
+query params.
+
+---
+
+## 5 — Live Updates
+
+The run list subscribes to run events over the websocket. The current search — filters and free text
+alike — is sent along with the subscription, and the API re-evaluates it for every incoming event so
+that only runs matching the search are pushed into the list.
+
+---
+
+## 6 — Empty Results
+
+A search returning no run is often a dead end reached from the global search: the user picked a
+workflow that exists but has never run, and lands on an empty list.
+
+When there is no run to show, the run list looks for the workflows the search was aiming at — taken
+from the `workflow` filter when there is exactly one, otherwise from the free text — and searches the
+project's workflow definitions for them. If any match, they replace the empty state with a single
+centered block: a message stating that no run matches this search and that the workflows below do,
+then the workflows themselves. The message is not separated from the list, they announce one
+another; only the workflows are separated from each other by a line. Each one shows its name,
+linking to its definition, and two compact actions — **look at its definition** in the explore view,
+or **start a run** of it. Starting a run this way pre-selects that workflow only, without inheriting
+the filters that returned nothing. Only the first few matches are listed, and the message is worded
+for their number.
+
+A workflow is named the same way everywhere it appears — run rows, run view header, matching
+workflows — its name first, then its `vcs/repository` scope in a lighter style.
+
+The ref of the workflow definition is only shown when naming a workflow, not when naming a run: next
+to a run it would be read as the ref the run checked out, which it is not as soon as the workflow
+targets another repository. A workflow defined on several refs shows the first one with a counter for
+the others, the full list being in the tooltip.
+
+The wording stays factual: it states that no run matches the search and that these workflows match,
+never that the workflows have no run — the empty result may well come from another filter such as a
+status. When no workflow matches, or when the search carries nothing to identify one, the plain
+"no result" message is shown.
+
+This lookup only happens when the result list is empty, and a failure to retrieve the suggestions
+leaves the plain empty state untouched.
+
+Starting a run from there leaves the empty state as soon as that run reaches the list through the
+websocket: it counts as a result, so the message and the suggested workflows give way to the run,
+and the list controls appear with it.
+
+---
+
+## 7 — Opening a Run
+
+A run is opened by clicking anywhere on its line, not only on its name. This is a convenience for
+the mouse: the line is not a control of its own, the run name inside it stays the keyboard and
+screen reader entry point. Clicks aimed at another control of the line, modified clicks and clicks
+ending a text selection are left alone.
+
+---
+
+## 8 — Pagination
+
+Results are paginated, with the total number of matching runs returned next to the page so the
+footer can display the result count and the pager. Both the filters and the free text are applied
+before counting.

--- a/ui/src/app/shared/input/input-filter.component.spec.ts
+++ b/ui/src/app/shared/input/input-filter.component.spec.ts
@@ -1,0 +1,87 @@
+import { FilterText, InputFilterComponent } from './input-filter.component';
+
+const nbsp = InputFilterComponent.spaceAlternative;
+
+describe('FilterText', () => {
+	it('should parse key:value filters', () => {
+		const res = FilterText.parse('status:Success status:Fail ref:refs/heads/main');
+		expect(res.filters).toEqual({ status: ['Success', 'Fail'], ref: ['refs/heads/main'] });
+		expect(res.query).toEqual([]);
+	});
+
+	it('should parse bare tokens as free text', () => {
+		const res = FilterText.parse('awesome status:Success main');
+		expect(res.filters).toEqual({ status: ['Success'] });
+		expect(res.query).toEqual(['awesome', 'main']);
+	});
+
+	it('should decode the space alternative in keys and values', () => {
+		const res = FilterText.parse(`my${nbsp}key:my${nbsp}long${nbsp}value`);
+		expect(res.filters).toEqual({ 'my key': ['my long value'] });
+	});
+
+	it('should ignore empty tokens', () => {
+		expect(FilterText.parse('  awesome  ')).toEqual({ filters: {}, query: ['awesome'] });
+		expect(FilterText.parse(null)).toEqual({ filters: {}, query: [] });
+	});
+
+	it('should keep empty filter values unless asked to skip them', () => {
+		expect(FilterText.parse('status:').filters).toEqual({ status: [''] });
+		expect(FilterText.parse('status:', { skipEmptyValues: true }).filters).toEqual({});
+	});
+
+	it('should build search params keeping every free text word', () => {
+		expect(FilterText.toSearchParams('awesome main type:workflow project:KEY')).toEqual({
+			type: ['workflow'],
+			project: ['KEY'],
+			query: 'awesome main'
+		});
+	});
+
+	it('should not set a query search param without free text', () => {
+		expect(FilterText.toSearchParams('type:workflow')).toEqual({ type: ['workflow'] });
+	});
+
+	it('should build query params with the free text under the query key', () => {
+		expect(FilterText.toQueryParams('awesome main status:Success status:Fail ref:')).toEqual({
+			status: ['Success', 'Fail'],
+			query: 'awesome main'
+		});
+	});
+
+	it('should collapse single valued filters in query params', () => {
+		expect(FilterText.toQueryParams('status:Success')).toEqual({ status: 'Success' });
+	});
+
+	it('should rebuild the filter text from query params, free text last', () => {
+		expect(FilterText.fromQueryParams({ query: 'awesome main', status: 'Success' }))
+			.toEqual('status:Success awesome main');
+	});
+
+	it('should encode spaces when rebuilding the filter text', () => {
+		expect(FilterText.fromQueryParams({ 'my key': 'my long value' }))
+			.toEqual(`my${nbsp}key:my${nbsp}long${nbsp}value`);
+	});
+
+	it('should ignore the given query param keys', () => {
+		expect(FilterText.fromQueryParams({ page: 2, sort: 'started:asc', query: 'awesome' }, ['page', 'sort']))
+			.toEqual('awesome');
+	});
+
+	it('should round trip filter text in canonical order through query params', () => {
+		[
+			'awesome',
+			'awesome main',
+			'status:Success',
+			'status:Success status:Fail awesome',
+			`my${nbsp}key:my${nbsp}value awesome`
+		].forEach(text => {
+			expect(FilterText.fromQueryParams(FilterText.toQueryParams(text))).toEqual(text);
+		});
+	});
+
+	it('should move the free text last when rebuilding the filter text', () => {
+		expect(FilterText.fromQueryParams(FilterText.toQueryParams('awesome status:Success')))
+			.toEqual('status:Success awesome');
+	});
+});

--- a/ui/src/app/shared/input/input-filter.component.ts
+++ b/ui/src/app/shared/input/input-filter.component.ts
@@ -19,6 +19,76 @@ export class Suggestion<T> {
 	data: T;
 }
 
+/**
+ * Serialization helpers for the raw filter text of app-input-filter.
+ * A filter text is a space separated list of tokens, a token being either a `key:value` filter
+ * or a free text search word. Free text words are carried by the `query` query param.
+ */
+export class FilterText {
+	static readonly queryKey = 'query';
+
+	static parse(text: string, opts?: { skipEmptyValues?: boolean }): { filters: { [key: string]: Array<string> }, query: Array<string> } {
+		const filters: { [key: string]: Array<string> } = {};
+		const query: Array<string> = [];
+		(text ?? '').split(' ').forEach(token => {
+			if (token === '') { return; }
+			const splitted = token.split(':');
+			if (splitted.length === 2) {
+				if (opts?.skipEmptyValues && splitted[1] === '') { return; }
+				const key = FilterText.decodeSpaces(splitted[0]);
+				if (!filters[key]) { filters[key] = []; }
+				filters[key].push(FilterText.decodeSpaces(splitted[1]));
+			} else if (splitted.length === 1) {
+				query.push(FilterText.decodeSpaces(token));
+			}
+		});
+		return { filters, query };
+	}
+
+	/** Params sent to a search API: filters as arrays, free text words joined under the query key. */
+	static toSearchParams(text: string): { [key: string]: any } {
+		const { filters, query } = FilterText.parse(text);
+		let params: { [key: string]: any } = { ...filters };
+		if (query.length > 0) {
+			params[FilterText.queryKey] = query.join(' ');
+		}
+		return params;
+	}
+
+	/** Router query params, dropping the filters left without a value. */
+	static toQueryParams(text: string): { [key: string]: any } {
+		const { filters, query } = FilterText.parse(text, { skipEmptyValues: true });
+		let params: { [key: string]: any } = {};
+		Object.keys(filters).forEach(key => {
+			params[key] = filters[key].length === 1 ? filters[key][0] : filters[key];
+		});
+		if (query.length > 0) {
+			params[FilterText.queryKey] = query.join(' ');
+		}
+		return params;
+	}
+
+	static fromQueryParams(values: { [key: string]: any }, ignoredKeys: Array<string> = []): string {
+		const keys = Object.keys(values ?? {})
+			.filter(key => ignoredKeys.indexOf(key) === -1)
+			// Keep the free text search last, so that the key:value filters stay easy to spot.
+			.sort((a, b) => (a === FilterText.queryKey ? 1 : 0) - (b === FilterText.queryKey ? 1 : 0));
+		return keys.map(key => {
+			const values_ = !Array.isArray(values[key]) ? [values[key]] : values[key];
+			return values_.map(v => key === FilterText.queryKey ? `${v}` :
+				`${FilterText.encodeSpaces(key)}:${FilterText.encodeSpaces(`${v}`)}`).join(' ');
+		}).join(' ').trim();
+	}
+
+	private static encodeSpaces(v: string): string {
+		return v.split(' ').join(InputFilterComponent.spaceAlternative);
+	}
+
+	private static decodeSpaces(v: string): string {
+		return v.split(InputFilterComponent.spaceAlternative).join(' ');
+	}
+}
+
 @Component({
 	standalone: false,
 	selector: 'app-input-filter',

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -256,6 +256,7 @@ import { NzEmptyModule } from 'ng-zorro-antd/empty';
 import { NsAutoHeightTableDirective } from './directives/ns-auto-height-table.directive';
 import { NzTypographyModule } from 'ng-zorro-antd/typography';
 import { DateFromNowComponent } from './date-from-now/date-from-now';
+import { WorkflowNameComponent } from './workflow-name/workflow-name.component';
 import { NzTreeModule } from 'ng-zorro-antd/tree';
 import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
 import { NzResultModule } from 'ng-zorro-antd/result';
@@ -453,6 +454,7 @@ const icons: IconDefinition[] = [
         CutPipe,
         DataTableComponent,
         DateFromNowComponent,
+        WorkflowNameComponent,
         DiffItemComponent,
         DiffListComponent,
         DurationMsPipe,
@@ -569,6 +571,7 @@ const icons: IconDefinition[] = [
         CutPipe,
         DataTableComponent,
         DateFromNowComponent,
+        WorkflowNameComponent,
         DiffItemComponent,
         DiffListComponent,
         DragulaModule,

--- a/ui/src/app/shared/workflow-name/workflow-name.component.ts
+++ b/ui/src/app/shared/workflow-name/workflow-name.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, Input } from "@angular/core";
+
+/**
+ * Displays a CDS entity as its name first, its ref and its vcs/repository scope following it in a
+ * lighter style. Used wherever a workflow is named, so that they all read alike.
+ *
+ * The ref is only meaningful when naming a workflow definition. Next to a run it would be read as
+ * the ref the run checked out, which it is not, so runs are named without it.
+ *
+ * Give a link to make the name alone a link, or wrap the whole component in one to make everything
+ * clickable.
+ */
+@Component({
+	standalone: false,
+	selector: 'app-workflow-name',
+	templateUrl: './workflow-name.html',
+	styleUrls: ['./workflow-name.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WorkflowNameComponent {
+	@Input() name: string;
+	@Input() scope: string;
+	/** Rendered right after the name, for a run number for example. */
+	@Input() suffix: string;
+	@Input() link: Array<any>;
+	@Input() linkQueryParams: { [key: string]: any };
+	@Input() linkTitle: string;
+
+	@Input() set ref(value: string) {
+		this.displayRef = WorkflowNameComponent.shortRef(value);
+	}
+
+	displayRef: string;
+
+	/** Refs are displayed without their `refs/heads/` or `refs/tags/` prefix. */
+	static shortRef(ref: string): string {
+		return (ref ?? '').replace(/^refs\/(heads|tags)\//, '');
+	}
+}

--- a/ui/src/app/shared/workflow-name/workflow-name.html
+++ b/ui/src/app/shared/workflow-name/workflow-name.html
@@ -1,0 +1,7 @@
+<span class="name">
+  <a *ngIf="link" [routerLink]="link" [queryParams]="linkQueryParams" [title]="linkTitle">{{name}}</a>
+  <ng-container *ngIf="!link">{{name}}</ng-container>
+  <ng-container *ngIf="suffix">&nbsp;{{suffix}}</ng-container>
+</span>
+<span class="ref" *ngIf="displayRef">&#64;{{displayRef}}</span>
+<span class="scope" *ngIf="scope">{{scope}}</span>

--- a/ui/src/app/shared/workflow-name/workflow-name.scss
+++ b/ui/src/app/shared/workflow-name/workflow-name.scss
@@ -1,0 +1,34 @@
+:host {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+// The flex values are explicit because app-searchable force applies `flex: 1` to every projected
+// span, which would give each part an equal share of the width and truncate them all.
+.name {
+  flex: 0 1 auto;
+  min-width: 0;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  a {
+    color: inherit;
+
+    &:hover {
+      color: #177ddc;
+    }
+  }
+}
+
+.ref,
+.scope {
+  flex: 0 0 auto;
+  color: #979797;
+  font-size: 12px;
+  white-space: nowrap;
+}

--- a/ui/src/app/views/projectv2/run-list/run-list-sidebar.component.ts
+++ b/ui/src/app/views/projectv2/run-list/run-list-sidebar.component.ts
@@ -20,6 +20,7 @@ import { ProjectRunFilterService } from 'app/service/project/project-run-filter.
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { ErrorUtils } from 'app/shared/error.utils';
+import { FilterText } from 'app/shared/input/input-filter.component';
 
 @Component({
     standalone: false,
@@ -79,19 +80,7 @@ export class ProjectV2RunListSidebarComponent implements OnInit, OnDestroy {
 		// Load personal filters
 		this.searchesSubscription = this._store.select(PreferencesState.selectProjectRunFilters(this.project.key)).subscribe(searches => {
 			this.searches = (searches ?? []).map(s => {
-				let params = {};
-				s.value.split(' ').forEach(f => {
-					const parts = f.split(':');
-					if (parts.length === 2 && parts[1] !== '') {
-						if (Array.isArray(params[parts[0]])) {
-							params[parts[0]].push(parts[1]);
-						} else if (params[parts[0]]) {
-							params[parts[0]] = [params[parts[0]], parts[1]];
-						} else {
-							params[parts[0]] = parts[1];
-						}
-					}
-				});
+				let params = FilterText.toQueryParams(s.value);
 				if (s.sort) { params['sort'] = s.sort; }
 				return {
 					name: s.name,
@@ -110,19 +99,7 @@ export class ProjectV2RunListSidebarComponent implements OnInit, OnDestroy {
 	}
 
 	parseFilterToParams(filter: ProjectRunFilter): any {
-		let params = {};
-		filter.value.split(' ').forEach(f => {
-			const parts = f.split(':');
-			if (parts.length === 2 && parts[1] !== '') {
-				if (Array.isArray(params[parts[0]])) {
-					params[parts[0]].push(parts[1]);
-				} else if (params[parts[0]]) {
-					params[parts[0]] = [params[parts[0]], parts[1]];
-				} else {
-					params[parts[0]] = parts[1];
-				}
-			}
-		});
+		let params = FilterText.toQueryParams(filter.value);
 		if (filter.sort) {
 			params['sort'] = filter.sort;
 		}

--- a/ui/src/app/views/projectv2/run-list/run-list.component.ts
+++ b/ui/src/app/views/projectv2/run-list/run-list.component.ts
@@ -19,8 +19,12 @@ import { EventV2Type } from "app/model/event-v2.model";
 import { animate, keyframes, state, style, transition, trigger } from "@angular/animations";
 import { ErrorUtils } from "app/shared/error.utils";
 import { ProjectV2State } from "app/store/project-v2.state";
-import { Filter, InputFilterComponent } from "../../../shared/input/input-filter.component";
+import { Filter, FilterText } from "../../../shared/input/input-filter.component";
 import { Clipboard } from '@angular/cdk/clipboard';
+import { SearchService } from "app/service/search.service";
+import { SearchResultType } from "app/model/search.model";
+import { DisplaySearchResult } from "app/views/search/search.component";
+import { WorkflowNameComponent } from "app/shared/workflow-name/workflow-name.component";
 
 @Component({
 	standalone: false,
@@ -50,6 +54,7 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 	static PANEL_KEY = 'project-v2-run-list-sidebar';
 	static DEFAULT_SORT = 'started:desc';
 	static DEFAULT_PAGESIZE = 20;
+	static MAX_MATCHING_WORKFLOWS = 5;
 
 	@ViewChild('saveSearchButton') saveSearchButton: NzPopconfirmDirective;
 
@@ -66,8 +71,10 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 	sort: string = ProjectV2RunListComponent.DEFAULT_SORT;
 	eventV2Subscription: Subscription;
 	animatedRuns: { [key: string]: boolean } = {};
+	matchingWorkflows: Array<DisplaySearchResult> = [];
 
 	private _http = inject(HttpClient);
+	private _searchService = inject(SearchService);
 	private _messageService = inject(NzMessageService);
 	private _cd = inject(ChangeDetectorRef);
 	private _store = inject(Store);
@@ -87,11 +94,7 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 		this.panelSize = this._store.selectSnapshot(PreferencesState.panelSize(ProjectV2RunListComponent.PANEL_KEY));
 		this.loadFilters();
 		this._activatedRoute.queryParams.subscribe(values => {
-			this.filterText = Object.keys(values).filter(key => key !== 'page' && key !== 'sort').map(key => {
-				return (!Array.isArray(values[key]) ? [values[key]] : values[key]).map(f => {
-					return `${key.replace(' ', InputFilterComponent.spaceAlternative)}:${f.replace(' ', InputFilterComponent.spaceAlternative)}`;
-				}).join(' ');
-			}).join(' ');
+			this.filterText = FilterText.fromQueryParams(values, ['page', 'sort']);
 			this.pageIndex = values['page'] ?? 1;
 			this.sort = values['sort'] ?? ProjectV2RunListComponent.DEFAULT_SORT;
 			this.search();
@@ -108,6 +111,10 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 				if (this.runs.length > ProjectV2RunListComponent.DEFAULT_PAGESIZE) {
 					this.runs.pop();
 				}
+				// The run pushed by the websocket matches the current search, so the empty result
+				// state and the workflows it was suggesting do not stand anymore.
+				this.totalCount++;
+				this.matchingWorkflows = [];
 			}
 			this.animatedRuns[event.payload.id] = true;
 			this._cd.markForCheck();
@@ -142,21 +149,9 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 
 		this.previousFilterText = this.filterText;
 
-		let mFilters = {};
-		this.filterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			const key = s[0].replace(InputFilterComponent.spaceAlternative, ' ');
-			if (s.length === 2) {
-				if (!mFilters[key]) {
-					mFilters[key] = [];
-				}
-				mFilters[key].push(s[1].replace(InputFilterComponent.spaceAlternative, ' '));
-			}
-		});
-
 		let params = new HttpParams();
 		params = params.appendAll({
-			...mFilters,
+			...FilterText.toSearchParams(this.filterText),
 			offset: this.pageIndex ? (this.pageIndex - 1) * ProjectV2RunListComponent.DEFAULT_PAGESIZE : 0,
 			limit: ProjectV2RunListComponent.DEFAULT_PAGESIZE
 		});
@@ -181,6 +176,7 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 				})));
 			this.totalCount = res.totalCount;
 			this.runs = res.runs;
+			await this.loadMatchingWorkflows();
 		} catch (e) {
 			this._messageService.error(`Unable to list workflow runs: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
 		}
@@ -189,20 +185,68 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 		this._cd.markForCheck();
 	}
 
-	saveSearchInQueryParams() {
-		let mFilters = {};
-		this.filterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			const key = s[0].replace(InputFilterComponent.spaceAlternative, ' ');
-			if (s.length === 2 && s[1] !== '') {
-				if (!mFilters[key]) {
-					mFilters[key] = [];
-				}
-				mFilters[key].push(s[1].replace(InputFilterComponent.spaceAlternative, ' '));
-			}
-		});
+	// Without any run to show, look for the workflows the search was aiming at, so that a workflow
+	// that exists but never ran can still be reached instead of ending on an empty list.
+	async loadMatchingWorkflows(): Promise<void> {
+		this.matchingWorkflows = [];
+		if (this.totalCount > 0) {
+			return;
+		}
 
-		let queryParams = { ...mFilters };
+		const { filters, query } = FilterText.parse(this.filterText);
+		const workflows = filters['workflow'] ?? [];
+		const terms = workflows.length === 1 ? workflows : (workflows.length === 0 ? query : []);
+		if (terms.length === 0) {
+			return;
+		}
+
+		try {
+			const res = await lastValueFrom(this._searchService.search({
+				project: this.project.key,
+				type: SearchResultType.Workflow,
+				query: terms.join(' ')
+			}, 0, ProjectV2RunListComponent.MAX_MATCHING_WORKFLOWS));
+			this.matchingWorkflows = res.results
+				.filter(r => r.type === SearchResultType.Workflow)
+				.map(r => new DisplaySearchResult(r));
+		} catch (e) {
+			// Only a hint, a failure here must not hide the empty result state.
+		}
+	}
+
+	workflowPath(result: DisplaySearchResult): string {
+		return result.runLink.params['workflow'];
+	}
+
+	// The workflow name is the last segment, what precedes it is its vcs/repository scope. Same
+	// split and same ref shortening as the source panel of a run, to read them alike.
+	workflowScope(result: DisplaySearchResult): string {
+		const path = this.workflowPath(result);
+		const separator = path.lastIndexOf('/');
+		return separator === -1 ? '' : path.substring(0, separator);
+	}
+
+	// A workflow can be defined on several refs, only the first one is shown inline with a counter
+	// for the others, the tooltip carrying the full list.
+	workflowRef(result: DisplaySearchResult): string {
+		const refs = ProjectV2RunListComponent.shortRefs(result);
+		if (refs.length === 0) {
+			return null;
+		}
+		return refs.length === 1 ? refs[0] : `${refs[0]} +${refs.length - 1}`;
+	}
+
+	workflowTitleTooltip(result: DisplaySearchResult): string {
+		const refs = ProjectV2RunListComponent.shortRefs(result);
+		return this.workflowPath(result) + (refs.length > 0 ? ` @${refs.join(', ')}` : '');
+	}
+
+	private static shortRefs(result: DisplaySearchResult): Array<string> {
+		return (result.result.variants ?? []).map(r => WorkflowNameComponent.shortRef(r));
+	}
+
+	saveSearchInQueryParams() {
+		let queryParams = FilterText.toQueryParams(this.filterText);
 		if (this.pageIndex > 1) {
 			queryParams['page'] = this.pageIndex;
 		}
@@ -271,18 +315,9 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 		this.saveSearchInQueryParams();
 	}
 
-	openRunStartDrawer(): void {
-		let mFilters = {};
-		this.filterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			const key = s[0].replace(InputFilterComponent.spaceAlternative, ' ');
-			if (s.length === 2) {
-				if (!mFilters[key]) {
-					mFilters[key] = [];
-				}
-				mFilters[key].push(s[1].replace(InputFilterComponent.spaceAlternative, ' '));
-			}
-		});
+	openRunStartDrawer(workflow: string = null): void {
+		// A workflow picked from an empty result set must not inherit the filters that found nothing.
+		const mFilters = workflow ? { workflow: [workflow] } : FilterText.parse(this.filterText).filters;
 		const drawerRef = this._drawerService.create<ProjectV2RunStartComponent, { value: string }, string>({
 			nzTitle: 'Start new Workflow Run',
 			nzContent: ProjectV2RunStartComponent,
@@ -318,6 +353,22 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 
 	trackRunElement(index: number, run: V2WorkflowRun): any {
 		return run.id;
+	}
+
+	// Opening a run by clicking anywhere on its line is a convenience for the mouse, the keyboard
+	// reaches it through the run link of the line. Clicks meant for another control of the line, a
+	// modified click or the end of a text selection are left alone.
+	clickRunLine(event: MouseEvent, run: V2WorkflowRun): void {
+		if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+			return;
+		}
+		if ((event.target as HTMLElement).closest('a, button, nz-tag, [role="button"]')) {
+			return;
+		}
+		if (window.getSelection()?.toString()) {
+			return;
+		}
+		this._router.navigate(['/project', run.project_key, 'run', run.id]);
 	}
 
 	onMouseEnterRun(id: string): void {

--- a/ui/src/app/views/projectv2/run-list/run-list.html
+++ b/ui/src/app/views/projectv2/run-list/run-list.html
@@ -22,7 +22,7 @@
 		<form nz-form (ngSubmit)="submitForm()">
 			<nz-form-item>
 				<nz-form-control>
-					<app-input-filter placeholder="Filter workflow runs" [filterText]="filterText" [filters]="filters"
+					<app-input-filter placeholder="Search workflow runs, or narrow with key:value filters" [filterText]="filterText" [filters]="filters"
 						(changeFilter)="changeFilter($event)" (submit)="submitForm()"></app-input-filter>
 				</nz-form-control>
 			</nz-form-item>
@@ -48,9 +48,13 @@
 	</div>
 
 	<nz-list class="run-list" [nzLoading]="loading" nzSize="small" nzNoResult="test">
+		<!-- The line click only duplicates the run link it contains, which stays the keyboard and
+		     screen reader entry point, so no extra focus stop nor key handler is wanted here. -->
+		<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
 		<nz-list-item *ngFor="let run of runs; let i = index; trackBy: trackRunElement"
-			[class.append]="!!animatedRuns[run.id]" [@appendToList]="animatedRuns[run.id] ? 'append' : 'active'"
-			(mouseenter)="onMouseEnterRun(run.id)">
+			class="run-line" [class.append]="!!animatedRuns[run.id]"
+			[@appendToList]="animatedRuns[run.id] ? 'append' : 'active'"
+			(mouseenter)="onMouseEnterRun(run.id)" (click)="clickRunLine($event, run)">
 			<ng-container>
 				<nz-list-item-meta [nzTitle]="runTitle" [nzAvatar]="runAvatar" [nzDescription]="runDescription">
 				</nz-list-item-meta>
@@ -74,10 +78,13 @@
 					</div>
 				</ng-template>
 				<ng-template #runTitle>
-					<app-searchable [link]="['/project', project.key, 'run']" [fixed]="true"
+					<app-searchable [style]="{display:'unset'}" [link]="['/project', project.key, 'run']" [fixed]="true"
 						[params]="{workflow: run.vcs_server+'/'+run.repository+'/'+run.workflow_name}" paramsHandling="merge">
-						<a [routerLink]="['/project', run.project_key, 'run', run.id]">{{run.vcs_server}}/{{run.repository}}/{{run.workflow_name}}
-							#{{run.run_number}}</a>
+						<a [routerLink]="['/project', run.project_key, 'run', run.id]"
+							[title]="run.vcs_server+'/'+run.repository+'/'+run.workflow_name+' #'+run.run_number">
+							<app-workflow-name [name]="run.workflow_name" [suffix]="'#'+run.run_number"
+								[scope]="run.vcs_server+'/'+run.repository"></app-workflow-name>
+						</a>
 					</app-searchable>
 				</ng-template>
 				<ng-template #runDescription>
@@ -153,11 +160,37 @@
 		</nz-list-item>
 		<nz-list-empty *ngIf="!loading && totalCount === 0" [nzNoResult]="emptyList"></nz-list-empty>
 		<ng-template #emptyList>
-			<nz-empty nzNotFoundContent="No result found"></nz-empty>
+			<nz-empty *ngIf="matchingWorkflows.length === 0" nzNotFoundContent="No result found"></nz-empty>
+			<div class="no-run" *ngIf="matchingWorkflows.length > 0">
+				<div class="message">
+					<h3>No run matches this search</h3>
+					<p>The following workflow{{matchingWorkflows.length > 1 ? 's' : ''}}
+						match{{matchingWorkflows.length > 1 ? '' : 'es'}} it. You can open
+						{{matchingWorkflows.length > 1 ? 'their definitions' : 'its definition'}} in the explore view,
+						or start a run of {{matchingWorkflows.length > 1 ? 'one of them' : 'it'}}.</p>
+				</div>
+				<ul>
+					<li *ngFor="let w of matchingWorkflows">
+						<a class="workflow" [routerLink]="w.exploreLink.path" [title]="workflowTitleTooltip(w)">
+							<app-workflow-name [name]="w.result.label" [scope]="workflowScope(w)"
+								[ref]="workflowRef(w)"></app-workflow-name>
+						</a>
+						<span class="actions">
+							<a nz-button [routerLink]="w.exploreLink.path"
+								[attr.aria-label]="'Explore workflow ' + workflowPath(w)"><span nz-icon nzType="folder"
+									nzTheme="outline" aria-hidden="true"></span> Explore</a>
+							<button nz-button nzType="primary"
+								(click)="openRunStartDrawer(workflowPath(w))"
+								[attr.aria-label]="'Start a run of workflow ' + workflowPath(w)"><span nz-icon
+									nzType="caret-right" nzTheme="fill" aria-hidden="true"></span> Start a run</button>
+						</span>
+					</li>
+				</ul>
+			</div>
 		</ng-template>
 	</nz-list>
 	<div *ngIf="totalCount > 0" class="footer">
-		{{totalCount}} results - sorted by
+		{{totalCount}} result{{totalCount > 1 ? 's' : ''}} - sorted by
 		<nz-select [ngModel]="sort" (ngModelChange)="onSortChange($event)" nzBorderless aria-label="Sort runs">
 			<nz-option nzValue="last_modified:desc" nzLabel="last modification desc"></nz-option>
 			<nz-option nzValue="last_modified:asc" nzLabel="last modification asc"></nz-option>

--- a/ui/src/app/views/projectv2/run-list/run-list.scss
+++ b/ui/src/app/views/projectv2/run-list/run-list.scss
@@ -71,6 +71,26 @@
       }
     }
 
+    .run-line {
+      cursor: pointer;
+
+      &:hover {
+        background-color: rgba(79, 163, 227, 0.06);
+      }
+    }
+
+    // The magnifier closes the title, right after the ref and the scope, so it takes their style
+    // rather than the one of the name. The hover has to be restated, this wins over app-searchable.
+    nz-list-item-meta ::ng-deep .ant-list-item-meta-title .search {
+      font-weight: normal;
+      font-size: 12px;
+      color: #979797;
+
+      &:hover {
+        color: #177ddc;
+      }
+    }
+
     nz-list-item-meta {
       ::ng-deep {
         .ant-list-item-meta-content {
@@ -165,6 +185,71 @@
       text-align: right;
       margin: 0 0 0 10px;
       min-width: 120px;
+    }
+
+    // Way out of an empty result set: the message and the workflows it announces, as one block.
+    ::ng-deep .ant-list-empty-text {
+      color: inherit;
+    }
+
+    .no-run {
+      max-width: 780px;
+      margin: 40px auto;
+      text-align: left;
+
+      .message {
+        text-align: center;
+        margin-bottom: 8px;
+
+        h3 {
+          font-size: 18px;
+          font-weight: 500;
+          color: inherit;
+          margin-bottom: 8px;
+        }
+
+        // Spread the sentence evenly over its lines rather than leaving a word alone on the last.
+        p {
+          margin-bottom: 20px;
+          text-wrap: balance;
+        }
+      }
+
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      li {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 0;
+
+        // No line between the message and the first workflow, they belong together.
+        +li {
+          border-top: 1px solid #f0f0f0;
+
+          :host-context(.night) & {
+            border-color: common.$darkTheme_grey_3;
+          }
+        }
+
+        .workflow {
+          flex: 1;
+          min-width: 0;
+          color: inherit;
+        }
+
+        .actions {
+          flex: 0 0 auto;
+          display: flex;
+          flex-direction: row;
+          gap: 8px;
+        }
+      }
     }
   }
 

--- a/ui/src/app/views/projectv2/run/run.html
+++ b/ui/src/app/views/projectv2/run/run.html
@@ -92,12 +92,12 @@
       <div class="graph">
         <nz-page-header class="title" nzBackIcon (nzBack)="onBack()">
           <nz-page-header-title>
-            <span style="margin-right: 10px;" title="Show workflow's runs">
-              <a [routerLink]="['/project', projectKey, 'run']"
-                [queryParams]="{workflow: workflowRun.vcs_server+'/'+workflowRun.repository+'/'+workflowRun.workflow_name}">
-              {{workflowRun.vcs_server}}/{{workflowRun.repository}}/{{workflowRun.workflow_name}}</a>
-              <span class="number">#{{workflowRun.run_number}}</span>
-            </span>
+            <app-workflow-name style="margin-right: 10px;" [name]="workflowRun.workflow_name"
+              [suffix]="'#'+workflowRun.run_number"
+              [scope]="workflowRun.vcs_server+'/'+workflowRun.repository"
+              [link]="['/project', projectKey, 'run']"
+              [linkQueryParams]="{workflow: workflowRun.vcs_server+'/'+workflowRun.repository+'/'+workflowRun.workflow_name}"
+              linkTitle="Show workflow's runs"></app-workflow-name>
             @if (workflowRun.run_attempt > 1 && selectedRunAttempt) {
               <nz-select
                 [ngModel]="selectedRunAttempt" (ngModelChange)="changeRunAttempt($event)" nzSize="small"

--- a/ui/src/app/views/projectv2/run/run.scss
+++ b/ui/src/app/views/projectv2/run/run.scss
@@ -282,13 +282,8 @@
                 align-items: center;
 
                 button,
-                nz-select,
-                .number {
+                nz-select {
                     margin-left: 5px;
-                }
-
-                .number {
-                    margin-right: 5px;
                 }
 
                 a {

--- a/ui/src/app/views/search/search-bar.component.ts
+++ b/ui/src/app/views/search/search-bar.component.ts
@@ -5,7 +5,7 @@ import { SearchService } from "app/service/search.service";
 import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import Debounce from "app/shared/decorator/debounce";
 import { ErrorUtils } from "app/shared/error.utils";
-import { Filter, InputFilterComponent, Suggestion } from "app/shared/input/input-filter.component";
+import { Filter, FilterText, InputFilterComponent, Suggestion } from "app/shared/input/input-filter.component";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { lastValueFrom } from "rxjs";
 import { DisplaySearchResult } from "./search.component";
@@ -46,21 +46,8 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 	}
 
 	submitSearch(): void {
-		let mFilters = {};
-		this.searchFilterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			if (s.length === 2 && s[1] !== '') {
-				if (!mFilters[s[0]]) {
-					mFilters[s[0]] = [];
-				}
-				mFilters[s[0]].push(s[1]);
-			} else if (s.length === 1) {
-				mFilters['query'] = f;
-			}
-		});
-
 		this._router.navigate(['/search'], {
-			queryParams: { ...mFilters }
+			queryParams: FilterText.toQueryParams(this.searchFilterText)
 		});
 	}
 
@@ -74,18 +61,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 		this.loading = true;
 		this._cd.markForCheck();
 
-		let mFilters = {};
-		this.searchFilterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			if (s.length === 2) {
-				if (!mFilters[s[0]]) {
-					mFilters[s[0]] = [];
-				}
-				mFilters[s[0]].push(decodeURI(s[1]));
-			} else if (s.length === 1) {
-				mFilters['query'] = f;
-			}
-		});
+		const mFilters = FilterText.toSearchParams(this.searchFilterText);
 
 		try {
 			const res = await lastValueFrom(this._searchService.search(mFilters, 0, 10));

--- a/ui/src/app/views/search/search.component.ts
+++ b/ui/src/app/views/search/search.component.ts
@@ -4,7 +4,7 @@ import { SearchResult, SearchResultType } from "app/model/search.model";
 import { SearchService } from "app/service/search.service";
 import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { ErrorUtils } from "app/shared/error.utils";
-import { Filter } from "app/shared/input/input-filter.component";
+import { Filter, FilterText } from "app/shared/input/input-filter.component";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { lastValueFrom, Subscription } from "rxjs";
 
@@ -112,11 +112,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 	ngOnInit(): void {
 		this.loadFilters();
 		this.queryParamsSub = this._activatedRoute.queryParams.subscribe(values => {
-			this.filterText = Object.keys(values).filter(key => key !== 'page').map(key => {
-				return (!Array.isArray(values[key]) ? [values[key]] : values[key]).map(f => {
-					return key === 'query' ? f : `${key}:${f}`;
-				}).join(' ');
-			}).join(' ');
+			this.filterText = FilterText.fromQueryParams(values, ['page']);
 			this.pageIndex = values['page'] ?? 1;
 			this.search();
 		});
@@ -148,18 +144,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 		this.loading = true;
 		this._cd.markForCheck();
 
-		let mFilters = {};
-		this.filterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			if (s.length === 2) {
-				if (!mFilters[s[0]]) {
-					mFilters[s[0]] = [];
-				}
-				mFilters[s[0]].push(decodeURI(s[1]));
-			} else if (s.length === 1) {
-				mFilters['query'] = f;
-			}
-		});
+		const mFilters = FilterText.toSearchParams(this.filterText);
 
 		try {
 			const res = await lastValueFrom(this._searchService.search(mFilters,
@@ -175,20 +160,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 	}
 
 	saveSearchInQueryParams() {
-		let mFilters = {};
-		this.filterText.split(' ').forEach(f => {
-			const s = f.split(':');
-			if (s.length === 2 && s[1] !== '') {
-				if (!mFilters[s[0]]) {
-					mFilters[s[0]] = [];
-				}
-				mFilters[s[0]].push(s[1]);
-			} else if (s.length === 1) {
-				mFilters['query'] = f;
-			}
-		});
-
-		let queryParams = { ...mFilters };
+		let queryParams = FilterText.toQueryParams(this.filterText);
 		if (this.pageIndex > 1) {
 			queryParams['page'] = this.pageIndex;
 		}


### PR DESCRIPTION
The run list of a project could only be narrowed with key:value filters, so finding a run meant knowing beforehand which field to filter on. It now also accepts free text, matched against the fields one is likely to remember: the workflow path and run number, the git repository, ref, commit, author and message, the version, the initiator and the annotations.

Every word has to match, independently, so words can be given in any order and each one narrows the results further. The LIKE wildcards are escaped to be matched literally, and the number of words is bounded so that an oversized query cannot multiply the cost of the comparisons. The clause is guarded by the emptiness of the word list, which leaves the searches made of filters only, saved ones included, untouched.

The global search already offered free text but only ever used the last word of a query: each bare word overwrote the previous one in the UI, and the handler read the first value of the parameter. It now shares the pattern building with the run search and requires every word, while keeping its ranking of a name match over a path match.

A search returning no run is often a dead end reached from the global search, on a workflow that exists but never ran. The empty result set now looks for the workflows the search was aiming at and offers to open their definition or to start a run of one of them.

Naming a workflow is factored into a component so that the run rows, the run view header and those suggestions read alike: the name first, its vcs/repository scope following in a lighter style. The ref is only shown when naming a workflow definition, since next to a run it would be read as the ref the run checked out, which it is not as soon as the workflow targets another repository.

Finally the runs of a project are now counted and searched with their annotations aggregated for that project only. The planner cannot push the project filter into a grouped subquery, so the aggregate was computed over every run of the table, whatever the project, on each search.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
