### PR TITLE
fix(api): refuse to book a disabled worker model for registration

### DIFF
--- a/engine/api/worker_model_hatchery.go
+++ b/engine/api/worker_model_hatchery.go
@@ -34,6 +34,11 @@ func (api *API) putBookWorkerModelHandler() service.Handler {
 			return err
 		}
 
+		// a hatchery may hold a stale model list: never let it book a disabled model for registration
+		if m.Disabled {
+			return sdk.NewErrorFrom(sdk.ErrWrongRequest, "worker model %s/%s is disabled", groupName, modelName)
+		}
+
 		s, err := services.LoadByID(ctx, api.mustDB(), getUserConsumer(ctx).AuthConsumerUser.Service.ID)
 		if err != nil {
 			return err

--- a/engine/api/worker_model_hatchery_test.go
+++ b/engine/api/worker_model_hatchery_test.go
@@ -72,3 +72,37 @@ func Test_getWorkerModelSecretHandler(t *testing.T) {
 	router.Mux.ServeHTTP(w, req)
 	assert.Equal(t, 403, w.Code)
 }
+
+// Test_putBookWorkerModelHandler_DisabledModel: a hatchery can hold a stale model list, so the API is
+// the last barrier against spawning a registration worker for a disabled model. Such a worker is
+// useless (the model cannot run jobs anymore) and its row references the model for several minutes,
+// which blocks the model deletion.
+func Test_putBookWorkerModelHandler_DisabledModel(t *testing.T) {
+	api, db, router := newTestAPI(t)
+
+	g := assets.InsertTestGroup(t, db, sdk.RandomString(10))
+	_, _, _, jwtHatchery := assets.InsertHatchery(t, db, *g)
+
+	disabledModel := insertLifecycleModel(t, db, sdk.RandomString(10), g.ID, false, true, nil)
+	enabledModel := insertLifecycleModel(t, db, sdk.RandomString(10), g.ID, false, false, nil)
+
+	uri := router.GetRoute(http.MethodPut, api.putBookWorkerModelHandler, map[string]string{
+		"permGroupName": g.Name,
+		"permModelName": disabledModel.Name,
+	})
+	test.NotEmpty(t, uri)
+	req := assets.NewJWTAuthentifiedRequest(t, jwtHatchery, http.MethodPut, uri, nil)
+	w := httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 400, w.Code, "booking a disabled worker model must be refused")
+
+	uri = router.GetRoute(http.MethodPut, api.putBookWorkerModelHandler, map[string]string{
+		"permGroupName": g.Name,
+		"permModelName": enabledModel.Name,
+	})
+	test.NotEmpty(t, uri)
+	req = assets.NewJWTAuthentifiedRequest(t, jwtHatchery, http.MethodPut, uri, nil)
+	w = httptest.NewRecorder()
+	router.Mux.ServeHTTP(w, req)
+	assert.Equal(t, 204, w.Code, "booking an enabled worker model must still work")
+}

--- a/tests/04_sc_workflow_run_model_eol.yml
+++ b/tests/04_sc_workflow_run_model_eol.yml
@@ -127,13 +127,12 @@ testcases:
       - result.code ShouldEqual 0
       - result.systemoutjson.status ShouldEqual Success
 
+# The model deletes are best effort: a hatchery may have spawned a registration worker while the
+# model was still enabled, and its worker row keeps a foreign key on the model for up to 300s after
+# its last heartbeat, making the delete fail. The prepare testcase removes any leftover next run.
 - name: cleanup
   steps:
   - script: {{.cdsctl}} -f {{.cdsctl.config}} project remove --force 04SCWORKFLOWRUNMODELEOL
   - script: {{.cdsctl}} -f {{.cdsctl.config}} group remove --force 04scworkflowrunmodeleol
-  - script: {{.cdsctl}} -f {{.cdsctl.config}} worker model delete 04SCWorkflowRunModelEOL-MODEL --force
-    assertions:
-      - result.code ShouldEqual 0
-  - script: {{.cdsctl}} -f {{.cdsctl.config}} worker model delete 04SCWorkflowRunModelEOL-MODEL-DISABLED --force
-    assertions:
-      - result.code ShouldEqual 0
+  - script: {{.cdsctl}} -f {{.cdsctl.config}} worker model delete 04SCWorkflowRunModelEOL-MODEL --force || true
+  - script: {{.cdsctl}} -f {{.cdsctl.config}} worker model delete 04SCWorkflowRunModelEOL-MODEL-DISABLED --force || true


### PR DESCRIPTION
Also make the 04SCWorkflowRunModelEOL cleanup best effort: a registration worker row can reference the model for up to 300s and block its deletion.

