### PR TITLE
Fix/cdn log dequeue backpressure

### DIFF
--- a/engine/cdn/cdn.go
+++ b/engine/cdn/cdn.go
@@ -26,16 +26,19 @@ import (
 )
 
 const (
-	defaultLruSize            = 128 * 1024 * 1024 // 128Mb
-	defaultStepMaxSize        = 15 * 1024 * 1024  // 15Mb
-	defaultStepLinesRateLimit = 1800
-	defaultGlobalTCPRateLimit = 2 * 1024 * 1024 // 2Mb
+	defaultLruSize             = 128 * 1024 * 1024 // 128Mb
+	defaultStepMaxSize         = 15 * 1024 * 1024  // 15Mb
+	defaultStepLinesRateLimit  = 1800
+	defaultGlobalTCPRateLimit  = 2 * 1024 * 1024 // 2Mb
+	defaultNbJobLogsGoroutines = 10
+	defaultDequeueBatchSize    = 100
 )
 
 // New returns a new service
 func New() *Service {
 	s := new(Service)
 	s.GoRoutines = sdk.NewGoRoutines(context.Background())
+	s.dequeueOwnerID = sdk.UUID()
 	return s
 }
 
@@ -80,6 +83,12 @@ func (s *Service) ApplyConfiguration(config interface{}) error {
 	}
 	if s.Cfg.Log.StepLinesRateLimit == 0 {
 		s.Cfg.Log.StepLinesRateLimit = defaultStepLinesRateLimit
+	}
+	if s.Cfg.Log.NbJobLogsGoroutines <= 0 {
+		s.Cfg.Log.NbJobLogsGoroutines = defaultNbJobLogsGoroutines
+	}
+	if s.Cfg.Log.DequeueBatchSize <= 0 {
+		s.Cfg.Log.DequeueBatchSize = defaultDequeueBatchSize
 	}
 	if s.Cfg.TCP.GlobalTCPRateLimit == 0 {
 		s.Cfg.TCP.GlobalTCPRateLimit = defaultGlobalTCPRateLimit

--- a/engine/cdn/cdn_log_engine.go
+++ b/engine/cdn/cdn_log_engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/telemetry"
 )
 
 var (
@@ -20,6 +21,26 @@ var (
 	keyJobLock     = cache.Key("cdn", "log", "lock")
 )
 
+// Heartbeat timings are package variables so tests can shrink them.
+var (
+	jobHeartbeatRefreshPeriod = 5 * time.Second
+	jobHeartbeatTTLSec        = 30
+)
+
+func (s *Service) maxJobLogsGoroutines() int64 {
+	if v := s.Cfg.Log.NbJobLogsGoroutines; v > 0 {
+		return v
+	}
+	return defaultNbJobLogsGoroutines
+}
+
+func (s *Service) dequeueBatchSize() int {
+	if v := s.Cfg.Log.DequeueBatchSize; v > 0 {
+		return v
+	}
+	return defaultDequeueBatchSize
+}
+
 // Check all job queues to know and start dequeue if needed
 func (s *Service) waitingJobs(ctx context.Context) {
 	for {
@@ -28,38 +49,61 @@ func (s *Service) waitingJobs(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
-			// List all queues
-			keyListQueue := cache.Key(keyJobLogQueue, "*")
-			listKeys, err := s.Cache.Keys(keyListQueue)
-			if err != nil {
-				err = sdk.WrapError(err, "unable to list jobs queues %s", keyListQueue)
-				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-				continue
-			}
-
-			// For each key, check if heartbeat key exist
-			for _, k := range listKeys {
-				keyParts := strings.Split(k, ":")
-				queueIdentifier := keyParts[len(keyParts)-1]
-
-				jobQueueKey, err := s.canDequeue(ctx, queueIdentifier)
-				if err != nil {
-					err = sdk.WrapError(err, "unable to check canDequeue %s", jobQueueKey)
-					log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-					continue
-				}
-				if jobQueueKey == "" {
-					continue
-				}
-
-				s.GoRoutines.Exec(ctx, "cdn-dequeue-job-message", func(ctx context.Context) {
-					if err := s.dequeueMessages(ctx, jobQueueKey, queueIdentifier); err != nil {
-						err = sdk.WrapError(err, "unable to dequeue redis incoming job queue")
-						log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-					}
-				})
-			}
+			s.claimJobQueues(ctx)
 		}
+	}
+}
+
+// claimJobQueues claims unattended job queues and starts a dequeue goroutine for each of them,
+// bounded by NbJobLogsGoroutines. The cap must be checked BEFORE canDequeue: a saturated
+// instance must never set a heartbeat it will not service, since a phantom heartbeat prevents
+// every other instance from claiming the queue for its whole TTL.
+func (s *Service) claimJobQueues(ctx context.Context) {
+	maxDequeuers := s.maxJobLogsGoroutines()
+	// At capacity: don't even scan. Queues stay safely in Redis (bounded by StepMaxSize)
+	// until a local slot frees up or another instance claims them.
+	if s.dequeuingJobQueues.Load() >= maxDequeuers {
+		return
+	}
+
+	// List all queues
+	keyListQueue := cache.Key(keyJobLogQueue, "*")
+	listKeys, err := s.Cache.Keys(keyListQueue)
+	if err != nil {
+		err = sdk.WrapError(err, "unable to list jobs queues %s", keyListQueue)
+		log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+		return
+	}
+
+	// For each key, check if heartbeat key exist
+	for _, k := range listKeys {
+		if s.dequeuingJobQueues.Load() >= maxDequeuers {
+			return
+		}
+
+		keyParts := strings.Split(k, ":")
+		queueIdentifier := keyParts[len(keyParts)-1]
+
+		jobQueueKey, err := s.canDequeue(ctx, queueIdentifier)
+		if err != nil {
+			err = sdk.WrapError(err, "unable to check canDequeue %s", jobQueueKey)
+			log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+			continue
+		}
+		if jobQueueKey == "" {
+			continue
+		}
+
+		telemetry.Record(ctx, s.Metrics.dequeuedJobQueues, s.dequeuingJobQueues.Add(1))
+		s.GoRoutines.Exec(ctx, "cdn-dequeue-job-message", func(ctx context.Context) {
+			defer func() {
+				telemetry.Record(ctx, s.Metrics.dequeuedJobQueues, s.dequeuingJobQueues.Add(-1))
+			}()
+			if err := s.dequeueMessages(ctx, jobQueueKey, queueIdentifier); err != nil {
+				err = sdk.WrapError(err, "unable to dequeue redis incoming job queue")
+				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+			}
+		})
 	}
 }
 
@@ -74,67 +118,95 @@ func (s *Service) dequeueMessages(ctx context.Context, jobLogsQueueKey string, q
 		log.Info(ctx, "dequeueJobMessages: %s END dequeue - %d messages received in %v", jobLogsQueueKey, nbMessages, delta)
 	}()
 
-	defer func() {
-		// Remove heartbeat
-		_ = s.Cache.Delete(cache.Key(keyJobHearbeat, queueIdentifier))
-	}()
+	// Refresh the heartbeat from a dedicated goroutine so that queue ownership does not
+	// depend on batch processing latency: a batch slower than the heartbeat TTL would
+	// otherwise let another dequeuer claim the same queue and duplicate the load.
+	heartbeatKey := cache.Key(keyJobHearbeat, queueIdentifier)
+	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
+	defer cancelHeartbeat()
+	s.GoRoutines.Exec(heartbeatCtx, "cdn-dequeue-heartbeat", func(ctx context.Context) {
+		tick := time.NewTicker(jobHeartbeatRefreshPeriod)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				if err := s.Cache.SetWithTTL(heartbeatKey, s.dequeueOwnerID, jobHeartbeatTTLSec); err != nil {
+					err = sdk.WrapError(err, "unable to heartbeat %s", heartbeatKey)
+					log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+				}
+			}
+		}
+	})
 
-	tick := time.NewTicker(5 * time.Second)
-	defer tick.Stop()
+	defer s.releaseJobQueueHeartbeat(queueIdentifier)
+
+	batchSize := s.dequeueBatchSize()
+	lastQueueCheck := time.Now()
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-tick.C:
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		dequeuCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		msgs, err := s.Cache.DequeueJSONRawMessagesWithContext(dequeuCtx, jobLogsQueueKey, 1*time.Millisecond, batchSize)
+		cancel()
+		if len(msgs) > 0 {
+			hms := make([]handledMessage, 0, len(msgs))
+			for _, m := range msgs {
+				var hm handledMessage
+				if err := sdk.JSONUnmarshal(m, &hm); err != nil {
+					return sdk.WithStack(err)
+				}
+				hms = append(hms, hm)
+			}
+
+			// Send TO CDN Buffer
+			if err := s.sendToBufferWithRetry(ctx, hms); err != nil {
+				err = sdk.WrapError(err, "unable to send log into buffer")
+				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+			}
+			telemetry.Record(ctx, s.Metrics.dequeuedMessages, int64(len(msgs)))
+			nbMessages += len(msgs)
+			t1 = time.Now()
+		}
+		if err != nil && !strings.Contains(err.Error(), "context deadline exceeded") {
+			err = sdk.WrapError(err, "unable to dequeue job logs queue %s", jobLogsQueueKey)
+			log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
+			continue
+		}
+
+		// Leave dequeue if the queue does not exist anymore (redis deletes an emptied list)
+		if time.Since(lastQueueCheck) >= 5*time.Second {
+			lastQueueCheck = time.Now()
 			b, err := s.Cache.Exist(jobLogsQueueKey)
 			if err != nil {
 				err = sdk.WrapError(err, "unable to check if queue still exist")
 				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
 				continue
-			} else if !b {
-				// leave dequeue if queue does not exist anymore
+			}
+			if !b {
 				log.Info(ctx, "dequeueJobMessages: leaving job queue %s (queue no more exists)", jobLogsQueueKey)
 				return nil
 			}
-			// heartbeat
-			heartbeatKey := cache.Key(keyJobHearbeat, queueIdentifier)
-			if err := s.Cache.SetWithTTL(heartbeatKey, true, 30); err != nil {
-				err = sdk.WrapError(err, "unable to heartbeat %s", heartbeatKey)
-				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-				continue
-			}
-		default:
-			dequeuCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
-			msgs, err := s.Cache.DequeueJSONRawMessagesWithContext(dequeuCtx, jobLogsQueueKey, 1*time.Millisecond, 1000)
-			cancel()
-			if len(msgs) > 0 {
-				hms := make([]handledMessage, 0, len(msgs))
-				for _, m := range msgs {
-					var hm handledMessage
-					if err := sdk.JSONUnmarshal(m, &hm); err != nil {
-						return sdk.WithStack(err)
-					}
-					hms = append(hms, hm)
-				}
-
-				// Send TO CDN Buffer
-				if err := s.sendToBufferWithRetry(ctx, hms); err != nil {
-					err = sdk.WrapError(err, "unable to send log into buffer")
-					log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-				}
-				nbMessages += len(msgs)
-				t1 = time.Now()
-			}
-			if err != nil {
-				if strings.Contains(err.Error(), "context deadline exceeded") {
-					continue
-				}
-				err = sdk.WrapError(err, "unable to dequeue job logs queue %s", jobLogsQueueKey)
-				log.Error(sdk.ContextWithStacktrace(ctx, err), err.Error())
-				continue
-			}
 		}
 	}
+}
+
+// releaseJobQueueHeartbeat deletes the heartbeat only if this instance still owns it.
+// Legacy heartbeats (boolean value) and heartbeats without owner fall back to an
+// unconditional delete.
+func (s *Service) releaseJobQueueHeartbeat(queueIdentifier string) {
+	key := cache.Key(keyJobHearbeat, queueIdentifier)
+	if s.dequeueOwnerID != "" {
+		var owner string
+		if ok, _ := s.Cache.Get(key, &owner); ok && owner != "" && owner != s.dequeueOwnerID {
+			// another instance claimed the queue in the meantime; don't kill its heartbeat
+			return
+		}
+	}
+	_ = s.Cache.Delete(key)
 }
 
 // Return queue name if jobID need to be dequeue or empty
@@ -166,7 +238,7 @@ func (s *Service) canDequeue(ctx context.Context, jobID string) (string, error) 
 
 	//hearbeat
 	log.Info(ctx, "heartbeat: take job %s", jobQueueKey)
-	if err := s.Cache.SetWithTTL(heartbeatKey, true, 30); err != nil {
+	if err := s.Cache.SetWithTTL(heartbeatKey, s.dequeueOwnerID, jobHeartbeatTTLSec); err != nil {
 		return "", err
 	}
 	return jobQueueKey, nil

--- a/engine/cdn/cdn_log_engine_test.go
+++ b/engine/cdn/cdn_log_engine_test.go
@@ -1,0 +1,214 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rockbears/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/engine/cdn/item"
+	"github.com/ovh/cds/engine/cdn/storage"
+	_ "github.com/ovh/cds/engine/cdn/storage/local"
+	_ "github.com/ovh/cds/engine/cdn/storage/redis"
+	cdntest "github.com/ovh/cds/engine/cdn/test"
+	"github.com/ovh/cds/engine/gorpmapper"
+	"github.com/ovh/cds/engine/test"
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/cdn"
+	"github.com/ovh/cds/sdk/log/hook/graylog"
+)
+
+func newTestLogEngineService(t *testing.T) (*Service, context.Context) {
+	m := gorpmapper.New()
+	item.InitDBMapping(m)
+	storage.InitDBMapping(m)
+
+	log.Factory = log.NewTestingWrapper(t)
+	db, factory, store, cancelDB := test.SetupPGToCancel(t, m, sdk.TypeCDN)
+	t.Cleanup(cancelDB)
+
+	cdntest.ClearItem(t, context.TODO(), m, db)
+
+	s := &Service{
+		DBConnectionFactory: factory,
+		Cache:               store,
+		Mapper:              m,
+	}
+	s.GoRoutines = sdk.NewGoRoutines(context.TODO())
+	s.dequeueOwnerID = sdk.UUID()
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+	s.Units = newRunningStorageUnits(t, m, db.DbMap, ctx, store)
+
+	// The redis instance is shared across tests: sweep stale job log keys
+	for _, pattern := range []string{keyJobLogQueue + ":*", keyJobHearbeat + ":*", keyJobLock + ":*"} {
+		keys, err := s.Cache.Keys(pattern)
+		require.NoError(t, err)
+		for _, k := range keys {
+			require.NoError(t, s.Cache.Delete(k))
+		}
+	}
+
+	return s, ctx
+}
+
+func newTestStepLogMessage(projectKey string, line int) handledMessage {
+	return handledMessage{
+		Msg: graylog.Message{
+			Full: fmt.Sprintf("log line %d", line),
+		},
+		Signature: cdn.Signature{
+			ProjectKey:   projectKey,
+			WorkflowID:   1,
+			WorkflowName: "MyWorkflow",
+			RunID:        1,
+			NodeRunID:    1,
+			NodeRunName:  "MyPipeline",
+			JobName:      "MyJob",
+			JobID:        1,
+			Worker: &cdn.SignatureWorker{
+				StepName:  "script1",
+				StepOrder: 1,
+			},
+		},
+	}
+}
+
+// A CDN instance at capacity must not claim more job queues: claiming sets a 30s heartbeat
+// that prevents every other instance from dequeuing the queue, so an over-claiming instance
+// both balloons its own memory and starves the rest of the fleet. Unbounded claiming is what
+// turned a single pod OOM into a fleet-wide crash loop (incident 2026-08-17).
+func TestClaimJobQueuesRespectsCap(t *testing.T) {
+	s, ctx := newTestLogEngineService(t)
+	s.Cfg.Log.NbJobLogsGoroutines = 1
+	s.Cfg.Log.DequeueBatchSize = 100
+
+	queueIdentifier := sdk.UUID()
+	queueKey := keyJobLogQueue + ":" + queueIdentifier
+	heartbeatKey := keyJobHearbeat + ":" + queueIdentifier
+
+	hm := newTestStepLogMessage(sdk.RandomString(10), 1)
+	require.NoError(t, s.Cache.Enqueue(queueKey, hm))
+
+	// Saturate the instance: claimJobQueues must return without touching the queue,
+	// and above all without setting a heartbeat it will not service.
+	s.dequeuingJobQueues.Store(1)
+	s.claimJobQueues(ctx)
+
+	exist, err := s.Cache.Exist(heartbeatKey)
+	require.NoError(t, err)
+	require.False(t, exist, "a saturated instance must not set a heartbeat on a queue it will not dequeue")
+	queueLen, err := s.Cache.QueueLen(queueKey)
+	require.NoError(t, err)
+	require.Equal(t, 1, queueLen, "a saturated instance must leave the queue content in redis")
+
+	// Free the slot: the queue must now be claimed and drained.
+	s.dequeuingJobQueues.Store(0)
+	s.claimJobQueues(ctx)
+
+	require.Eventually(t, func() bool {
+		queueLen, err := s.Cache.QueueLen(queueKey)
+		require.NoError(t, err)
+		return queueLen == 0
+	}, 15*time.Second, 100*time.Millisecond, "the queue must be drained once a dequeue slot is available")
+
+	// The dequeue goroutine exits after noticing the emptied queue and frees its slot.
+	require.Eventually(t, func() bool {
+		return s.dequeuingJobQueues.Load() == 0
+	}, 20*time.Second, 100*time.Millisecond, "the dequeue slot must be released when the dequeuer exits")
+}
+
+// The queue ownership heartbeat must stay alive while a batch of messages is being written
+// to the buffer. Before the fix, the heartbeat was only refreshed between batches: a batch
+// slower than the heartbeat TTL let another dequeuer claim the same queue, duplicating the
+// memory and database load — the amplification loop behind the OOM cascade (incident 2026-08-17).
+func TestDequeueMessagesKeepsHeartbeatDuringSlowBatch(t *testing.T) {
+	s, ctx := newTestLogEngineService(t)
+	s.Cfg.Log.DequeueBatchSize = 1000
+
+	previousRefreshPeriod, previousTTL := jobHeartbeatRefreshPeriod, jobHeartbeatTTLSec
+	jobHeartbeatRefreshPeriod, jobHeartbeatTTLSec = 200*time.Millisecond, 1
+	t.Cleanup(func() {
+		jobHeartbeatRefreshPeriod, jobHeartbeatTTLSec = previousRefreshPeriod, previousTTL
+	})
+
+	queueIdentifier := sdk.UUID()
+	heartbeatKey := keyJobHearbeat + ":" + queueIdentifier
+
+	// Enough messages so that dequeuing and storing them outlives the 1s heartbeat TTL.
+	projectKey := sdk.RandomString(10)
+	nbMessages := 2000
+	for i := 0; i < nbMessages; i++ {
+		hm := newTestStepLogMessage(projectKey, i)
+		require.NoError(t, s.Cache.Enqueue(keyJobLogQueue+":"+queueIdentifier, hm))
+	}
+
+	queueKey, err := s.canDequeue(ctx, queueIdentifier)
+	require.NoError(t, err)
+	require.NotEmpty(t, queueKey)
+
+	dequeueCtx, cancelDequeue := context.WithCancel(ctx)
+	t.Cleanup(cancelDequeue)
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- s.dequeueMessages(dequeueCtx, queueKey, queueIdentifier)
+	}()
+
+	// While the queue is being drained, the heartbeat must exist at every poll: any gap
+	// means another instance could claim the queue and duplicate the dequeuer.
+	for {
+		queueLen, err := s.Cache.QueueLen(queueKey)
+		require.NoError(t, err)
+		if queueLen == 0 {
+			break
+		}
+		exist, err := s.Cache.Exist(heartbeatKey)
+		require.NoError(t, err)
+		require.True(t, exist, "the heartbeat expired while messages were still being processed")
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Prove the test had power: the drain outlived the heartbeat TTL, so an unrefreshed
+	// heartbeat would have expired mid-processing.
+	require.Greater(t, time.Since(start), time.Duration(jobHeartbeatTTLSec)*time.Second,
+		"processing must outlive the heartbeat TTL for this test to be meaningful")
+
+	cancelDequeue()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+// A dequeuer releasing a job queue must not delete a heartbeat now owned by another
+// instance, otherwise the queue gets claimed twice.
+func TestReleaseJobQueueHeartbeatOwnerCheck(t *testing.T) {
+	s, _ := newTestLogEngineService(t)
+
+	queueIdentifier := sdk.UUID()
+	heartbeatKey := keyJobHearbeat + ":" + queueIdentifier
+
+	// Heartbeat owned by another instance: must be kept.
+	require.NoError(t, s.Cache.SetWithTTL(heartbeatKey, sdk.UUID(), 30))
+	s.releaseJobQueueHeartbeat(queueIdentifier)
+	exist, err := s.Cache.Exist(heartbeatKey)
+	require.NoError(t, err)
+	require.True(t, exist, "a heartbeat owned by another instance must not be deleted")
+
+	// Heartbeat owned by this instance: must be deleted.
+	require.NoError(t, s.Cache.SetWithTTL(heartbeatKey, s.dequeueOwnerID, 30))
+	s.releaseJobQueueHeartbeat(queueIdentifier)
+	exist, err = s.Cache.Exist(heartbeatKey)
+	require.NoError(t, err)
+	require.False(t, exist, "a heartbeat owned by this instance must be deleted on release")
+
+	// Legacy heartbeat (boolean value, written by a pre-upgrade instance): fall back to
+	// the unconditional delete for rolling-deploy compatibility.
+	require.NoError(t, s.Cache.SetWithTTL(heartbeatKey, true, 30))
+	s.releaseJobQueueHeartbeat(queueIdentifier)
+	exist, err = s.Cache.Exist(heartbeatKey)
+	require.NoError(t, err)
+	require.False(t, exist, "a legacy heartbeat must be deleted on release")
+}

--- a/engine/cdn/cdn_log_store.go
+++ b/engine/cdn/cdn_log_store.go
@@ -14,10 +14,28 @@ import (
 	"github.com/ovh/cds/sdk/cdn"
 )
 
+// storeLogsCache memoizes item and item unit lookups for the lifetime of a dequeued batch:
+// without it, every single log line costs ~4 SELECTs (incl. 2 decryptions) against the
+// database. Entries are keyed by apiRefHash / itemID because one job queue carries several
+// steps and service logs, each being a distinct item.
+type storeLogsCache struct {
+	items     map[string]*sdk.CDNItem     // by apiRefHash
+	itemUnits map[string]*sdk.CDNItemUnit // by itemID
+}
+
+func newStoreLogsCache() *storeLogsCache {
+	return &storeLogsCache{
+		items:     make(map[string]*sdk.CDNItem),
+		itemUnits: make(map[string]*sdk.CDNItemUnit),
+	}
+}
+
 func (s *Service) sendToBufferWithRetry(ctx context.Context, hms []handledMessage) error {
 	if len(hms) == 0 {
 		return nil
 	}
+
+	batchCache := newStoreLogsCache()
 
 	// Browse all messages
 	for _, hm := range hms {
@@ -38,7 +56,7 @@ func (s *Service) sendToBufferWithRetry(ctx context.Context, hms []handledMessag
 		currentLog := buildMessage(hm)
 		cpt := 0
 		for {
-			if err := s.storeLogs(ctx, itemType, hm.Signature, hm.IsTerminated, currentLog); err != nil {
+			if err := s.storeLogsWithCache(ctx, batchCache, itemType, hm.Signature, hm.IsTerminated, currentLog); err != nil {
 				if sdk.ErrorIs(err, sdk.ErrLocked) && cpt < 10 {
 					cpt++
 					time.Sleep(250 * time.Millisecond)
@@ -53,9 +71,26 @@ func (s *Service) sendToBufferWithRetry(ctx context.Context, hms []handledMessag
 }
 
 func (s *Service) storeLogs(ctx context.Context, itemType sdk.CDNItemType, signature cdn.Signature, terminated bool, content string) error {
-	it, err := s.loadOrCreateItem(ctx, itemType, signature)
+	return s.storeLogsWithCache(ctx, newStoreLogsCache(), itemType, signature, terminated, content)
+}
+
+func (s *Service) storeLogsWithCache(ctx context.Context, c *storeLogsCache, itemType sdk.CDNItemType, signature cdn.Signature, terminated bool, content string) error {
+	apiRef, err := sdk.NewCDNApiRef(itemType, signature)
 	if err != nil {
 		return err
+	}
+	hashRef, err := apiRef.ToHash()
+	if err != nil {
+		return err
+	}
+
+	it, ok := c.items[hashRef]
+	if !ok {
+		it, err = s.loadOrCreateItem(ctx, itemType, signature)
+		if err != nil {
+			return err
+		}
+		c.items[hashRef] = it
 	}
 
 	var t0 = it.Created.UnixNano() / 1000000 // convert to ms
@@ -63,9 +98,13 @@ func (s *Service) storeLogs(ctx context.Context, itemType sdk.CDNItemType, signa
 
 	ctx = context.WithValue(ctx, storage.FieldAPIRef, it.APIRefHash)
 
-	iu, err := s.loadOrCreateItemUnitBuffer(ctx, it.ID, itemType)
-	if err != nil {
-		return err
+	iu, ok := c.itemUnits[it.ID]
+	if !ok {
+		iu, err = s.loadOrCreateItemUnitBuffer(ctx, it.ID, itemType)
+		if err != nil {
+			return err
+		}
+		c.itemUnits[it.ID] = iu
 	}
 
 	// In case where the item was marked as complete we don't allow append of other logs
@@ -98,9 +137,7 @@ func (s *Service) storeLogs(ctx context.Context, itemType sdk.CDNItemType, signa
 	}
 
 	// Send an event in WS broker to refresh streams on current item
-	s.GoRoutines.Exec(ctx, "storeLogsPublishWSEvent", func(ctx context.Context) {
-		s.publishWSEvent(*iu)
-	})
+	s.publishWSEvent(*iu)
 
 	// If we have all lines or buffer is full and we received the last line
 	if terminated {
@@ -116,6 +153,11 @@ func (s *Service) storeLogs(ctx context.Context, itemType sdk.CDNItemType, signa
 		if err := tx.Commit(); err != nil {
 			return sdk.WithStack(err)
 		}
+
+		// completeItem changed the item status in database: evict the cached entries so a
+		// late line for this item reloads a fresh state and gets skipped as completed.
+		delete(c.items, hashRef)
+		delete(c.itemUnits, it.ID)
 
 		s.Units.PushInSyncQueue(ctx, it.ID, it.Created)
 	}

--- a/engine/cdn/cdn_metrics.go
+++ b/engine/cdn/cdn_metrics.go
@@ -37,6 +37,12 @@ func (s *Service) initMetrics(ctx context.Context) error {
 	s.Metrics.tcpServerServiceLogCount = stats.Int64("cdn/tcp/service_log_count", "number of service log received", stats.UnitDimensionless)
 	tcpServerServiceLogCountView := telemetry.NewViewCount(s.Metrics.tcpServerServiceLogCount.Name(), s.Metrics.tcpServerServiceLogCount, []tag.Key{tagServiceName, tagServiceType})
 
+	s.Metrics.dequeuedJobQueues = stats.Int64("cdn/dequeue/job_queues", "number of job logs queues currently claimed by this instance", stats.UnitDimensionless)
+	dequeuedJobQueuesView := telemetry.NewViewLast(s.Metrics.dequeuedJobQueues.Name(), s.Metrics.dequeuedJobQueues, []tag.Key{tagServiceName, tagServiceType})
+
+	s.Metrics.dequeuedMessages = stats.Int64("cdn/dequeue/messages", "number of job logs messages dequeued", stats.UnitDimensionless)
+	dequeuedMessagesView := telemetry.NewViewCount(s.Metrics.dequeuedMessages.Name(), s.Metrics.dequeuedMessages, []tag.Key{tagServiceName, tagServiceType})
+
 	s.Metrics.itemCompletedByGCCount = stats.Int64("cdn/items/completed_by_gc", "number of items completed by GC", stats.UnitDimensionless)
 	itemCompletedByGCCountView := telemetry.NewViewCount(s.Metrics.itemCompletedByGCCount.Name(), s.Metrics.itemCompletedByGCCount, []tag.Key{tagServiceName, tagServiceType})
 
@@ -75,6 +81,8 @@ func (s *Service) initMetrics(ctx context.Context) error {
 		tcpServerHitsCountView,
 		tcpServerStepLogCountView,
 		tcpServerServiceLogCountView,
+		dequeuedJobQueuesView,
+		dequeuedMessagesView,
 		itemCompletedByGCCountView,
 		itemInDatabaseCountView,
 		itemPerStorageUnitCountView,

--- a/engine/cdn/status_handler.go
+++ b/engine/cdn/status_handler.go
@@ -73,6 +73,14 @@ func (s *Service) Status(ctx context.Context) *sdk.MonitoringStatus {
 		return true
 	})
 
+	nbDequeuing := s.dequeuingJobQueues.Load()
+	dequeueStatus := sdk.MonitoringStatusOK
+	if nbDequeuing >= s.maxJobLogsGoroutines() {
+		// saturated: job logs queues are waiting in redis until a slot frees up
+		dequeueStatus = sdk.MonitoringStatusWarn
+	}
+	m.AddLine(addMonitoringLine(nbDequeuing, "dequeue/job_queues", nil, dequeueStatus))
+
 	m.AddLine(s.DBConnectionFactory.Status(ctx))
 
 	return m

--- a/engine/cdn/storage/types.go
+++ b/engine/cdn/storage/types.go
@@ -338,6 +338,8 @@ func (x *RunningStorageUnits) IsBuffer(id string) bool {
 
 type LogConfig struct {
 	// Step logs
-	StepMaxSize        int64 `toml:"stepMaxSize" default:"15728640" comment:"Max step logs size in bytes (default: 15MB)" json:"stepMaxSize"`
-	StepLinesRateLimit int64 `toml:"stepLinesRateLimit" default:"1800" comment:"Number of lines that a worker can send by seconds" json:"stepLinesRateLimit"`
+	StepMaxSize         int64 `toml:"stepMaxSize" default:"15728640" comment:"Max step logs size in bytes (default: 15MB)" json:"stepMaxSize"`
+	StepLinesRateLimit  int64 `toml:"stepLinesRateLimit" default:"1800" comment:"Number of lines that a worker can send by seconds" json:"stepLinesRateLimit"`
+	NbJobLogsGoroutines int64 `toml:"nbJobLogsGoroutines" default:"10" comment:"Maximum number of job logs queues dequeued concurrently by a CDN instance" json:"nbJobLogsGoroutines"`
+	DequeueBatchSize    int   `toml:"dequeueBatchSize" default:"100" comment:"Maximum number of log messages read from a job logs queue in a single batch" json:"dequeueBatchSize"`
 }

--- a/engine/cdn/types.go
+++ b/engine/cdn/types.go
@@ -3,6 +3,7 @@ package cdn
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opencensus.io/stats"
@@ -41,11 +42,15 @@ type Service struct {
 	WSBroker            *websocket.Broker
 	WSEventsMutex       sync.Mutex
 	WSEvents            map[string]sdk.CDNWSEvent
+	dequeuingJobQueues  atomic.Int64 // job log queues currently claimed by this instance
+	dequeueOwnerID      string       // unique instance id stored as heartbeat value
 	Metrics             struct {
 		tcpServerErrorsCount     *stats.Int64Measure
 		tcpServerHitsCount       *stats.Int64Measure
 		tcpServerStepLogCount    *stats.Int64Measure
 		tcpServerServiceLogCount *stats.Int64Measure
+		dequeuedJobQueues        *stats.Int64Measure
+		dequeuedMessages         *stats.Int64Measure
 		itemCompletedByGCCount   *stats.Int64Measure
 		itemInDatabaseCount      *stats.Int64Measure
 		itemPerStorageUnitCount  *stats.Int64Measure


### PR DESCRIPTION
## Context

  Bug: 10 container OOMKills in 13 minutes across the cds-cdn fleet, triggered by 3 concurrent workflow runs emitting ~125k log lines. Memory ballooned from ~150 Mi cruise to >1
  Gi in under 2.5 minutes per pod.

  Root cause: the log consumption path (Redis → Postgres) has no bounds at all, while the ingress path (TCP → Redis) is already rate-limited three ways (globalTCPRateLimit, stepLinesRateLimit, stepMaxSize).
  Incoming log volume translated directly into heap, and the queue-takeover mechanism turned one pod OOM into a fleet-wide crash loop.

 ## Bugs fixed

  1. Unbounded queue claiming (the cascade). Every 250 ms each pod scanned all cdn:log:job:<id> queues and spawned one dequeue goroutine per queue without a live heartbeat — with no cap. When a pod died, its
  heartbeats expired (30 s TTL) and the survivors claimed all of its queues at once, ballooned, and died in turn.
  → New config knob nbJobLogsGoroutines (default 10 — same name and default as the knob that existed before the per-job-queue refactor 16042b9160 removed it), enforced with an atomic counter. The cap is checked
  before canDequeue: a saturated instance must never set a heartbeat it will not service, since a phantom heartbeat blocks every other instance for its whole TTL.

  2. Unbounded batch memory. The dequeue read a hardcoded 1000 messages per call, holding both the raw and the decoded slices in heap simultaneously (~2-4 KB per message), multiplied by an unbounded number of
  claimed queues.
  → New config knob dequeueBatchSize (default 100). Worst-case in-flight memory is now ~10 queues × 100 msgs × ~4 KB × 2 copies ≈ 8 MB per pod. Backpressure is free: pending messages stay in Redis, already
  bounded to ~15 MB per job by stepMaxSize.

  3. Heartbeat starvation (the self-amplification). The heartbeat refresh lived in a select ticker branch that could not run while a batch was being written inline. A batch slower than 30 s (plausible: ~4 DB
  round trips per log line against maxconn=20, plus ErrLocked retries up to 2.5 s per message) let the heartbeat expire mid-batch, so another pod claimed the same queue → duplicate dequeuers → more DB contention
  → even slower batches → loop.
  → dequeueMessages is restructured as a linear loop with a dedicated heartbeat-refresher goroutine per active dequeuer (cancelled on exit): queue ownership liveness no longer depends on batch-processing latency.

  4. Ownerless heartbeat release. The heartbeat value was literally true and the deferred cleanup deleted it unconditionally — a late-exiting dequeuer could kill a heartbeat freshly claimed by another pod,
  causing a double claim.
  → The heartbeat now stores the instance UUID; release deletes it only if still owned. Rolling-deploy safe: legacy true values fall back to the unconditional delete (current behavior), and canDequeue only ever
  checks key existence.

  5. Context/stack-trace memory leak (minor but real). ctx = sdk.ContextWithStacktrace(ctx, err) inside infinite loops grew an unbounded chain of valueCtx on the longest-lived goroutines of the service, pinning
  formatted stack traces forever. Fixed in cdn_log_engine.go and handleConnection (log on a throwaway local ctx instead).
