### PR TITLE
fix(api): keep the published binaries when a plugin is imported

### DIFF
--- a/engine/api/grpc_plugin.go
+++ b/engine/api/grpc_plugin.go
@@ -111,19 +111,24 @@ func (api *API) putGRPCluginHandler() service.Handler {
 			return sdk.WithStack(err)
 		}
 
-		old, err := plugin.LoadByName(ctx, api.mustDB(), name)
-		if err != nil {
-			return sdk.WrapError(err, "unable to load old plugin")
-		}
-
-		p.ID = old.ID
-		p.Binaries = old.Binaries
-
 		tx, err := db.Begin()
 		if err != nil {
 			return sdk.WrapError(err, "Cannot start transaction")
 		}
 		defer tx.Rollback() //nolint
+
+		// The row is locked until the end of the transaction: all the binaries of a plugin live in
+		// the same row, so an update racing with a binary upload would otherwise drop the binaries
+		// the other one references.
+		old, err := plugin.LoadByNameForUpdate(ctx, tx, name)
+		if err != nil {
+			return sdk.WrapError(err, "unable to load old plugin")
+		}
+
+		p.ID = old.ID
+		// Updating a definition does not publish binaries: the ones already published are kept,
+		// otherwise the plugin would not be runnable until its new binaries are uploaded.
+		p.Binaries = old.Binaries
 
 		// a plugin can be attached to a integration model OR not, for "action plugin"
 		if p.Integration != "" {

--- a/engine/api/grpc_plugin_test.go
+++ b/engine/api/grpc_plugin_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/engine/api/objectstore"
+	"github.com/ovh/cds/engine/api/plugin"
+	"github.com/ovh/cds/engine/api/test"
+	"github.com/ovh/cds/engine/api/test/assets"
+	"github.com/ovh/cds/sdk"
+)
+
+// A plugin is deployed by importing its definition, then uploading its binaries one by one. Jobs
+// keep starting during that sequence: the binaries already published must stay served, with a
+// descriptor matching the content, until they are replaced.
+func Test_pluginDeploymentKeepsBinariesAvailable(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+
+	storage, err := objectstore.Init(context.TODO(), objectstore.Config{
+		Kind: objectstore.Filesystem,
+		Options: objectstore.ConfigOptions{
+			Filesystem: objectstore.ConfigOptionsFilesystem{Basedir: t.TempDir()},
+		},
+	})
+	require.NoError(t, err)
+	api.SharedStorage = storage
+
+	_, jwt := assets.InsertAdminUser(t, db)
+
+	p := sdk.GRPCPlugin{
+		Name:        sdk.RandomString(10),
+		Type:        sdk.GRPCPluginAction,
+		Author:      "me",
+		Description: "the description",
+	}
+	uriCreate := api.Router.GetRoute("POST", api.postGRPCluginHandler, nil)
+	test.NotEmpty(t, uriCreate)
+	w := httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(w, assets.NewJWTAuthentifiedRequest(t, jwt, "POST", uriCreate, &p))
+	require.Equal(t, 200, w.Code)
+
+	uploadPluginBinary(t, api, jwt, p.Name, "the binary of the previous release")
+	requirePluginBinaryServed(t, api, jwt, p.Name, "the binary of the previous release")
+
+	// the deployment starts by importing the definition again
+	imported := p
+	imported.Description = "an updated description"
+	uriImport := api.Router.GetRouteV2("POST", api.postImportPluginHandler, nil) + "?force=true"
+	test.NotEmpty(t, uriImport)
+	w = httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(w, assets.NewJWTAuthentifiedRequest(t, jwt, "POST", uriImport, &imported))
+	require.Equal(t, 200, w.Code)
+
+	requirePluginBinaryServed(t, api, jwt, p.Name, "the binary of the previous release")
+
+	// same for a plugin imported through the v1 route
+	uriUpdate := api.Router.GetRoute("PUT", api.putGRPCluginHandler, map[string]string{"name": p.Name})
+	test.NotEmpty(t, uriUpdate)
+	w = httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(w, assets.NewJWTAuthentifiedRequest(t, jwt, "PUT", uriUpdate, &imported))
+	require.Equal(t, 200, w.Code)
+
+	requirePluginBinaryServed(t, api, jwt, p.Name, "the binary of the previous release")
+
+	// then the new binaries are uploaded
+	uploadPluginBinary(t, api, jwt, p.Name, "the binary being released")
+	requirePluginBinaryServed(t, api, jwt, p.Name, "the binary being released")
+
+	reloaded, err := plugin.LoadByName(context.TODO(), db, p.Name)
+	require.NoError(t, err)
+	require.Equal(t, "an updated description", reloaded.Description)
+	require.Len(t, reloaded.Binaries, 1)
+}
+
+func uploadPluginBinary(t *testing.T, api *API, jwt, pluginName, content string) {
+	t.Helper()
+
+	sum := sha512.Sum512([]byte(content))
+	b := sdk.GRPCPluginBinary{
+		OS:          "linux",
+		Arch:        "amd64",
+		Name:        pluginName + "-linux-amd64",
+		Perm:        0700,
+		Size:        int64(len(content)),
+		SHA512sum:   hex.EncodeToString(sum[:]),
+		FileContent: []byte(content),
+	}
+
+	uri := api.Router.GetRoute("POST", api.postGRPCluginBinaryHandler, map[string]string{"name": pluginName})
+	test.NotEmpty(t, uri)
+	w := httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(w, assets.NewJWTAuthentifiedRequest(t, jwt, "POST", uri, &b))
+	require.Equal(t, 200, w.Code)
+}
+
+// requirePluginBinaryServed checks what a worker gets: the published descriptor, and the content
+// served for it.
+func requirePluginBinaryServed(t *testing.T, api *API, jwt, pluginName, content string) {
+	t.Helper()
+
+	vars := map[string]string{"name": pluginName, "os": "linux", "arch": "amd64"}
+
+	uriInfos := api.Router.GetRoute("GET", api.getGRPCluginBinaryInfosHandler, vars)
+	test.NotEmpty(t, uriInfos)
+	wInfos := httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(wInfos, assets.NewJWTAuthentifiedRequest(t, jwt, "GET", uriInfos, nil))
+	require.Equal(t, 200, wInfos.Code, "the plugin binary must stay published")
+
+	var b sdk.GRPCPluginBinary
+	require.NoError(t, json.Unmarshal(wInfos.Body.Bytes(), &b))
+
+	uriDownload := api.Router.GetRoute("GET", api.getGRPCluginBinaryHandler, vars)
+	test.NotEmpty(t, uriDownload)
+	wDownload := httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(wDownload, assets.NewJWTAuthentifiedRequest(t, jwt, "GET", uriDownload, nil))
+	require.Equal(t, 200, wDownload.Code, "the plugin binary must stay downloadable")
+	require.Equal(t, content, wDownload.Body.String())
+
+	sum := sha512.Sum512(wDownload.Body.Bytes())
+	require.Equal(t, hex.EncodeToString(sum[:]), b.SHA512sum, "the served content must match the published checksum")
+}

--- a/engine/api/v2_plugin.go
+++ b/engine/api/v2_plugin.go
@@ -52,7 +52,10 @@ func (api *API) postImportPluginHandler() ([]service.RbacChecker, service.Handle
 			}
 			defer tx.Rollback() //nolint
 
-			oldP, err := plugin.LoadByName(ctx, db, p.Name)
+			// The row is locked until the end of the transaction: all the binaries of a plugin live
+			// in the same row, so an import racing with a binary upload would otherwise drop the
+			// binaries the other one references.
+			oldP, err := plugin.LoadByNameForUpdate(ctx, tx, p.Name)
 			if err != nil && !sdk.ErrorIs(err, sdk.ErrNotFound) {
 				return err
 			}
@@ -65,6 +68,10 @@ func (api *API) postImportPluginHandler() ([]service.RbacChecker, service.Handle
 				// If plugin exist and --force, update it
 				if force {
 					p.ID = oldP.ID
+					// Importing a definition does not publish binaries: the ones already published
+					// are kept, otherwise the plugin would not be runnable until its new binaries
+					// are uploaded.
+					p.Binaries = oldP.Binaries
 					if err := plugin.Update(tx, &p); err != nil {
 						return sdk.WrapError(err, "unable to insert plugin")
 					}


### PR DESCRIPTION
Importing a plugin definition reset its binaries: the v2 import handler sent an empty list to the database, and all the binaries of a plugin live in the same column. A deployment imports the definition before uploading the new binaries, so the plugin had no binary at all for the whole upload and every job started meanwhile failed with "unable to find plugin X for os/arch". Deploying the plugins concurrently only made the window more visible: several plugins are now in that state at the same time.

The import keeps the binaries already published, which is what the v1 handler was doing, and both handlers now load the plugin row inside their transaction with LoadByNameForUpdate: the row was read outside of it, so an import racing with a binary upload dropped the binaries referenced by the other one.

A binary is therefore only removed by binary-delete, never by an import.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
