### PR TITLE
feat(api,ui): live workflow run view and faster explore view

### DIFF
--- a/docs/content/docs/concepts/cds_as_code/events.md
+++ b/docs/content/docs/concepts/cds_as_code/events.md
@@ -106,14 +106,20 @@ Each action on CDS triggers an event.
 
 * `RunCrafted`
 * `RunBuilding`
+* `RunUpdated`
 * `RunEnded`
-* `RunRestartFailedJob`
+* `RunRestart`
+* `RunDeleted`
 
 # Workflow Run Job events
 
 * `RunJobEnqueued`
 * `RunJobScheduled`
 * `RunJobBuilding`
+* `RunJobBlocked`
+* `RunJobCancelled`
+* `RunJobSkipped`
+* `RunJobStopped`
 * `RunJobManualTriggered`
 * `RunJobRunResultAdded`
 * `RunJobRunResultUpdated`

--- a/engine/api/event_v2/event.go
+++ b/engine/api/event_v2/event.go
@@ -310,7 +310,7 @@ func sendVCSPullRequestComment(ctx context.Context, db *gorp.DbMap, vcsClient sd
 }
 
 func pushNotifications(ctx context.Context, db *gorp.DbMap, event sdk.FullEventV2) error {
-	if event.ProjectKey == "" {
+	if event.ProjectKey == "" || isProgressOnly(event) {
 		return nil
 	}
 	notifications, err := notification_v2.LoadAll(ctx, db, event.ProjectKey, gorpmapper.GetAllOptions.WithDecryption)
@@ -371,7 +371,17 @@ func pushNotifications(ctx context.Context, db *gorp.DbMap, event sdk.FullEventV
 	return nil
 }
 
+// A progress event says nothing new about the state of a run, it only tells a view watching it that
+// something moved. It is worth a websocket frame, not an audit trail nor a notification.
+func isProgressOnly(e sdk.FullEventV2) bool {
+	return e.Type == sdk.EventRunJobStepUpdated
+}
+
 func pushToElasticSearch(ctx context.Context, db *gorp.DbMap, e sdk.FullEventV2) error {
+	if isProgressOnly(e) {
+		return nil
+	}
+
 	esServices, err := services.LoadAllByType(ctx, db, sdk.TypeElasticsearch)
 	if err != nil {
 		return sdk.WrapError(err, "unable to load elasticsearch service")

--- a/engine/api/event_v2/event_run.go
+++ b/engine/api/event_v2/event_run.go
@@ -69,6 +69,19 @@ func PublishRunJobManualEvent(ctx context.Context, store cache.Store, eventType 
 }
 
 func PublishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, wr sdk.V2WorkflowRun, rj sdk.V2WorkflowRunJob) {
+	publishRunJobEvent(ctx, store, eventType, rj)
+
+	ev := NewEventJobSummaryV2(wr, rj)
+	event.PublishEventJobSummary(ctx, ev, nil)
+}
+
+// PublishRunJobStepUpdate reports the progress of the steps of a job. It carries no job summary: the
+// job status did not change, only its steps did.
+func PublishRunJobStepUpdate(ctx context.Context, store cache.Store, rj sdk.V2WorkflowRunJob) {
+	publishRunJobEvent(ctx, store, sdk.EventRunJobStepUpdated, rj)
+}
+
+func publishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, rj sdk.V2WorkflowRunJob) {
 	bts, _ := json.Marshal(rj)
 	e := sdk.WorkflowRunJobEvent{
 		GlobalEventV2: sdk.GlobalEventV2{
@@ -97,9 +110,6 @@ func PublishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.Ev
 		Username:      rj.Initiator.Username(),
 	}
 	publish(ctx, store, e)
-
-	ev := NewEventJobSummaryV2(wr, rj)
-	event.PublishEventJobSummary(ctx, ev, nil)
 }
 
 func PublishRunEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, wr sdk.V2WorkflowRun, jobs map[string]sdk.V2WorkflowRunJob, runResults []sdk.V2WorkflowRunResult, initiator *sdk.V2Initiator) {

--- a/engine/api/v2_queue.go
+++ b/engine/api/v2_queue.go
@@ -61,6 +61,9 @@ func (api *API) postJobRunStepHandler() ([]service.RbacChecker, service.Handler)
 		if err := tx.Commit(); err != nil {
 			return sdk.WithStack(err)
 		}
+
+		event_v2.PublishRunJobStepUpdate(ctx, api.Cache, *runjob)
+
 		return nil
 	}
 }

--- a/engine/api/v2_websocket.go
+++ b/engine/api/v2_websocket.go
@@ -57,19 +57,19 @@ type webSocketV2Filters []sdk.WebsocketV2Filter
 func (f webSocketV2Filters) HasOneKey(keys ...string) (found bool, needPostCheck bool) {
 	for i := range keys {
 		for _, filter := range f {
-			if keys[i] == filter.Key() {
-				found = true
-				switch filter.Type {
-				case sdk.WebsocketV2FilterTypeGlobal,
-					sdk.WebsocketV2FilterTypeProjectRuns,
-					sdk.WebsocketV2FilterTypeQueue:
-					needPostCheck = true
-				}
-				// If we found a filter that don't need post check we can return directly
-				// If not we will check if another filter match the given keys, this will prevent from running post check if not needed
-				if !needPostCheck {
-					return
-				}
+			if keys[i] != filter.Key() {
+				continue
+			}
+			found = true
+			switch filter.Type {
+			case sdk.WebsocketV2FilterTypeGlobal,
+				sdk.WebsocketV2FilterTypeProjectRuns,
+				sdk.WebsocketV2FilterTypeQueue:
+				needPostCheck = true
+			default:
+				// A filter that needs no post check is enough to allow the event, whatever the other
+				// filters matching it.
+				return true, false
 			}
 		}
 	}
@@ -113,7 +113,8 @@ func (c *websocketV2ClientData) updateEventFilters(ctx context.Context, db gorp.
 		switch f.Type {
 		case sdk.WebsocketV2FilterTypeProject,
 			sdk.WebsocketV2FilterTypeProjectPurgeReport,
-			sdk.WebsocketV2FilterTypeProjectRuns:
+			sdk.WebsocketV2FilterTypeProjectRuns,
+			sdk.WebsocketV2FilterTypeProjectRun:
 			if isMaintainer {
 				continue
 			}
@@ -331,7 +332,7 @@ func (a *API) websocketV2OnMessage(e sdk.FullEventV2) {
 				Event:  e,
 			}); err != nil {
 				log.Debug(ctx, "api.websocketV2OnMessage> can't send to client %s it will be removed: %+v", clientID, err)
-				a.WSServer.RemoveClient(clientID)
+				a.WSV2Server.RemoveClient(clientID)
 			}
 		})
 	}
@@ -341,6 +342,17 @@ func (a *API) websocketV2OnMessage(e sdk.FullEventV2) {
 func (a *API) websocketV2ComputeEventKeys(event sdk.FullEventV2) []string {
 	// Compute required filter(s) key for given event
 	var keys []string
+
+	// Every event carrying a workflow run id is of interest for a client watching that run: the run
+	// itself, its jobs, their steps and their results. Read access on the project was checked when the
+	// filter was registered, so no post check is needed.
+	if event.WorkflowRunID != "" {
+		keys = append(keys, sdk.WebsocketV2Filter{
+			Type:          sdk.WebsocketV2FilterTypeProjectRun,
+			ProjectKey:    event.ProjectKey,
+			WorkflowRunID: event.WorkflowRunID,
+		}.Key())
+	}
 
 	// Event that match project-runs filter
 	switch event.Type {

--- a/engine/api/v2_websocket_test.go
+++ b/engine/api/v2_websocket_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func TestWebsocketV2ComputeEventKeys(t *testing.T) {
+	api := &API{}
+
+	runKey := sdk.WebsocketV2Filter{
+		Type:          sdk.WebsocketV2FilterTypeProjectRun,
+		ProjectKey:    "KEY",
+		WorkflowRunID: "run-1",
+	}.Key()
+
+	t.Run("run event matches both the run list and the run itself", func(t *testing.T) {
+		keys := api.websocketV2ComputeEventKeys(sdk.FullEventV2{
+			Type:          sdk.EventRunBuilding,
+			ProjectKey:    "KEY",
+			WorkflowRunID: "run-1",
+		})
+		require.Contains(t, keys, runKey)
+		require.Contains(t, keys, sdk.WebsocketV2Filter{
+			Type:       sdk.WebsocketV2FilterTypeProjectRuns,
+			ProjectKey: "KEY",
+		}.Key())
+	})
+
+	t.Run("job event matches the queue and the run itself", func(t *testing.T) {
+		keys := api.websocketV2ComputeEventKeys(sdk.FullEventV2{
+			Type:          sdk.EventRunJobBuilding,
+			ProjectKey:    "KEY",
+			WorkflowRunID: "run-1",
+			RunJobID:      "job-1",
+		})
+		require.Contains(t, keys, runKey)
+		require.Contains(t, keys, sdk.WebsocketV2Filter{Type: sdk.WebsocketV2FilterTypeQueue}.Key())
+	})
+
+	t.Run("step and result events only match the run itself", func(t *testing.T) {
+		for _, eventType := range []sdk.EventType{sdk.EventRunJobStepUpdated, sdk.EventRunJobRunResultAdded, sdk.EventRunUpdated, sdk.EventRunDeleted} {
+			keys := api.websocketV2ComputeEventKeys(sdk.FullEventV2{
+				Type:          eventType,
+				ProjectKey:    "KEY",
+				WorkflowRunID: "run-1",
+			})
+			require.Equal(t, []string{runKey}, keys, "unexpected keys for event %s", eventType)
+		}
+	})
+
+	t.Run("event without run id does not match a run filter", func(t *testing.T) {
+		keys := api.websocketV2ComputeEventKeys(sdk.FullEventV2{
+			Type:       sdk.EventRepositoryCreated,
+			ProjectKey: "KEY",
+		})
+		require.NotContains(t, keys, runKey)
+	})
+}
+
+func TestWebsocketV2FiltersHasOneKey(t *testing.T) {
+	projectRuns := sdk.WebsocketV2Filter{Type: sdk.WebsocketV2FilterTypeProjectRuns, ProjectKey: "KEY"}
+	projectRun := sdk.WebsocketV2Filter{Type: sdk.WebsocketV2FilterTypeProjectRun, ProjectKey: "KEY", WorkflowRunID: "run-1"}
+	queue := sdk.WebsocketV2Filter{Type: sdk.WebsocketV2FilterTypeQueue}
+
+	t.Run("a run filter allows the event without post check", func(t *testing.T) {
+		found, needPostCheck := webSocketV2Filters{projectRuns, projectRun}.HasOneKey(projectRuns.Key(), projectRun.Key())
+		require.True(t, found)
+		require.False(t, needPostCheck, "the run filter matches, the search of the run list must not be replayed")
+	})
+
+	t.Run("the run list filter alone still needs a post check", func(t *testing.T) {
+		found, needPostCheck := webSocketV2Filters{projectRuns}.HasOneKey(projectRuns.Key(), projectRun.Key())
+		require.True(t, found)
+		require.True(t, needPostCheck)
+	})
+
+	t.Run("the queue filter alone still needs a post check", func(t *testing.T) {
+		found, needPostCheck := webSocketV2Filters{queue}.HasOneKey(queue.Key(), projectRun.Key())
+		require.True(t, found)
+		require.True(t, needPostCheck)
+	})
+
+	t.Run("no filter matches", func(t *testing.T) {
+		found, _ := webSocketV2Filters{queue}.HasOneKey(projectRun.Key())
+		require.False(t, found)
+	})
+}

--- a/engine/api/v2_workflow_run.go
+++ b/engine/api/v2_workflow_run.go
@@ -751,8 +751,19 @@ func (api *API) getWorkflowRunsSearchAllProjectV2Handler() ([]service.RbacChecke
 
 			w.Header().Add("X-Total-Count", fmt.Sprintf("%d", count))
 
-			return service.WriteJSON(w, runs, http.StatusOK)
+			return writeRunsJSON(w, req, runs)
 		}
+}
+
+// Runs are returned without the definition they ran when the caller asked for the summary media
+// type, see sdk.ContentTypeWorkflowRunSummary.
+func writeRunsJSON(w http.ResponseWriter, req *http.Request, runs []sdk.V2WorkflowRun) error {
+	if service.Accepts(req, sdk.ContentTypeWorkflowRunSummary) {
+		for i := range runs {
+			runs[i].WorkflowData = sdk.V2WorkflowRunData{}
+		}
+	}
+	return service.WriteJSON(w, runs, http.StatusOK)
 }
 
 func (api *API) getWorkflowRunsSearchV2Handler() ([]service.RbacChecker, service.Handler) {
@@ -780,7 +791,7 @@ func (api *API) getWorkflowRunsSearchV2Handler() ([]service.RbacChecker, service
 
 			w.Header().Add("X-Total-Count", fmt.Sprintf("%d", count))
 
-			return service.WriteJSON(w, runs, http.StatusOK)
+			return writeRunsJSON(w, req, runs)
 		}
 }
 

--- a/engine/api/v2_workflow_run.go
+++ b/engine/api/v2_workflow_run.go
@@ -106,7 +106,10 @@ func (api *API) getWorkflowRunResultsV2Handler() ([]service.RbacChecker, service
 				}
 			}
 
-			runJobs, err := workflow_v2.LoadRunJobsByRunID(ctx, api.mustDB(), wr.ID, wr.RunAttempt)
+			// The jobs of the attempt asked for, not of the last one: a result belongs to the job that
+			// produced it, so looking for the results of an older attempt among the jobs of the last one
+			// finds nothing.
+			runJobs, err := workflow_v2.LoadRunJobsByRunID(ctx, api.mustDB(), wr.ID, attempt)
 			if err != nil {
 				return err
 			}

--- a/engine/api/v2_workflow_run_engine.go
+++ b/engine/api/v2_workflow_run_engine.go
@@ -523,6 +523,13 @@ func (api *API) workflowRunV2Trigger(ctx context.Context, wrEnqueue sdk.V2Workfl
 		return sdk.WithStack(tx.Commit())
 	}
 
+	// The definition of the run changed while it was running: jobs coming from a template or a matrix
+	// replaced the job that declared them. Send the new definition so that a run view can redraw its
+	// graph instead of waiting for a manual refresh.
+	if runUpdated {
+		event_v2.PublishRunEvent(ctx, api.Cache, sdk.EventRunUpdated, *run, allrunJobsMap, runResults, &wrEnqueue.Initiator)
+	}
+
 	needReEnqueue := hasSkippedOrFailedJob || hasNoStepsJobs || hasTemplatedJob
 	api.endWorkflowV2Trigger(ctx, run, allrunJobsMap, runJobs, runResults, wrEnqueue, needReEnqueue)
 

--- a/engine/api/v2_workflow_run_engine.go
+++ b/engine/api/v2_workflow_run_engine.go
@@ -526,8 +526,11 @@ func (api *API) workflowRunV2Trigger(ctx context.Context, wrEnqueue sdk.V2Workfl
 	// The definition of the run changed while it was running: jobs coming from a template or a matrix
 	// replaced the job that declared them. Send the new definition so that a run view can redraw its
 	// graph instead of waiting for a manual refresh.
+	// The initiator of the enqueue is not passed on purpose: it may carry a user id without the user
+	// itself, which Username() dereferences, and the engine rewriting the definition is not the doing
+	// of whoever enqueued it. The run reports its own initiator.
 	if runUpdated {
-		event_v2.PublishRunEvent(ctx, api.Cache, sdk.EventRunUpdated, *run, allrunJobsMap, runResults, &wrEnqueue.Initiator)
+		event_v2.PublishRunEvent(ctx, api.Cache, sdk.EventRunUpdated, *run, allrunJobsMap, runResults, nil)
 	}
 
 	needReEnqueue := hasSkippedOrFailedJob || hasNoStepsJobs || hasTemplatedJob

--- a/engine/service/http.go
+++ b/engine/service/http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -158,6 +159,17 @@ func WriteMarshal(w http.ResponseWriter, req *http.Request, data interface{}, st
 	}
 
 	return sdk.WithStack(Write(w, bytes.NewReader(body), status, contentType))
+}
+
+// Accepts reports whether the request asks for the given media type in its Accept header.
+func Accepts(r *http.Request, mediaType string) bool {
+	for _, accepted := range strings.Split(r.Header.Get("Accept"), ",") {
+		// Drop the parameters of the media range, "application/json;q=0.9" accepts application/json.
+		if name, _, _ := strings.Cut(accepted, ";"); strings.TrimSpace(name) == mediaType {
+			return true
+		}
+	}
+	return false
 }
 
 // WriteProcessTime writes the duration of the call in the responsewriter

--- a/sdk/event_v2.go
+++ b/sdk/event_v2.go
@@ -22,12 +22,18 @@ const (
 	EventRunJobRunResultAdded   EventType = "RunJobRunResultAdded"
 	EventRunJobRunResultUpdated EventType = "RunJobRunResultUpdated"
 	EventRunJobEnded            EventType = "RunJobEnded"
+	// EventRunJobStepUpdated is sent when a worker reports the progress of the steps of a job. Only
+	// the steps moved, the job status did not change.
+	EventRunJobStepUpdated EventType = "RunJobStepUpdated"
 
 	EventRunCrafted  EventType = "RunCrafted"
 	EventRunBuilding EventType = "RunBuilding"
-	EventRunEnded    EventType = "RunEnded"
-	EventRunRestart  EventType = "RunRestart"
-	EventRunDeleted  EventType = "RunDeleted"
+	// EventRunUpdated is sent when the definition of a running workflow changed, which happens when
+	// jobs coming from a template or a matrix replace the job that declared them.
+	EventRunUpdated EventType = "RunUpdated"
+	EventRunEnded   EventType = "RunEnded"
+	EventRunRestart EventType = "RunRestart"
+	EventRunDeleted EventType = "RunDeleted"
 
 	EventEntityCreated EventType = "EntityCreated"
 	EventEntityUpdated EventType = "EntityUpdated"

--- a/sdk/v2_websocket.go
+++ b/sdk/v2_websocket.go
@@ -11,7 +11,10 @@ const (
 	WebsocketV2FilterTypeProject            WebsocketV2FilterType = "project"
 	WebsocketV2FilterTypeProjectPurgeReport WebsocketV2FilterType = "project-purge-report"
 	WebsocketV2FilterTypeProjectRuns        WebsocketV2FilterType = "project-runs"
-	WebsocketV2FilterTypeQueue              WebsocketV2FilterType = "queue"
+	// WebsocketV2FilterTypeProjectRun receives every event of a single workflow run: the run itself,
+	// its jobs, their steps and their results.
+	WebsocketV2FilterTypeProjectRun WebsocketV2FilterType = "project-run"
+	WebsocketV2FilterTypeQueue      WebsocketV2FilterType = "queue"
 )
 
 func (f WebsocketV2FilterType) IsValid() bool {
@@ -19,6 +22,7 @@ func (f WebsocketV2FilterType) IsValid() bool {
 	case WebsocketV2FilterTypeGlobal,
 		WebsocketV2FilterTypeProject,
 		WebsocketV2FilterTypeProjectRuns,
+		WebsocketV2FilterTypeProjectRun,
 		WebsocketV2FilterTypeProjectPurgeReport,
 		WebsocketV2FilterTypeQueue:
 		return true
@@ -32,6 +36,7 @@ type WebsocketV2Filter struct {
 	Type              WebsocketV2FilterType `json:"type"`
 	ProjectKey        string                `json:"project_key"`
 	ProjectRunsParams string                `json:"project_runs_params"`
+	WorkflowRunID     string                `json:"workflow_run_id"`
 	PurgeReportID     string                `json:"purge_report_id"`
 }
 
@@ -44,6 +49,8 @@ func (f WebsocketV2Filter) Key() string {
 		return fmt.Sprintf("%s-%s-%s", f.Type, f.ProjectKey, f.PurgeReportID)
 	case WebsocketV2FilterTypeProjectRuns:
 		return fmt.Sprintf("%s-%s", f.Type, f.ProjectKey)
+	case WebsocketV2FilterTypeProjectRun:
+		return fmt.Sprintf("%s-%s-%s", f.Type, f.ProjectKey, f.WorkflowRunID)
 	default:
 		return string(f.Type)
 	}
@@ -60,6 +67,10 @@ func (f WebsocketV2Filter) IsValid() error {
 		WebsocketV2FilterTypeProjectRuns:
 		if f.ProjectKey == "" {
 			return NewErrorFrom(ErrWrongRequest, "missing project key")
+		}
+	case WebsocketV2FilterTypeProjectRun:
+		if f.ProjectKey == "" || f.WorkflowRunID == "" {
+			return NewErrorFrom(ErrWrongRequest, "missing project key or workflow run id")
 		}
 	case WebsocketV2FilterTypeProjectPurgeReport:
 		if f.ProjectKey == "" || f.PurgeReportID == "" {

--- a/sdk/v2_workflow_run.go
+++ b/sdk/v2_workflow_run.go
@@ -124,6 +124,14 @@ func (m *WorkflowRunAnnotations) Scan(src interface{}) error {
 	return WrapError(json.Unmarshal(source, m), "cannot unmarshal WorkflowRunAnnotations")
 }
 
+// ContentTypeWorkflowRunSummary is the media type a client asks for, through the Accept header, to
+// receive workflow runs without the definition they ran. A list of runs shows names, statuses and git
+// information; the workflow definition of each of them, with its actions and its worker models,
+// weighs more than all the rest put together and is of no use there.
+// It is not a query parameter because unknown parameters of the run search are read as annotation
+// filters, which would reserve that word for good.
+const ContentTypeWorkflowRunSummary = "application/vnd.cds.workflow-run-summary+json"
+
 type WorkflowRunContext struct {
 	CDS CDSContext        `json:"cds,omitempty" jsonschema_description:"CDS workflow run information and metadata"`
 	Git GitContext        `json:"git,omitempty" jsonschema_description:"Git repository information and commit details"`

--- a/ui/libs/workflow-graph/src/lib/graph.component.ts
+++ b/ui/libs/workflow-graph/src/lib/graph.component.ts
@@ -9,6 +9,7 @@ import {
     HostListener,
     inject,
     Input,
+    OnChanges,
     OnDestroy,
     Output,
     ViewChild,
@@ -33,21 +34,28 @@ export type WorkflowV2JobsGraphOrNodeOrMatrixComponent = GraphStageNodeComponent
     styleUrls: ['./graph.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class GraphComponent implements AfterViewInit, OnDestroy {
+export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
     static maxScale = 15;
     static minScale = 1 / 5;
 
+    /** What the inputs set in the current change detection pass ask for, see applyPendingRender. */
+    private pendingRender: 'none' | 'refresh' | 'draw' = 'none';
+
     @ViewChild('svgGraph', { read: ViewContainerRef }) svgContainer: ViewContainerRef;
 
+    /** Either the yaml of a workflow, or the workflow itself when the caller already holds it. */
     @Input() set workflow(data: any) {
-        // Parse the workflow
         let workflow: V2Workflow;
-        try {
-            workflow = load(data && data !== '' ? data : '{}', <LoadOptions>{
-                onWarning: (e) => { }
-            });
-        } catch (e) {
-            console.error("Invalid workflow:", data, e)
+        if (data && typeof data !== 'string') {
+            workflow = data as V2Workflow;
+        } else {
+            try {
+                workflow = load(data && data !== '' ? data : '{}', <LoadOptions>{
+                    onWarning: (e) => { }
+                });
+            } catch (e) {
+                console.error("Invalid workflow:", data, e)
+            }
         }
 
         this.hasStages = !!workflow && !!workflow.stages;
@@ -99,19 +107,35 @@ export class GraphComponent implements AfterViewInit, OnDestroy {
             this.initHooks();
         }
 
-        this.changeDisplay();
+        this.requestRender('draw');
         this._cd.markForCheck();
     }
 
     _runJobs: Array<V2WorkflowRunJob> = [];
 
     @Input() set runJobs(data: Array<V2WorkflowRunJob>) {
+        const previousShape = GraphComponent.runJobsShape(this._runJobs);
         this._runJobs = data ?? [];
-        if (!this.svgContainer) {
-            return;
-        }
         this.initRunJobs();
-        this.initGraph();
+        // While a run progresses, only the statuses of its jobs change: refresh the nodes in place
+        // instead of laying out and drawing the whole graph again, which would drop the focus, the
+        // hover and the running duration of every node.
+        const sameShape = this.graph && previousShape === GraphComponent.runJobsShape(this._runJobs);
+        this.requestRender(sameShape ? 'refresh' : 'draw');
+    }
+
+    /**
+     * What the run jobs impose on the drawing: which job of the workflow is drawn as a matrix instead
+     * of a single node. A job gaining or losing its run does not move anything, its node has the same
+     * size either way, while a matrix has as many rows as the definition declares variants.
+     */
+    private static runJobsShape(runJobs: Array<V2WorkflowRunJob>): string {
+        return (runJobs ?? [])
+            .filter(j => !!j.matrix)
+            .map(j => j.job_id)
+            .filter((v, i, all) => all.indexOf(v) === i)
+            .sort()
+            .join('|');
     }
 
     _workflowRun: V2WorkflowRun
@@ -119,6 +143,9 @@ export class GraphComponent implements AfterViewInit, OnDestroy {
         this._workflowRun = data;
         this.initHooks();
         this.initGate();
+        // The gates of the run may have been triggered since the graph was drawn.
+        this.requestRender('refresh');
+        this._cd.markForCheck();
     }
 
     @Input() navigationDisabled: boolean = false;
@@ -183,7 +210,38 @@ export class GraphComponent implements AfterViewInit, OnDestroy {
     ngAfterViewInit(): void {
         this.ready = true;
         this._cd.detectChanges();
-        this.changeDisplay();
+        this.pendingRender = 'none';
+        this.initGraph();
+    }
+
+    ngOnChanges(): void {
+        this.applyPendingRender();
+    }
+
+    private requestRender(kind: 'draw' | 'refresh'): void {
+        // Drawing again covers a refresh, the reverse is not true.
+        if (kind === 'draw' || this.pendingRender === 'none') {
+            this.pendingRender = kind;
+        }
+    }
+
+    /**
+     * The workflow, its run and its run jobs are set in the same change detection pass. Acting on each
+     * of them would lay the graph out several times, and would show it once without its runs before
+     * showing it with them, so the work is done once, when all of them have landed.
+     */
+    private applyPendingRender(): void {
+        const pending = this.pendingRender;
+        this.pendingRender = 'none';
+
+        if (!this.ready || !this.svgContainer || pending === 'none') {
+            return;
+        }
+        if (pending === 'draw') {
+            this.initGraph();
+        } else {
+            this.refreshRun();
+        }
     }
 
     @HostListener('window:keydown', ['$event'])
@@ -415,6 +473,16 @@ export class GraphComponent implements AfterViewInit, OnDestroy {
         });
 
         this.computeGraphSummary();
+    }
+
+    /** Push the run data now held by the nodes down to the drawn graph, without redrawing it. */
+    refreshRun(): void {
+        this.initGate();
+        // Selection maps run job ids to nodes, and a restart gives new ids to the same jobs.
+        this.navigationGraph = new NavigationGraph(this.nodes, this.direction);
+        this.graph.refreshRun();
+        this.graph.setRunActive((this._runJobs ?? []).filter(j => V2WorkflowRunJobStatusIsActive(j.status)).length > 0);
+        this._cd.markForCheck();
     }
 
     computeGraphSummary(): void {

--- a/ui/libs/workflow-graph/src/lib/graph.lib.ts
+++ b/ui/libs/workflow-graph/src/lib/graph.lib.ts
@@ -22,6 +22,8 @@ export enum SelectionMode {
 
 export interface InteractiveNode {
     getNodes(): Array<GraphNode>;
+    /** Re-read the run data carried by the node, the graph itself is left untouched. */
+    refreshRun(): void;
     setHighlight(active: boolean, options?: any): void;
     selectNode(navigationKey: string): void;
     activateNode(navigationKey: string): void;
@@ -50,6 +52,7 @@ export class WorkflowV2Graph<T extends InteractiveNode> {
     static margin = 40; // let 40px on top and bottom of the graph
     static marginSubGraph = 20; // let 20px on top and bottom of the sub graph
     static maxOriginScale = 1;
+    static edgeColors = ['color-success', 'color-fail', 'color-inactive'];
 
     nodesComponent = new Map<string, ComponentRef<T>>();
     nodes = new Array<Node>();
@@ -596,6 +599,65 @@ export class WorkflowV2Graph<T extends InteractiveNode> {
 
     setNodeStatus(key: string, status: string): void {
         this.nodeStatus[`node-${key}`] = status;
+    }
+
+    /**
+     * Refresh the graph from the run data now carried by its nodes, without rebuilding it: nodes keep
+     * their component, their DOM and the focus, and the layout is not computed again.
+     * Only valid while the shape of the graph is unchanged, see GraphComponent.runJobs.
+     */
+    refreshRun(): void {
+        this.nodesComponent.forEach(c => c.instance.refreshRun());
+        this.refreshEdgesStatus();
+    }
+
+    /** Recompute the status of the nodes, forks and joins, then recolor the edges accordingly. */
+    private refreshEdgesStatus(): void {
+        this.nodes.forEach(n => {
+            if (n.type === GraphNodeType.Stage || n.type === GraphNodeType.Matrix) {
+                return;
+            }
+            // Same rule as initGraph: only a node holding a run colors the edges leaving it.
+            const node = this.nodesComponent.get(`node-${n.key}`)?.instance.getNodes()[0];
+            if (node?.run) {
+                this.nodeStatus[`node-${n.key}`] = node.run.status;
+            } else {
+                delete this.nodeStatus[`node-${n.key}`];
+            }
+        });
+
+        Object.keys(this.forks).forEach(f => {
+            this.nodeStatus[`fork-${f}`] = this.sumNodesStatus(this.forks[f].parents);
+        });
+        Object.keys(this.joins).forEach(j => {
+            this.nodeStatus[`join-${j}`] = this.sumNodesStatus(this.joins[j].parents);
+        });
+
+        this.applyEdgesColor();
+    }
+
+    private sumNodesStatus(keys: Array<string>): string {
+        const nodes = keys
+            .map(n => this.nodesComponent.get(n)?.instance.getNodes() ?? [])
+            .reduce((p, c) => p.concat(c), []);
+        if (nodes.length === 0) {
+            return null;
+        }
+        return NodeStatus.sum(nodes.map(n => n.run ? n.run.status : null));
+    }
+
+    /** Repaint the rendered edges from the current node statuses, as drawEdges does when drawing. */
+    private applyEdgesColor(): void {
+        if (!this.g) {
+            return;
+        }
+        this.g.selectAll('g.edgePath').each((d: any, index: number, groups: any) => {
+            const group = d3.select(groups[index]);
+            const status = this.nodeStatus[d?.v];
+            const color = status ? this.nodeStatusToColor(status) : '';
+            WorkflowV2Graph.edgeColors.forEach(c => group.classed(c, c === color));
+            group.selectAll('path').attr('style', color ? 'stroke-width: 2px;' : 'stroke: #B5B7BD;stroke-width: 2px;');
+        });
     }
 
     createGNode(name: string, componentRef: ComponentRef<T>, width: number, height: number, options: {}): void {

--- a/ui/libs/workflow-graph/src/lib/node/fork-join-node.components.ts
+++ b/ui/libs/workflow-graph/src/lib/node/fork-join-node.components.ts
@@ -30,6 +30,11 @@ export class GraphForkJoinNodeComponent implements OnInit, InteractiveNode {
         this.status = NodeStatus.sum(this.nodes.map(n => n.run ? n.run.status : null));
     }
 
+    refreshRun(): void {
+        this.status = NodeStatus.sum(this.nodes.map(n => n.run ? n.run.status : null));
+        this._cd.markForCheck();
+    }
+
     getNodes() {
         return this.nodes;
     }

--- a/ui/libs/workflow-graph/src/lib/node/job-node.component.ts
+++ b/ui/libs/workflow-graph/src/lib/node/job-node.component.ts
@@ -80,7 +80,24 @@ export class GraphJobNodeComponent implements OnInit, OnDestroy, InteractiveNode
         if (this.node.job.if) {
             this.conditionTooltip += `\n - if: ${this.node.job.if}`;
         }
+        this.initRun();
+    }
+
+    /** The run of the node changed: recompute what is derived from it, keeping the node in place. */
+    refreshRun(): void {
+        this.initRun();
+    }
+
+    private initRun(): void {
+        if (this.delaySubs) {
+            this.delaySubs.unsubscribe();
+            this.delaySubs = null;
+        }
+        this.warningStep = false;
+        delete this.duration;
         if (!this.node.run) {
+            delete this.dates;
+            this._cd.markForCheck();
             return;
         }
         this.dates = {

--- a/ui/libs/workflow-graph/src/lib/node/matrix-node.component.ts
+++ b/ui/libs/workflow-graph/src/lib/node/matrix-node.component.ts
@@ -82,6 +82,27 @@ export class GraphMatrixNodeComponent implements OnInit, OnDestroy, InteractiveN
     }
 
     ngOnInit(): void {
+        this.initRun();
+    }
+
+    /** The runs of the variants changed: recompute what is derived from them, keeping the node in place. */
+    refreshRun(): void {
+        this.initRun();
+    }
+
+    private initRun(): void {
+        if (this.delaySubs) {
+            this.delaySubs.unsubscribe();
+            this.delaySubs = null;
+        }
+        this.dates = {};
+        this.status = {};
+        this.jobRunIDs = {};
+        this.displayNames = {};
+        this.retries = {};
+        this.warningSteps = {};
+        this.durations = {};
+
         const alls = GraphNode.generateMatrixOptions(this.node.job.strategy.matrix);
         this.keys = alls.map(option => {
             return Array.from(option.keys()).sort().map(key => {

--- a/ui/libs/workflow-graph/src/lib/node/stage-node.component.ts
+++ b/ui/libs/workflow-graph/src/lib/node/stage-node.component.ts
@@ -84,6 +84,10 @@ export class GraphStageNodeComponent implements AfterViewInit, InteractiveNode {
         this.graph.setRunActive(active);
     }
 
+    refreshRun(): void {
+        this.graph?.refreshRun();
+    }
+
     ngAfterViewInit(): void {
         this.ready = true;
         this._cd.detectChanges();

--- a/ui/specs/workflow-run-graph.md
+++ b/ui/specs/workflow-run-graph.md
@@ -17,6 +17,17 @@ The graph is built from the workflow YAML definition and runtime job data:
 3. The graph engine lays out nodes and edges using the **dagre** layout algorithm, then renders them as SVG.
 4. After drawing, the graph auto-centers to fit the viewport. A resize observer re-centers on container changes.
 
+### 1.3 Drawing Again Or Refreshing In Place
+
+Laying out and drawing the graph again replaces every node, which costs the focus, the hover and the
+duration of the running jobs. It is therefore only done when the layout itself would differ: when the
+workflow definition changed, when the direction is toggled, or when a job starts being drawn as a
+matrix. A job merely gaining or losing its run keeps the same node of the same size.
+
+While a run progresses, the graph is refreshed in place instead: each node re-reads the run it
+carries, forks and joins recompute their aggregated status, and the edges are recolored from the
+status of the job they leave. The layout, the viewport and the focus are untouched.
+
 ### 1.2 Layout
 
 The graph layout can be either **horizontal** (left-to-right) or **vertical** (top-to-bottom). Users can toggle the direction; doing so rebuilds the entire graph.
@@ -348,7 +359,71 @@ Job nodes display condition information in tooltips to help users understand exe
 
 ---
 
-## 10 — Source File Reference
+## 10 — Opening A Run
+
+Everything the view shows is keyed by the id of the run, not by anything the run carries, so the run,
+its jobs, its results and its infos are read **at once** and applied **together**. The view is drawn
+once, complete: the graph is laid out a single time, already colored, instead of appearing grey and
+filling in afterwards.
+
+Applying them together is not only about speed. The jobs of a run are matched to the nodes of the
+graph by job name, and two runs of the same workflow share those names: a graph drawn from one run
+while still holding the jobs of another paints its nodes with the statuses of that other run. The
+definition and the jobs are therefore always set in the same breath, and what could not be read is
+shown empty rather than kept from the run being left — that goes for the jobs, the results, the test
+report and the runs of the sidebar when the workflow changes.
+
+The runs listed in the sidebar are the only thing needing the run to be read first, since they are the
+runs of its workflow. They are read afterwards and hold nothing back; their strip keeps its width from
+the first frame so that their arrival does not push the graph sideways, and shows placeholders until
+they land. They are asked for without the definition each of them ran, which weighs more than
+everything else in that answer and is not displayed.
+
+While the run itself is being read, the frame of the view is drawn rather than a blank page, and the
+graph it will hold is left as it was when coming from another run. A spinner only fades in if the wait
+lasts, so a run that arrives quickly never shows one.
+
+---
+
+## 11 — Live Updates
+
+The run view mirrors a run that is still going. It subscribes to the events of that single run — the
+run itself, its jobs, the steps of its jobs and their results — and applies each of them to what it
+already holds, rather than reading everything again on a timer.
+
+| Event | Applied to the view |
+|---|---|
+| Run | Replaces the run: status, attempt, annotations, definition. A status change is announced to screen readers. |
+| Job | Replaces that job, or appends it when seen for the first time. The graph refreshes in place. |
+| Job step | Carries the same job with its steps moved forward: refreshes the open job panel and the warning marker of its node. |
+| Job result | Adds or replaces one result, feeding the results and tests tabs. |
+| Run deleted | Warns that the run does not exist anymore. |
+
+Events of an attempt other than the displayed one are ignored. When the run is restarted from
+somewhere else, the view follows the new attempt, unless the user was deliberately looking at a
+previous one.
+
+**What events do not carry.** Run infos and job infos are not published as events: they are read again
+when the run or one of its jobs changes state, and at most once per interval for a job going through
+many steps.
+
+**Definition changing mid-run.** A job coming from a template or a matrix is replaced, while the run
+is going, by the jobs it declares. The API sends the new definition of the run, and the view also
+reads the run again whenever a job event names a job that its definition does not know. Either way
+the graph is drawn again from the new definition, without closing the panel that is open.
+
+**Safety nets**, since an event can always be missed:
+- Events sent while the websocket was closed are lost: everything is read again when it opens.
+- A background tab has its timers throttled and its frames delayed: everything is read again when it
+  becomes visible again.
+- While the run is active, a low-frequency refresh reads everything again.
+- Events are not ordered on the wire: an event older than the last one applied to the same subject is
+  dropped.
+- When the run ends, everything is read one last time.
+
+---
+
+## 11 — Source File Reference
 
 | Area | Key files |
 |---|---|

--- a/ui/src/app/event-v2.service.ts
+++ b/ui/src/app/event-v2.service.ts
@@ -6,6 +6,7 @@ import { WebsocketV2Event, WebsocketV2Filter, WebsocketV2FilterType } from './mo
 import { Store } from '@ngxs/store';
 import { AddEventV2 } from './store/event-v2.action';
 import { NzMessageService } from 'ng-zorro-antd/message';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable()
 export class EventV2Service {
@@ -13,6 +14,7 @@ export class EventV2Service {
     websocket: WebSocketSubject<any>;
     currentFilters: Array<WebsocketV2Filter>;
     private connected: boolean;
+    private _connected = new BehaviorSubject<boolean>(false);
 
     constructor(
         private _router: Router,
@@ -20,9 +22,25 @@ export class EventV2Service {
         private _store: Store
     ) { }
 
+    /**
+     * Emits whenever the websocket opens or closes. Events sent while it was closed are lost, so a
+     * view that mirrors a state through events has to refresh itself when it opens again.
+     */
+    get connected$(): Observable<boolean> {
+        return this._connected.asObservable();
+    }
+
     stopWebsocket() {
         if (this.websocket) {
             this.websocket.complete();
+        }
+        this.setConnected(false);
+    }
+
+    private setConnected(connected: boolean): void {
+        this.connected = connected;
+        if (this._connected.value !== connected) {
+            this._connected.next(connected);
         }
     }
 
@@ -36,11 +54,16 @@ export class EventV2Service {
             openObserver: {
                 next: value => {
                     if (value.type === 'open') {
-                        this.connected = true;
                         if (this.currentFilters) {
                             this.websocket.next(this.currentFilters);
                         }
+                        this.setConnected(true);
                     }
+                }
+            },
+            closeObserver: {
+                next: () => {
+                    this.setConnected(false);
                 }
             }
         });
@@ -56,9 +79,11 @@ export class EventV2Service {
                     return ok;
                 }),
                 concatMap((message: WebsocketV2Event) => this._store.dispatch(new AddEventV2(message.event))),
-            ).subscribe((e) => { console.log(e) }, (err) => {
+            ).subscribe(() => { }, (err) => {
+                this.setConnected(false);
                 console.error('Error: ', err);
             }, () => {
+                this.setConnected(false);
                 console.warn('Websocket Completed');
             });
     }

--- a/ui/src/app/model/event-v2.model.ts
+++ b/ui/src/app/model/event-v2.model.ts
@@ -1,10 +1,23 @@
 export enum EventV2Type {
 	EventRunCrafted = "RunCrafted",
 	EventRunBuilding = "RunBuilding",
+	EventRunUpdated = "RunUpdated",
 	EventRunEnded = "RunEnded",
 	EventRunRestart = "RunRestart",
+	EventRunDeleted = "RunDeleted",
 
 	EventRunJobEnqueued = "RunJobEnqueued",
+	EventRunJobBlocked = "RunJobBlocked",
+	EventRunJobCancelled = "RunJobCancelled",
+	EventRunJobSkipped = "RunJobSkipped",
+	EventRunJobStopped = "RunJobStopped",
+	EventRunJobScheduled = "RunJobScheduled",
+	EventRunJobBuilding = "RunJobBuilding",
+	EventRunJobManualTriggered = "RunJobManualTriggered",
+	EventRunJobStepUpdated = "RunJobStepUpdated",
+	EventRunJobEnded = "RunJobEnded",
+	EventRunJobRunResultAdded = "RunJobRunResultAdded",
+	EventRunJobRunResultUpdated = "RunJobRunResultUpdated",
 
 	EventProjectPurge = "EventProjectPurge",
 

--- a/ui/src/app/model/websocket-v2.ts
+++ b/ui/src/app/model/websocket-v2.ts
@@ -4,6 +4,8 @@ export enum WebsocketV2FilterType {
     GLOBAL = 'global',
     PROJECT = 'project',
     PROJECT_RUNS = 'project-runs',
+    // Every event of a single workflow run: the run itself, its jobs, their steps and their results.
+    PROJECT_RUN = 'project-run',
     PROJECT_PURGE_REPORT = 'project-purge-report',
     QUEUE = 'queue'
 }
@@ -12,6 +14,7 @@ export class WebsocketV2Filter {
     type: WebsocketV2FilterType;
     project_key: string;
     project_runs_params: string;
+    workflow_run_id: string;
     purge_report_id: string;
 }
 

--- a/ui/src/app/service/project/project.service.ts
+++ b/ui/src/app/service/project/project.service.ts
@@ -5,8 +5,8 @@ import { ProjectIntegration } from 'app/model/integration.model';
 import { Schema } from 'app/model/json-schema.model';
 import { Key } from 'app/model/keys.model';
 import { LoadOpts, Project, ProjectRepository, RepositoryHookEvent } from 'app/model/project.model';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
 import { RepositoryAnalysis } from "../../model/analysis.model";
 import { Branch, Tag } from "../../model/repositories.model";
 import { Entity, EntityType } from "../../model/entity.model";
@@ -14,6 +14,8 @@ import { VCSProject } from 'app/model/vcs.model';
 
 @Injectable()
 export class ProjectService {
+
+    private _jsonSchemas: { [type: string]: Observable<Schema> } = {};
 
     constructor(
         private _http: HttpClient
@@ -159,9 +161,22 @@ export class ProjectService {
         return this._http.get<Entity>(`/v2/project/${key}/vcs/${vcsName}/repository/${encodedRepo}/entities/${entityType}/${entityName}`, { params });
     }
 
+    /**
+     * The schema of an entity type is the same for the whole session: the API builds it from every
+     * action, worker model and region the user can reach. It is read once rather than on every entity
+     * opened, a failed read being forgotten so the next one tries again.
+     */
     getJSONSchema(type: string): Observable<Schema> {
-        return this._http.get<Schema>(`/v2/jsonschema/${type}`).pipe(
-            map(s => Object.assign(new Schema(), s))
-        );
+        if (!this._jsonSchemas[type]) {
+            this._jsonSchemas[type] = this._http.get<Schema>(`/v2/jsonschema/${type}`).pipe(
+                map(s => Object.assign(new Schema(), s)),
+                catchError(e => {
+                    delete this._jsonSchemas[type];
+                    return throwError(() => e);
+                }),
+                shareReplay(1)
+            );
+        }
+        return this._jsonSchemas[type];
     }
 }

--- a/ui/src/app/service/workflowv2/workflow.service.ts
+++ b/ui/src/app/service/workflowv2/workflow.service.ts
@@ -1,8 +1,15 @@
 import { inject, Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient, HttpHeaders, HttpParams } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunTriggerJobsRequest, V2WorkflowRunManualRequest, V2WorkflowRunManualResponse, WorkflowRunInfo, WorkflowRunResult } from "../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
 import { CDNLogLink, CDNLogLinks } from "app/model/cdn.model";
+
+/**
+ * Asks a run search for runs without the definition they ran. A list shows numbers, statuses and git
+ * information; the definition of the workflow each run ran weighs more than all the rest put together
+ * and none of it is displayed there.
+ */
+export const RUN_SUMMARY_HEADERS = new HttpHeaders({ Accept: 'application/vnd.cds.workflow-run-summary+json' });
 
 @Injectable()
 export class V2WorkflowRunService {
@@ -29,24 +36,26 @@ export class V2WorkflowRunService {
         return this._http.post(`/v2/project/${projKey}/run/${workflowRunID}/job/${jobRunID}/stop`, null);
     }
 
-    getJobs(r: V2WorkflowRun, attempt: number = null): Observable<Array<V2WorkflowRunJob>> {
+    // Keyed by ids rather than by the run itself: the jobs, the results and the infos of a run can
+    // then be read at the same time as the run, instead of waiting for it.
+    getJobs(projKey: string, workflowRunID: string, attempt: number = null): Observable<Array<V2WorkflowRunJob>> {
         let params = new HttpParams();
         if (attempt) {
             params = params.append('attempt', attempt);
         }
-        return this._http.get<Array<V2WorkflowRunJob>>(`/v2/project/${r.project_key}/run/${r.id}/job`, { params });
+        return this._http.get<Array<V2WorkflowRunJob>>(`/v2/project/${projKey}/run/${workflowRunID}/job`, { params });
     }
 
-    getResults(r: V2WorkflowRun, attempt: number = null): Observable<Array<WorkflowRunResult>> {
+    getResults(projKey: string, workflowRunID: string, attempt: number = null): Observable<Array<WorkflowRunResult>> {
         let params = new HttpParams();
         if (attempt) {
             params = params.append('attempt', attempt);
         }
-        return this._http.get<Array<WorkflowRunResult>>(`/v2/project/${r.project_key}/run/${r.id}/result`, { params });
+        return this._http.get<Array<WorkflowRunResult>>(`/v2/project/${projKey}/run/${workflowRunID}/result`, { params });
     }
 
-    getRunInfos(r: V2WorkflowRun): Observable<Array<WorkflowRunInfo>> {
-        return this._http.get<Array<WorkflowRunInfo>>(`/v2/project/${r.project_key}/run/${r.id}/infos`);
+    getRunInfos(projKey: string, workflowRunID: string): Observable<Array<WorkflowRunInfo>> {
+        return this._http.get<Array<WorkflowRunInfo>>(`/v2/project/${projKey}/run/${workflowRunID}/infos`);
     }
 
     getRunJobInfos(r: V2WorkflowRun, jobRunID: string): Observable<Array<WorkflowRunInfo>> {

--- a/ui/src/app/views/projectv2/explore/explore-entity.component.ts
+++ b/ui/src/app/views/projectv2/explore/explore-entity.component.ts
@@ -119,20 +119,26 @@ export class ProjectV2ExploreEntityComponent implements OnInit, OnDestroy {
 		this._cd.markForCheck();
 
 		try {
+			// The entity is keyed by the names the url carries, not by what the vcs and the repository
+			// answer: all four are read at once rather than the entity after the others.
 			const results = await Promise.all([
 				lastValueFrom(this._projectService.getVCSProject(this.projectKey, vcsName)),
 				lastValueFrom(this._projectService.getVCSRepository(this.projectKey, vcsName, repoName)),
-				lastValueFrom(this._projectService.getJSONSchema(entityType))
+				lastValueFrom(this._projectService.getJSONSchema(entityType)),
+				lastValueFrom(this._projectService.getRepoEntity(this.projectKey, vcsName, repoName, entityType, entityName, this.currentRef))
 			]);
 			this.vcs = results[0];
 			this.repository = results[1];
 			this.jsonSchema = results[2];
-			this.entity = await lastValueFrom(this._projectService.getRepoEntity(this.projectKey, this.vcs.name, this.repository.name, entityType, entityName, this.currentRef));
+			this.entity = results[3];
 			this.showWorkflowPreview = false;
 			if (this.entity.type === EntityType.Workflow) {
 				const wkf = load(this.entity.data);
 				this.showWorkflowPreview = !wkf['from'];
 			}
+			// The editor outlives the entity it shows, so the schema of its type is applied on every
+			// load and not only when the editor is built.
+			this.applyJsonSchema();
 		} catch (e: any) {
 			this._messageService.error(`Unable to load entity: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
 			this._router.navigate(['/project', this.projectKey, 'explore', 'vcs', vcsName, 'repository', repoName]);
@@ -143,12 +149,7 @@ export class ProjectV2ExploreEntityComponent implements OnInit, OnDestroy {
 	}
 
 	onEditorInit(e: editor.ICodeEditor | editor.IEditor): void {
-		monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-			schemas: [{
-				uri: '',
-				schema: JSONSchema.flat(this.jsonSchema)
-			}]
-		});
+		this.applyJsonSchema();
 		this._editorInstance = <editor.ICodeEditor>e;
 		// The editor is destroyed and rebuilt on every entity load, so the collection
 		// has to be rebound; the previous one belongs to a discarded editor.
@@ -185,6 +186,18 @@ export class ProjectV2ExploreEntityComponent implements OnInit, OnDestroy {
 			'repository', path.repository ?? this.repository.name,
 			EntityTypeUtil.toURLParam(entityType), path.name
 		], ref ? { queryParams: { ref } } : {});
+	}
+
+	private applyJsonSchema(): void {
+		if (!this.jsonSchema || typeof monaco === 'undefined') {
+			return;
+		}
+		monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+			schemas: [{
+				uri: '',
+				schema: JSONSchema.flat(this.jsonSchema)
+			}]
+		});
 	}
 
 	private applyDecorations(): void {

--- a/ui/src/app/views/projectv2/explore/explore-entity.html
+++ b/ui/src/app/views/projectv2/explore/explore-entity.html
@@ -1,9 +1,11 @@
-@if (loading) {
+@if (loading && !entity) {
   <nz-spin nzTip="Loading entity"></nz-spin>
 }
 
-@if (entity && !loading) {
-  <div class="content">
+@if (entity) {
+  <!-- The editor stays mounted while the next entity is read: building monaco again for each of them
+       is what made opening one slow. -->
+  <div class="content" [class.loading]="loading">
     <div class="leftPanel">
       <nz-tabs nzType="card" nzSize="small">
         <nz-tab [nzTitle]="entity.type + ' ' + entity.file_path"></nz-tab>

--- a/ui/src/app/views/projectv2/explore/explore-entity.scss
+++ b/ui/src/app/views/projectv2/explore/explore-entity.scss
@@ -9,6 +9,13 @@ nz-spin {
   width: 100%;
   overflow: hidden;
 
+  // The entity being left stays visible while the next one is read. It only dims if that read takes
+  // a moment, and comes back at once.
+  &.loading {
+    opacity: 0.55;
+    transition: opacity 150ms ease-out 250ms;
+  }
+
   .leftPanel {
     flex: 1;
     display: flex;

--- a/ui/src/app/views/projectv2/explore/explore-repository.component.ts
+++ b/ui/src/app/views/projectv2/explore/explore-repository.component.ts
@@ -58,14 +58,19 @@ export class ProjectV2ExploreRepositoryComponent implements OnDestroy {
             if (this.vcsProject?.name === p['vcsName'] && this.repository?.name === p['repoName']) {
                 return;
             }
+            // The events of a repository are keyed by the names the url carries: they are read at the
+            // same time as the repository and the vcs rather than after them.
+            this.loadingHooks = true;
             forkJoin([
                 this._projectService.getVCSRepository(this.project.key, p['vcsName'], p['repoName']),
-                this._projectService.getVCSProject(this.project.key, p['vcsName'])
+                this._projectService.getVCSProject(this.project.key, p['vcsName']),
+                this._projectService.listRepositoryEvents(this.project.key, p['vcsName'], p['repoName'])
             ]).subscribe(result => {
                 this.repository = result[0];
                 this.vcsProject = result[1];
+                this.applyHookEvents(result[2]);
+                this.loadingHooks = false;
                 this._cd.markForCheck();
-                this.loadHookEvents();
             });
         });
     }
@@ -76,7 +81,14 @@ export class ProjectV2ExploreRepositoryComponent implements OnDestroy {
         this.loadingHooks = true;
         this._cd.markForCheck();
 
-        this.hookEvents = await lastValueFrom(this._projectService.listRepositoryEvents(this.project.key, this.vcsProject.name, this.repository.name));
+        this.applyHookEvents(await lastValueFrom(this._projectService.listRepositoryEvents(this.project.key, this.vcsProject.name, this.repository.name)));
+
+        this.loadingHooks = false;
+        this._cd.markForCheck();
+    }
+
+    private applyHookEvents(hookEvents: Array<RepositoryHookEvent>) {
+        this.hookEvents = hookEvents;
         (this.hookEvents ?? []).forEach(he => {
             he.created_string = new Date(he.created / 1000000).toJSON();
             if (he.workflows) {
@@ -87,9 +99,6 @@ export class ProjectV2ExploreRepositoryComponent implements OnDestroy {
                 he.nbScheduled = workflowInProject.filter(w => w.status === HookEventWorkflowStatus.Scheduled).length;
             }
         });
-
-        this.loadingHooks = false;
-        this._cd.markForCheck();
     }
 
     async removeRepositoryFromProject() {

--- a/ui/src/app/views/projectv2/explore/explore-sidebar.component.ts
+++ b/ui/src/app/views/projectv2/explore/explore-sidebar.component.ts
@@ -40,6 +40,21 @@ import { ProjectV2TriggerAnalysisComponent, ProjectV2TriggerAnalysisComponentPar
 })
 @AutoUnsubscribe()
 export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, AfterViewInit {
+    /**
+     * The tree of the last project explored. The view is rebuilt from scratch every time it is opened,
+     * and reading a repository goes through the vcs provider: without this, coming back to it means
+     * waiting for the whole tree again. Kept on the class, since it must outlive the component, and
+     * for one project only, the one being explored.
+     */
+    private static snapshot: {
+        projectKey: string;
+        vcss: Array<VCSProject>;
+        repositories: { [vcs: string]: Array<ProjectRepository> };
+        entities: { [repositoryPath: string]: Map<EntityType, Array<Entity>> };
+        branches: { [repositoryPath: string]: Array<Branch> };
+        tags: { [repositoryPath: string]: Array<Tag> };
+    };
+
     @Input() project: Project;
 
     loading: boolean = true;
@@ -70,6 +85,17 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
     ngOnInit(): void {
         this.treeExpandState = this._store.selectSnapshot(PreferencesState.selectProjectTreeExpandState(this.project.key));
         this.refSelectState = this._store.selectSnapshot(PreferencesState.selectProjectRefSelectState(this.project.key));
+
+        // Coming back to the explore view draws the tree it was left with at once, then reads it
+        // again in the background rather than showing nothing until every repository has answered.
+        const snapshot = ProjectV2ExploreSidebarComponent.snapshot;
+        if (snapshot && snapshot.projectKey === this.project.key) {
+            this.vcss = snapshot.vcss;
+            this.repositories = snapshot.repositories;
+            this.entities = snapshot.entities;
+            this.branches = snapshot.branches;
+            this.tags = snapshot.tags;
+        }
 
         this.load();
 
@@ -102,9 +128,16 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
                     this.treeExpandState[vcs.name] = true;
                 }
             });
+            this._cd.markForCheck();
             await this.loadRepositories();
-            const params = this._routerService.getRouteSnapshotParams({}, this._router.routerState.snapshot.root);
-            await this.expandTreeToSelectedRoute(params);
+            ProjectV2ExploreSidebarComponent.snapshot = {
+                projectKey: this.project.key,
+                vcss: this.vcss,
+                repositories: this.repositories,
+                entities: this.entities,
+                branches: this.branches,
+                tags: this.tags
+            };
         } catch (e: any) {
             this._messageService.error(`Unable to load vcs and repositories: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
@@ -119,34 +152,65 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
         this.vcss.forEach((vcs, i) => {
             this.repositories[vcs.name] = resp[i];
         });
-        // Async load each repository expanded
-        let promises = [];
-        this.vcss.forEach((vcs, i) => {
-            this.repositories[vcs.name].forEach(repo => {
-                if (this.treeExpandState[vcs.name + '/' + repo.name]) {
-                    promises.push(this.loadRepository(vcs, repo));
-                }
-            });
-        });
-        await Promise.all(promises);
+        // The repositories are shown as soon as they are known, without waiting for their content.
+        this._cd.markForCheck();
+
+        // What the url points at is expanded before reading anything, so that its repository joins
+        // the batch instead of being read once every other one has answered.
+        this.expandToRoute(this._routerService.getRouteSnapshotParams({}, this._router.routerState.snapshot.root));
+
+        await Promise.all(this.vcss.flatMap(vcs => (this.repositories[vcs.name] ?? [])
+            .filter(repo => this.treeExpandState[vcs.name + '/' + repo.name])
+            .map(repo => this.loadRepository(vcs, repo))));
     }
 
     async loadRepository(vcs: VCSProject, repo: ProjectRepository) {
+        const key = vcs.name + '/' + repo.name;
+
+        // Nothing to show for that repository yet: without this, the tree announces "No resource
+        // found" until its entities answer. A repository that already shows some is refreshed
+        // silently, keeping them.
+        if (!this.entities[key]) {
+            this.loadingEntities[key] = true;
+            this._cd.markForCheck();
+        }
+
         try {
-            const branches = await lastValueFrom(this._projectService.getVCSRepositoryBranches(this.project.key, vcs.name, repo.name, 50));
-            this.branches[vcs.name + '/' + repo.name] = branches;
-            const tags = await lastValueFrom(this._projectService.getVCSRepositoryTags(this.project.key, vcs.name, repo.name));
-            this.tags[vcs.name + '/' + repo.name] = tags;
-            if (!this.refSelectState[vcs.name + '/' + repo.name] || (
-                !branches.find(b => 'refs/heads/' + b.display_id === this.refSelectState[vcs.name + '/' + repo.name])
-                && !tags.find(t => 'refs/tags/' + t.tag === this.refSelectState[vcs.name + '/' + repo.name])
-            )) {
-                this.refSelectState[vcs.name + '/' + repo.name] = 'refs/heads/' + branches.find(b => b.default).display_id;
+            // The entities of a ref only need that ref. With one already selected, they are read at
+            // the same time as the branches and the tags of the repository, which come from the vcs
+            // provider and are the slowest of the three, instead of after them.
+            const selectedRef = this.refSelectState[key];
+            const entitiesOfSelectedRef = selectedRef
+                ? lastValueFrom(this._projectService.getRepoEntities(this.project.key, vcs.name, repo.name, selectedRef)).catch(() => null)
+                : null;
+
+            const [branches, tags] = await Promise.all([
+                lastValueFrom(this._projectService.getVCSRepositoryBranches(this.project.key, vcs.name, repo.name, 50)),
+                lastValueFrom(this._projectService.getVCSRepositoryTags(this.project.key, vcs.name, repo.name))
+            ]);
+            this.branches[key] = branches;
+            this.tags[key] = tags;
+
+            const refExists = !!selectedRef && (
+                !!branches.find(b => 'refs/heads/' + b.display_id === selectedRef)
+                || !!tags.find(t => 'refs/tags/' + t.tag === selectedRef)
+            );
+            if (!refExists) {
+                this.refSelectState[key] = 'refs/heads/' + branches.find(b => b.default).display_id;
             }
-            await this.loadEntities(vcs, repo);
+
+            // The ref that was selected is gone: what was read for it is dropped and the default
+            // branch is read instead.
+            const entities = (refExists ? await entitiesOfSelectedRef : null)
+                ?? await lastValueFrom(this._projectService.getRepoEntities(this.project.key, vcs.name, repo.name, this.refSelectState[key]));
+            this.applyEntities(vcs, repo, entities);
         } catch (e: any) {
             this._messageService.error(`Unable to load repository: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
         }
+
+        // Each repository shows up as it answers, rather than all of them once the slowest has.
+        this.loadingEntities[key] = false;
+        this._cd.markForCheck();
     }
 
     clickVCS(vcs: VCSProject): void {
@@ -189,6 +253,10 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
 
     async loadEntities(vcs: VCSProject, repo: ProjectRepository) {
         const resp = await lastValueFrom(this._projectService.getRepoEntities(this.project.key, vcs.name, repo.name, this.refSelectState[vcs.name + '/' + repo.name]));
+        this.applyEntities(vcs, repo, resp);
+    }
+
+    private applyEntities(vcs: VCSProject, repo: ProjectRepository, resp: Array<Entity>) {
         if (resp.length === 0) {
             this.entities[vcs.name + '/' + repo.name] = null;
             return
@@ -303,36 +371,49 @@ export class ProjectV2ExploreSidebarComponent implements OnInit, OnDestroy, Afte
     }
 
     async expandTreeToSelectedRoute(params: any) {
-        if (!params['vcsName'] || this.vcss.findIndex(vcs => vcs.name === params['vcsName']) < 0) {
-            return;
+        const target = this.expandToRoute(params);
+        if (target?.read) {
+            await this.loadRepository(target.vcs, target.repo);
         }
+    }
+
+    /**
+     * Expands the branch of the tree the url points at, reading nothing. Tells whether the content of
+     * the repository it names has to be read, so that the caller can decide when.
+     */
+    private expandToRoute(params: any): { vcs: VCSProject, repo: ProjectRepository, read: boolean } {
         const vcs = this.vcss.find(vcs => vcs.name === params['vcsName']);
-        this.treeExpandState[vcs.name] = true;
-        if (!params['repoName'] || this.repositories[vcs.name].findIndex(repo => repo.name === params['repoName']) < 0) {
-            return;
+        if (!vcs) {
+            return null;
         }
-        let loadRepo = false;
-        const repo = this.repositories[vcs.name].find(repo => repo.name === params['repoName'])
-        if (!this.treeExpandState[vcs.name + '/' + repo.name]) {
-            this.treeExpandState[vcs.name + '/' + repo.name] = true;
-            loadRepo = true;
+        this.treeExpandState[vcs.name] = true;
+
+        const repo = (this.repositories[vcs.name] ?? []).find(repo => repo.name === params['repoName']);
+        if (!repo) {
+            return null;
+        }
+        const key = vcs.name + '/' + repo.name;
+
+        let read = false;
+        if (!this.treeExpandState[key]) {
+            this.treeExpandState[key] = true;
+            read = true;
         }
         const ref = this._activatedRoute.snapshot.queryParams['ref'];
-        if (ref && this.refSelectState[vcs.name + '/' + repo.name] !== ref) {
-            this.refSelectState[vcs.name + '/' + repo.name] = ref;
-            loadRepo = true;
+        if (ref && this.refSelectState[key] !== ref) {
+            this.refSelectState[key] = ref;
+            read = true;
         }
-        if (loadRepo) {
-            await this.loadRepository(vcs, repo);
-        }
+
         if (params['entityType']) {
             try {
-                const entityType = EntityTypeUtil.fromURLParam(params['entityType']);
-                this.treeExpandState[vcs.name + '/' + repo.name + '/' + entityType] = true;
+                this.treeExpandState[key + '/' + EntityTypeUtil.fromURLParam(params['entityType'])] = true;
             } catch (e) {
                 // URL carries an unknown entity type, nothing to expand
             }
         }
+
+        return { vcs, repo, read };
     }
 
     saveRefSelectState(): void {

--- a/ui/src/app/views/projectv2/explore/explore-sidebar.html
+++ b/ui/src/app/views/projectv2/explore/explore-sidebar.html
@@ -12,7 +12,7 @@
   </button>
 </div>
 <div class="content">
-  @for (vcs of vcss; track vcs) {
+  @for (vcs of vcss; track vcs.name) {
     <div class="tree-node-header large" appClickable [attr.aria-expanded]="!!treeExpandState[vcs.name]" (click)="clickVCS(vcs)">
       <span nz-icon [nzType]="!treeExpandState[vcs.name] ? 'caret-right' : 'caret-down'" nzTheme="fill" aria-hidden="true"></span>
       <div class="name">{{vcs.name}}</div>
@@ -28,7 +28,7 @@
           <nz-alert nzType="info"
           nzMessage="No repository found"></nz-alert>
         }
-        @for (repo of repositories[vcs.name]; track repo) {
+        @for (repo of repositories[vcs.name]; track repo.name) {
           <div class="tree-node-header large" appClickable [attr.aria-expanded]="!!treeExpandState[vcs.name+'/'+repo.name]" (click)="clickRepository(vcs, repo)">
             <span nz-icon [nzType]="!treeExpandState[vcs.name+'/'+repo.name] ? 'caret-right' : 'caret-down'"
             nzTheme="fill" aria-hidden="true"></span>
@@ -60,7 +60,7 @@
               @if (loadingEntities[vcs.name+'/'+repo.name]) {
                 <nz-spin nzSimple></nz-spin>
               }
-              @for (entity of entities[vcs.name+'/'+repo.name] | keyvalue; track entity) {
+              @for (entity of entities[vcs.name+'/'+repo.name] | keyvalue; track entity.key) {
                 <div class="tree-node-header" appClickable [attr.aria-expanded]="!!treeExpandState[vcs.name+'/'+repo.name+'/'+entity.key]" (click)="clickEntityType(vcs, repo, entity.key)">
                   <span nz-icon
                     [nzType]="!treeExpandState[vcs.name+'/'+repo.name+'/'+entity.key] ? 'folder' : 'folder-open'"
@@ -69,7 +69,7 @@
                 </div>
                 @if (treeExpandState[vcs.name+'/'+repo.name+'/'+entity.key]) {
                   <div class="tree-node-content">
-                    @for (v of entity.value; track v) {
+                    @for (v of entity.value; track v.name) {
                       <div class="tree-node-header">
                         <a class="name"
                           [routerLink]="['/project', project.key, 'explore', 'vcs', vcs.name, 'repository', repo.name, v.type.toLowerCase(), v.name]"

--- a/ui/src/app/views/projectv2/run-list/run-list.component.ts
+++ b/ui/src/app/views/projectv2/run-list/run-list.component.ts
@@ -22,6 +22,7 @@ import { ProjectV2State } from "app/store/project-v2.state";
 import { Filter, FilterText } from "../../../shared/input/input-filter.component";
 import { Clipboard } from '@angular/cdk/clipboard';
 import { SearchService } from "app/service/search.service";
+import { RUN_SUMMARY_HEADERS } from "app/service/workflowv2/workflow.service";
 import { SearchResultType } from "app/model/search.model";
 import { DisplaySearchResult } from "app/views/search/search.component";
 import { WorkflowNameComponent } from "app/shared/workflow-name/workflow-name.component";
@@ -166,7 +167,11 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 		});
 
 		try {
-			const res = await lastValueFrom(this._http.get(`/v2/project/${this.project.key}/run`, { params, observe: 'response' })
+			const res = await lastValueFrom(this._http.get(`/v2/project/${this.project.key}/run`, {
+				params,
+				headers: RUN_SUMMARY_HEADERS,
+				observe: 'response'
+			})
 				.pipe(map(res => {
 					let headers: HttpHeaders = res.headers;
 					return {

--- a/ui/src/app/views/projectv2/run/run-job.component.ts
+++ b/ui/src/app/views/projectv2/run/run-job.component.ts
@@ -14,8 +14,8 @@ import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { DisplayMode, ScrollTarget } from "../../workflow/run/node/pipeline/workflow-run-job/workflow-run-job.component";
 import { PipelineStatus } from "app/model/pipeline.model";
 import { V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
-import { concatMap, delay, from, interval, lastValueFrom, retryWhen, Subscription } from "rxjs";
-import { StepStatus, V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunJobStatusIsTerminated, WorkflowRunInfo } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
+import { delay, lastValueFrom, retryWhen, Subscription } from "rxjs";
+import { StepStatus, V2WorkflowRun, V2WorkflowRunJob, WorkflowRunInfo } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
 import { DurationService } from "../../../../../libs/workflow-graph/src/lib/duration.service";
 import moment from "moment";
 import { NzMessageService } from "ng-zorro-antd/message";
@@ -73,10 +73,12 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     @Input() workflowRun: V2WorkflowRun
     @Input() jobRun: V2WorkflowRunJob;
 
+    /** Run infos are not carried by the events of the run, they are read again at most that often. */
+    static INFOS_REFRESH_DELAY = 5000;
+
     mode = DisplayMode.ANSI;
     tabs: Array<Tab> = [];
     currentTabIndex = 0;
-    pollRunJobInfosSubs: Subscription;
     websocket: WebSocketSubject<any>;
     websocketSubscription: Subscription;
     jobRunInfos: Array<WorkflowRunInfo> = [];
@@ -85,6 +87,9 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     jobRetries: Array<V2WorkflowRunJob>;
     selectedJobRetry: V2WorkflowRunJob;
     selectedRetry: number = 0;
+
+    private infosRefreshedAt: number = 0;
+    private infosRefreshTimer: any;
 
     constructor(
         private _cd: ChangeDetectorRef,
@@ -98,6 +103,7 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
 
     ngOnDestroy(): void {
         if (this.websocket) { this.stopStreamingLogsForJob(); }
+        this.cancelInfosRefresh();
     }
 
     ngOnInit(): void {
@@ -112,7 +118,7 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     reset(): void {
         this.tabs = [{ name: 'Job', logBlocks: [new LogBlock('Information')] }];
         this.currentTabIndex = 0;
-        if (this.pollRunJobInfosSubs) { this.pollRunJobInfosSubs.unsubscribe(); }
+        this.cancelInfosRefresh();
         this.stopStreamingLogsForJob();
     }
 
@@ -135,6 +141,8 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
             this._cd.markForCheck();
             await this.setServices();
             this._cd.markForCheck();
+        } else if (jobRunChanged) {
+            this.scheduleInfosRefresh();
         }
         if (isInit || jobRunChanged) {
             await this.setSteps();
@@ -185,22 +193,36 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
         this._cd.markForCheck();
     }
 
+    /**
+     * The job moved: its infos may have been completed. They are read again without exceeding one call
+     * per interval, whatever the number of steps the job goes through in the meantime.
+     */
+    private scheduleInfosRefresh(): void {
+        if (this.infosRefreshTimer) {
+            return;
+        }
+        const delayMs = Math.max(0, RunJobComponent.INFOS_REFRESH_DELAY - (Date.now() - this.infosRefreshedAt));
+        this.infosRefreshTimer = setTimeout(() => {
+            this.infosRefreshTimer = null;
+            this.refreshInfos();
+        }, delayMs);
+    }
+
+    private cancelInfosRefresh(): void {
+        if (this.infosRefreshTimer) {
+            clearTimeout(this.infosRefreshTimer);
+            this.infosRefreshTimer = null;
+        }
+    }
+
     async setInfos() {
+        this.infosRefreshedAt = Date.now();
+
         try {
             this.jobRunInfos = await lastValueFrom(this._workflowRunService.getRunJobInfos(this.workflowRun, this.selectedJobRetry.id));
         } catch (e) {
             this._messageService.error(`Unable to get run job infos: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
             return;
-        }
-
-        if (!V2WorkflowRunJobStatusIsTerminated(this.selectedJobRetry.status) && !this.pollRunJobInfosSubs) {
-            this.pollRunJobInfosSubs = interval(5000)
-                .pipe(concatMap(_ => from(this.refreshInfos())))
-                .subscribe();
-        }
-
-        if (V2WorkflowRunJobStatusIsTerminated(this.selectedJobRetry.status) && this.pollRunJobInfosSubs) {
-            this.pollRunJobInfosSubs.unsubscribe();
         }
 
         this.tabs[0].logBlocks[0].lines = (this.jobRunInfos ?? [])

--- a/ui/src/app/views/projectv2/run/run-job.component.ts
+++ b/ui/src/app/views/projectv2/run/run-job.component.ts
@@ -14,8 +14,8 @@ import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { DisplayMode, ScrollTarget } from "../../workflow/run/node/pipeline/workflow-run-job/workflow-run-job.component";
 import { PipelineStatus } from "app/model/pipeline.model";
 import { V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
-import { delay, lastValueFrom, retryWhen, Subscription } from "rxjs";
-import { StepStatus, V2WorkflowRun, V2WorkflowRunJob, WorkflowRunInfo } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
+import { delay, interval, lastValueFrom, retryWhen, Subscription } from "rxjs";
+import { StepStatus, V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunJobStatus, V2WorkflowRunJobStatusIsTerminated, WorkflowRunInfo } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
 import { DurationService } from "../../../../../libs/workflow-graph/src/lib/duration.service";
 import moment from "moment";
 import { NzMessageService } from "ng-zorro-antd/message";
@@ -32,6 +32,8 @@ export class Tab {
 export class LogBlock {
     id: number;
     name: string;
+    /** The block carrying the infos of the job, which is not a step and has nothing to show without them. */
+    information: boolean;
     lines: Array<CDNLine>;
     endLines: Array<CDNLine>;
     closed: boolean;
@@ -87,6 +89,31 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     jobRetries: Array<V2WorkflowRunJob>;
     selectedJobRetry: V2WorkflowRunJob;
     selectedRetry: number = 0;
+    /**
+     * Whether the panel moves on when the job is retried. It does while showing the last retry, and
+     * stops as soon as an earlier one is picked: someone reading it is not to be moved away from it.
+     */
+    private followLastRetry: boolean = true;
+
+    /** What a job that has not run yet shows in place of logs it does not have. */
+    pending: {
+        label: string;
+        icon: string;
+        since: string;
+    };
+    pendingSubs: Subscription;
+
+    /**
+     * The placeholder only stands as long as the panel has nothing else to show: the infos of the job,
+     * or the first step to report a status, take over as soon as they land.
+     */
+    get showPending(): boolean {
+        if (!this.pending) {
+            return false;
+        }
+        const logBlocks = this.tabs[this.currentTabIndex]?.logBlocks ?? [];
+        return !logBlocks.some(block => !block.information || block.lines.length > 0);
+    }
 
     private infosRefreshedAt: number = 0;
     private infosRefreshTimer: any;
@@ -116,7 +143,9 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     reset(): void {
-        this.tabs = [{ name: 'Job', logBlocks: [new LogBlock('Information')] }];
+        const informations = new LogBlock('Information');
+        informations.information = true;
+        this.tabs = [{ name: 'Job', logBlocks: [informations] }];
         this.currentTabIndex = 0;
         this.cancelInfosRefresh();
         this.stopStreamingLogsForJob();
@@ -126,17 +155,45 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
         const isInit = this.jobRun && !changes;
         const jobRunChanged = !!changes && !!changes.jobRun;
         const jobRunIDChanged = jobRunChanged && changes.jobRun.previousValue && changes.jobRun.previousValue.id !== changes.jobRun.currentValue.id;
-        if (jobRunIDChanged) {
+        const displayedID = this.selectedJobRetry?.id;
+
+        // The panel is handed another run job of the same job: it was retried while being read.
+        const sameJobRetried = jobRunIDChanged && changes.jobRun.previousValue.job_id === changes.jobRun.currentValue.job_id;
+
+        if (jobRunIDChanged && !sameJobRetried) {
             this.reset();
+            // The retry that was selected belongs to the job being left, this one has its own.
+            this.selectedRetry = this.jobRun.retry;
+            this.followLastRetry = true;
+        } else if (sameJobRetried && this.followLastRetry) {
+            this.selectedRetry = this.jobRun.retry;
         }
+
         if (this.jobRun.retry > 0) {
-            await this.getRetry();
-            this.selectedJobRetry = this.jobRetries.find(r => r.retry === this.selectedRetry);
+            // The list holds every retry of the job, it only changes when it is retried again.
+            if (this.jobRetries?.length !== this.jobRun.retry + 1) {
+                await this.getRetry();
+            }
+            // The last retry is the one the run view keeps up to date, the others are done and never
+            // change: taking it from the input rather than from the list is what keeps the steps of a
+            // retried job moving.
+            this.selectedJobRetry = this.selectedRetry === this.jobRun.retry
+                ? this.jobRun
+                : (this.jobRetries.find(r => r.retry === this.selectedRetry) ?? this.jobRun);
             this._cd.markForCheck();
         } else {
             this.selectedJobRetry = this.jobRun;
         }
-        if (isInit || jobRunIDChanged) {
+
+        // Another run job is on screen: another job, or another retry of the same one. Its steps and
+        // its logs are not the ones displayed, and a log block already holding lines is never read
+        // again, so the blocks are dropped rather than reused.
+        const displayedJobChanged = !!displayedID && displayedID !== this.selectedJobRetry?.id;
+        if (displayedJobChanged) {
+            this.reset();
+        }
+
+        if (isInit || jobRunIDChanged || displayedJobChanged) {
             await this.setInfos();
             this._cd.markForCheck();
             await this.setServices();
@@ -144,16 +201,70 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
         } else if (jobRunChanged) {
             this.scheduleInfosRefresh();
         }
-        if (isInit || jobRunChanged) {
+        this.setPending();
+
+        if (isInit || jobRunChanged || displayedJobChanged) {
             await this.setSteps();
             this.computeStepFirstLineNumbers();
             this._cd.markForCheck();
             await this.loadStepsLogs();
         }
-       
 
         this._cd.detectChanges();
         this.autoScroll();
+    }
+
+    /**
+     * A job that has not started has no log to show, and used to open on an empty panel. What it is
+     * waiting for, and for how long, is shown instead.
+     */
+    private setPending(): void {
+        if (this.pendingSubs) {
+            this.pendingSubs.unsubscribe();
+            this.pendingSubs = null;
+        }
+
+        const job = this.selectedJobRetry;
+        if (!job || job.started) {
+            this.pending = null;
+            return;
+        }
+
+        this.pending = { ...RunJobComponent.pendingState(job.status), since: null };
+        // How long it has been waiting only means something while it still is: a job that will never
+        // run is not "queued for three days".
+        if (!V2WorkflowRunJobStatusIsTerminated(job.status)) {
+            this.refreshPendingSince();
+            this.pendingSubs = interval(1000).subscribe(() => this.refreshPendingSince());
+        }
+    }
+
+    private refreshPendingSince(): void {
+        // Hidden behind what the panel has to show: nothing to keep counting.
+        if (!this.showPending || !this.selectedJobRetry?.queued) {
+            return;
+        }
+        this.pending.since = DurationService.duration(new Date(this.selectedJobRetry.queued), new Date());
+        this._cd.markForCheck();
+    }
+
+    private static pendingState(status: V2WorkflowRunJobStatus): { label: string, icon: string } {
+        switch (status) {
+            case V2WorkflowRunJobStatus.Waiting:
+                return { label: 'Waiting for a worker', icon: 'clock-circle' };
+            case V2WorkflowRunJobStatus.Scheduling:
+                return { label: 'A worker is starting', icon: 'loading' };
+            case V2WorkflowRunJobStatus.Blocked:
+                return { label: 'Waiting for its turn', icon: 'pause-circle' };
+            case V2WorkflowRunJobStatus.Skipped:
+                return { label: 'Skipped, it never ran', icon: 'stop' };
+            case V2WorkflowRunJobStatus.Cancelled:
+                return { label: 'Cancelled before it ran', icon: 'close-circle' };
+            case V2WorkflowRunJobStatus.Stopped:
+                return { label: 'Stopped before it ran', icon: 'close-circle' };
+            default:
+                return { label: 'Not started yet', icon: 'clock-circle' };
+        }
     }
 
     async getRetry() {
@@ -274,18 +385,21 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
             }
         }
 
-        const links = await lastValueFrom(this._workflowRunService.getAllLogsLinks(this.workflowRun, this.selectedJobRetry.id));
-        links.datas.forEach((link, i) => {
-            if (this.tabs[0].logBlocks[i + 1]) {
-                this.tabs[0].logBlocks[i + 1].link = link;
-            }
-        });
+        // No step has run: there is no log to link and no line to count.
+        if (this.tabs[0].logBlocks.length > 1) {
+            const links = await lastValueFrom(this._workflowRunService.getAllLogsLinks(this.workflowRun, this.selectedJobRetry.id));
+            links.datas.forEach((link, i) => {
+                if (this.tabs[0].logBlocks[i + 1]) {
+                    this.tabs[0].logBlocks[i + 1].link = link;
+                }
+            });
 
-        const results = await lastValueFrom(this._cdnService.getLogsLinesCount(links, 'job-step-log'));
-        results.forEach(r => {
-            const idx = links?.datas?.findIndex(d => d.api_ref === r.api_ref);
-            this.tabs[0].logBlocks[idx + 1].totalLinesCount = r.lines_count;
-        });
+            const results = await lastValueFrom(this._cdnService.getLogsLinesCount(links, 'job-step-log'));
+            results.forEach(r => {
+                const idx = links?.datas?.findIndex(d => d.api_ref === r.api_ref);
+                this.tabs[0].logBlocks[idx + 1].totalLinesCount = r.lines_count;
+            });
+        }
 
         if (!PipelineStatus.isDone(this.selectedJobRetry.status)) {
             this.startStreamingLogsForJob();
@@ -322,8 +436,13 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
     computeStepFirstLineNumbers(): void {
         let nextFirstLineNumber = 1;
         for (let i = 0; i < this.tabs[this.currentTabIndex].logBlocks.length; i++) {
-            this.tabs[this.currentTabIndex].logBlocks[i].firstDisplayedLineNumber = nextFirstLineNumber;
-            nextFirstLineNumber += this.tabs[this.currentTabIndex].logBlocks[i].totalLinesCount + 1; // add one more line for step name
+            const logBlock = this.tabs[this.currentTabIndex].logBlocks[i];
+            // The infos of the job are not shown when there are none: they take no line either.
+            if (logBlock.information && logBlock.lines.length === 0) {
+                continue;
+            }
+            logBlock.firstDisplayedLineNumber = nextFirstLineNumber;
+            nextFirstLineNumber += logBlock.totalLinesCount + 1; // add one more line for step name
         }
     }
 
@@ -460,6 +579,8 @@ export class RunJobComponent implements OnInit, OnChanges, OnDestroy {
 
     onRetryChange(retry: number): void {
         this.selectedRetry = retry;
+        // Reading an earlier retry pins the panel to it, coming back to the last one lets it move on.
+        this.followLastRetry = retry === this.jobRun.retry;
         this.change();
     }
 

--- a/ui/src/app/views/projectv2/run/run-job.html
+++ b/ui/src/app/views/projectv2/run/run-job.html
@@ -24,8 +24,22 @@
 @if (jobRun) {
   <div class="scrollWrapper" (scroll)="onScroll($event)" (dblclick)="$event.stopPropagation();"
     #scrollWrapper>
+    <!-- A job that has not run has no log: show what it waits for and what it will do, rather than an
+         empty panel. -->
+    @if (showPending) {
+      <div class="pending" role="status">
+        <span nz-icon [nzType]="pending.icon" nzTheme="outline" aria-hidden="true"></span>
+        <span class="label">{{pending.label}}</span>
+        @if (pending.since) {
+          <span class="since" title="Queued since">{{pending.since}}</span>
+        }
+      </div>
+    }
     <!-- Display job services and steps -->
     @for (logBlock of tabs[currentTabIndex].logBlocks; track trackStepElement(i, logBlock); let i = $index) {
+      <!-- The infos of the job are a block like the others, but it is not a step: with nothing to
+           say it is left out rather than shown empty. -->
+      @if (!logBlock.information || logBlock.lines.length > 0) {
       <div class="step"
         [attr.role]="websocket && !logBlock.closed ? 'log' : null">
         <div class="line info" appClickable [attr.aria-expanded]="!logBlock.closed" (click)="clickOpenClose(logBlock)">
@@ -138,6 +152,7 @@
           }
         }
       </div>
+      }
     }
     <div class="footer">
       <div class="goto" appClickable (click)="clickScroll(scrollTargets.BOTTOM)">Bottom<i nz-icon nzType="caret-down"

--- a/ui/src/app/views/projectv2/run/run-job.scss
+++ b/ui/src/app/views/projectv2/run/run-job.scss
@@ -70,6 +70,20 @@
     padding-bottom: 19px;
 }
 
+// Shown instead of logs a job does not have yet.
+.pending {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 20px;
+    font-size: 13px;
+    line-height: 20px;
+
+    .since {
+        color: #B4B4B4;
+    }
+}
+
 .step {
     display: flex;
     flex-direction: column;

--- a/ui/src/app/views/projectv2/run/run.component.ts
+++ b/ui/src/app/views/projectv2/run/run.component.ts
@@ -1,14 +1,13 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, inject, OnDestroy, TemplateRef, ViewChild } from "@angular/core";
 import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { from, interval, lastValueFrom, Subscription } from "rxjs";
-import { dump } from "js-yaml";
-import { V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
+import { RUN_SUMMARY_HEADERS, V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
 import { PreferencesState } from "app/store/preferences.state";
 import { Store } from "@ngxs/store";
 import * as actionPreferences from "app/store/preferences.action";
 import { Tab } from "app/shared/tabs/tabs.component";
 import { Tests } from "../../../model/pipeline.model";
-import { concatMap, map } from "rxjs/operators";
+import { concatMap, map, switchMap } from "rxjs/operators";
 import { ActivatedRoute, Router } from "@angular/router";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { NavigationState } from "app/store/navigation.state";
@@ -26,7 +25,7 @@ import { GraphComponent } from "../../../../../libs/workflow-graph/src/public-ap
 import { Title } from "@angular/platform-browser";
 import { WebsocketV2Filter, WebsocketV2FilterType } from "app/model/websocket-v2";
 import { EventV2Service } from "app/event-v2.service";
-import { EventV2Type } from "app/model/event-v2.model";
+import { EventV2Type, FullEventV2 } from "app/model/event-v2.model";
 import { EventV2State } from "app/store/event-v2.state";
 import { animate, keyframes, state, style, transition, trigger } from "@angular/animations";
 
@@ -49,6 +48,14 @@ import { animate, keyframes, state, style, transition, trigger } from "@angular/
                 style({ opacity: 0.5 }),
                 style({ opacity: 1 })
             ])))
+        ]),
+        // Two runs of the same workflow in the same state look alike: without this, switching from
+        // one to the other moves nothing but a number, and nothing tells the user it happened.
+        trigger('runSwitch', [
+            transition('* => *', [
+                style({ opacity: 0.25 }),
+                animate('200ms ease-out', style({ opacity: 1 }))
+            ])
         ])
     ],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -84,6 +91,18 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         restart: false,
         stop: false
     };
+    /** The run itself is being read: the view shows its shape, waiting for what fills it. */
+    loadingRun: boolean = false;
+    /**
+     * The last run asked for. Reads are not cancellable, so a read that is not for this run anymore
+     * is thrown away instead of being shown: going through runs quickly must land on the last one,
+     * never on whichever answered last.
+     */
+    private requestedRunID: string;
+    /** Holds the place of the runs of the sidebar while they are being read. */
+    readonly runsPlaceholders = Array.from({ length: 8 }, (_, i) => i);
+    /** Someone who asked for less movement gets no transition when the run changes. */
+    readonly reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     animatedRuns: { [key: string]: boolean } = {};
     selectionModeActive: boolean = false;
     gateDrawerOpen: boolean = false;
@@ -94,8 +113,15 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     paramsSub: Subscription;
     queryParamsSub: Subscription;
     resizingSubscription: Subscription;
-    pollSubs: Subscription;
+    refreshSubs: Subscription;
     eventV2Subscription: Subscription;
+    connectedSubscription: Subscription;
+
+    /** Last applied event per subject, events are not ordered on the wire. */
+    private lastEventTimestamps: { [key: string]: number } = {};
+    private refreshTimers: { [key: string]: any } = {};
+    /** Bumped by every event changing the state of the run, to spot a read racing with it. */
+    private eventSequence: number = 0;
 
     // Panels
     resizing: boolean;
@@ -108,6 +134,12 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
     static INFO_PANEL_KEY = 'workflow-run-info';
     static JOB_PANEL_KEY = 'workflow-run-job';
+    /**
+     * The view is driven by the events of the run. This refresh is only a safety net for what events
+     * cannot carry (run infos written without any status change) and for what a disconnection may have
+     * dropped, hence its low frequency.
+     */
+    static SAFETY_REFRESH_DELAY = 30000;
 
     /** Panels without a target are serialized as "type" alone, others as "type:encodedData". */
     static parsePanelParam(value: string): { type: string, data: string } {
@@ -133,8 +165,11 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     private _liveAnnouncer = inject(LiveAnnouncer);
 
     constructor() {
+        // switchMap, not concatMap: going through several runs quickly must not read them one after
+        // the other and show each of them on the way. Only the last one asked for is applied, see the
+        // guard in load().
         this.paramsSub = this._route.params.pipe(
-            concatMap(_ => {
+            switchMap(_ => {
                 const params = this._routerService.getRouteSnapshotParams({}, this._router.routerState.snapshot.root);
                 const workflowRunID = params['workflowRunID'];
                 if (this.workflowRun && this.workflowRun.id === workflowRunID) {
@@ -166,26 +201,13 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         this.infoPanelSize = this._store.selectSnapshot(PreferencesState.panelSize(ProjectV2RunComponent.INFO_PANEL_KEY));
         this.jobPanelSize = this._store.selectSnapshot(PreferencesState.panelSize(ProjectV2RunComponent.JOB_PANEL_KEY)) ?? '50%';
 
-        this.eventV2Subscription = this._store.select(EventV2State.last).subscribe((event) => {
-            if (!event || [EventV2Type.EventRunCrafted, EventV2Type.EventRunBuilding, EventV2Type.EventRunEnded, EventV2Type.EventRunRestart].indexOf(event.type) === -1) { return; }
-            if (!this.runs) { return; }
-            const idx = this.runs.findIndex(run => run.id === event.workflow_run_id);
-            if (idx !== -1 && this.workflowRun && event.workflow_run_id === this.workflowRun.id
-                && this.runs[idx].status !== event.payload.status) {
-                this._liveAnnouncer.announce(`Run ${event.payload.run_number} ${event.payload.status}`, 'polite');
+        this.eventV2Subscription = this._store.select(EventV2State.last).subscribe((event) => this.onEvent(event));
+
+        // Events sent while the websocket was down are lost, so read everything again when it opens.
+        this.connectedSubscription = this._eventV2Service.connected$.subscribe(connected => {
+            if (connected && this.workflowRun) {
+                this.scheduleReload();
             }
-            delete (this.animatedRuns[event.payload.id]);
-            this._cd.detectChanges();
-            if (idx !== -1) {
-                this.runs[idx] = event.payload;
-            } else {
-                this.runs = [event.payload].concat(...this.runs);
-                if (this.runs.length > 50) {
-                    this.runs.pop();
-                }
-            }
-            this.animatedRuns[event.payload.id] = true;
-            this._cd.markForCheck();
         });
     }
 
@@ -206,41 +228,344 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         this._cd.markForCheck();
     }
 
-    ngOnDestroy(): void { } // Should be set to use @AutoUnsubscribe with AOT
+    ngOnDestroy(): void {
+        this.clearScheduledRefresh();
+    }
+
+    // A tab left in the background has its timers throttled and its websocket frames delayed, so what
+    // it displays cannot be trusted when the user comes back to it.
+    @HostListener('document:visibilitychange')
+    onVisibilityChange(): void {
+        if (document.visibilityState === 'visible' && this.workflowRun && !this.workflowRunIsTerminated) {
+            this.scheduleReload();
+        }
+    }
+
+    onEvent(event: FullEventV2): void {
+        if (!event) {
+            return;
+        }
+
+        this.updateRunList(event);
+
+        // An event for the run currently being read: what is being read is already behind it, and
+        // load() will notice through the sequence.
+        if (this.loadingRun && event.workflow_run_id === this.requestedRunID) {
+            this.eventSequence++;
+        }
+
+        if (!this.workflowRun || event.workflow_run_id !== this.workflowRun.id) {
+            return;
+        }
+
+        switch (event.type) {
+            case EventV2Type.EventRunCrafted:
+            case EventV2Type.EventRunBuilding:
+            case EventV2Type.EventRunUpdated:
+            case EventV2Type.EventRunEnded:
+            case EventV2Type.EventRunRestart:
+                this.applyRunEvent(event);
+                break;
+            case EventV2Type.EventRunDeleted:
+                this._messageService.warning('This workflow run has been deleted', { nzDuration: 4000 });
+                break;
+            case EventV2Type.EventRunJobManualTriggered:
+                // The inputs of the gate are kept on the run, which this event does not carry.
+                this.scheduleReload();
+                break;
+            case EventV2Type.EventRunJobRunResultAdded:
+            case EventV2Type.EventRunJobRunResultUpdated:
+                this.applyRunResultEvent(event);
+                break;
+            default:
+                if (event.type.indexOf('RunJob') === 0) {
+                    this.applyRunJobEvent(event);
+                }
+        }
+    }
+
+    /** The sidebar lists the last runs of the same workflow, fed by the run events of the project. */
+    private updateRunList(event: FullEventV2): void {
+        if ([EventV2Type.EventRunCrafted, EventV2Type.EventRunBuilding, EventV2Type.EventRunEnded, EventV2Type.EventRunRestart].indexOf(event.type) === -1) { return; }
+        if (!this.runs) { return; }
+        const idx = this.runs.findIndex(run => run.id === event.workflow_run_id);
+        delete (this.animatedRuns[event.payload.id]);
+        this._cd.detectChanges();
+        if (idx !== -1) {
+            this.runs[idx] = event.payload;
+        } else {
+            this.runs = [event.payload].concat(...this.runs);
+            if (this.runs.length > 50) {
+                this.runs.pop();
+            }
+        }
+        this.animatedRuns[event.payload.id] = true;
+        this._cd.markForCheck();
+    }
+
+    private applyRunEvent(event: FullEventV2): void {
+        if (!this.isNewerEvent('run', event)) { return; }
+
+        const run = event.payload as V2WorkflowRun;
+        const previousStatus = this.workflowRun.status;
+        const previousAttempt = this.workflowRun.run_attempt;
+        const previousShape = ProjectV2RunComponent.workflowShape(this.workflowRun.workflow_data?.workflow);
+        const wasOnLastAttempt = this.selectedRunAttempt === previousAttempt;
+
+        // The payload of the event carries the results of the jobs in the contexts, the run read from
+        // the API does not: drop them so that the run stays the same object whatever refreshed it.
+        const { jobs, ...contexts } = run.contexts ?? {};
+        this.workflowRun = { ...run, contexts };
+        this.workflowRunIsTerminated = V2WorkflowRunStatusIsTerminated(run.status);
+        this.workflowRunIsActive = !this.workflowRunIsTerminated;
+
+        if (previousStatus !== run.status) {
+            this._liveAnnouncer.announce(`Run ${run.run_number} ${run.status}`, 'polite');
+        }
+
+        // The run was restarted from somewhere else: follow its new attempt, unless the user was
+        // deliberately looking at a previous one.
+        if (run.run_attempt > previousAttempt && wasOnLastAttempt) {
+            this.selectedRunAttempt = run.run_attempt;
+            this.scheduleJobsRefresh();
+        }
+
+        // Jobs coming from a template or a matrix replace the job that declared them while the run is
+        // going: the graph has to be drawn again from the new definition, and the new jobs read.
+        if (previousShape !== ProjectV2RunComponent.workflowShape(run.workflow_data?.workflow)) {
+            this.workflowGraph = run.workflow_data.workflow;
+            this.scheduleJobsRefresh();
+        }
+
+        this.scheduleRunInfoRefresh();
+
+        if (this.workflowRunIsTerminated) {
+            this.stopSafetyRefresh();
+            // Last word on the run: read everything the events may have missed while it was running.
+            this.scheduleJobsRefresh();
+        } else {
+            this.startSafetyRefresh();
+        }
+
+        this.eventSequence++;
+        this._cd.markForCheck();
+    }
+
+    private applyRunJobEvent(event: FullEventV2): void {
+        if (!this.jobs || event.run_attempt !== this.selectedRunAttempt) { return; }
+        if (!this.isNewerEvent(`job-${event.run_job_id}`, event)) { return; }
+
+        const job = event.payload as V2WorkflowRunJob;
+        if (!job?.id) { return; }
+
+        // A job the displayed definition does not know about: it was added by a template or a matrix
+        // expanded after the graph was drawn, the run has to be read again to get its new definition.
+        if (!this.workflowRun.workflow_data?.workflow?.jobs?.[job.job_id]) {
+            this.scheduleReload();
+            return;
+        }
+
+        const idx = this.jobs.findIndex(j => j.id === job.id);
+        this.jobs = idx !== -1 ? this.jobs.map((j, i) => i === idx ? job : j) : this.jobs.concat(job);
+
+        if (this.selectedJobRun?.id === job.id) {
+            this.selectedJobRun = job;
+        }
+
+        this.hasJobsFailed = this.jobs.filter(j => V2WorkflowRunJobStatusIsFailed(j.status)).length > 0;
+        this.hasSkippedGateJobs = this.getSkippedGateJobIds().length > 0;
+
+        // Steps moving forward do not change the state of the run: no need to read its infos, and a
+        // read racing with them can be trusted.
+        if (event.type !== EventV2Type.EventRunJobStepUpdated) {
+            this.scheduleRunInfoRefresh();
+            this.eventSequence++;
+        }
+
+        this._cd.markForCheck();
+    }
+
+    private applyRunResultEvent(event: FullEventV2): void {
+        if (!this.results || event.run_attempt !== this.selectedRunAttempt) { return; }
+
+        const result = event.payload as WorkflowRunResult;
+        if (!result?.id || !this.isNewerEvent(`result-${result.id}`, event)) { return; }
+
+        const idx = this.results.findIndex(r => r.id === result.id);
+        this.results = idx !== -1 ? this.results.map((r, i) => i === idx ? result : r) : this.results.concat(result);
+
+        if (this.selectedRunResult?.id === result.id) {
+            this.selectedRunResult = result;
+        }
+        if (this.results.find(r => r.type === WorkflowRunResultType.tests)) {
+            this.computeTestsReport();
+        }
+
+        this.eventSequence++;
+        this._cd.markForCheck();
+    }
+
+    /** Events are not ordered on the wire, an outdated one must not overwrite a fresher state. */
+    private isNewerEvent(key: string, event: FullEventV2): boolean {
+        const timestamp = Date.parse(event.timestamp);
+        if (isNaN(timestamp)) {
+            return true;
+        }
+        if (this.lastEventTimestamps[key] > timestamp) {
+            return false;
+        }
+        this.lastEventTimestamps[key] = timestamp;
+        return true;
+    }
+
+    private static workflowPath(run: V2WorkflowRun): string {
+        return `${run.vcs_server}/${run.repository}/${run.workflow_name}`;
+    }
 
     /**
-     * Load a workflow run and all its associated data.
-     * Resets all restart selection state (selected jobs, gate data, selection mode,
-     * graph visuals) to prevent stale state from carrying over between runs.
+     * What the graph is drawn from: the jobs of the run, their stage, their gate and their
+     * dependencies. Two runs sharing that shape draw the same graph.
+     */
+    private static workflowShape(workflow: any): string {
+        if (!workflow) {
+            return '';
+        }
+        const jobs = workflow.jobs ?? {};
+        const stages = workflow.stages ?? {};
+        return JSON.stringify({
+            jobs: Object.keys(jobs).sort().map(k => [k, jobs[k]?.stage ?? '', jobs[k]?.gate ?? '', (jobs[k]?.needs ?? []).slice().sort()]),
+            stages: Object.keys(stages).sort().map(k => [k, (stages[k]?.needs ?? []).slice().sort()])
+        });
+    }
+
+    private scheduleJobsRefresh(): void {
+        this.scheduleRefresh('jobs', 300, () => this.loadJobsAndResults());
+    }
+
+    private scheduleReload(): void {
+        this.scheduleRefresh('reload', 300, () => this.reload());
+    }
+
+    private scheduleRunInfoRefresh(): void {
+        this.scheduleRefresh('infos', 1000, () => this.loadRunInfos());
+    }
+
+    private scheduleRefresh(key: string, delayMs: number, refresh: () => Promise<void>): void {
+        if (this.refreshTimers[key]) {
+            clearTimeout(this.refreshTimers[key]);
+        }
+        this.refreshTimers[key] = setTimeout(() => {
+            delete this.refreshTimers[key];
+            refresh();
+        }, delayMs);
+    }
+
+    private clearScheduledRefresh(): void {
+        Object.keys(this.refreshTimers).forEach(k => clearTimeout(this.refreshTimers[k]));
+        this.refreshTimers = {};
+    }
+
+    private startSafetyRefresh(): void {
+        if (this.refreshSubs) {
+            return;
+        }
+        this.refreshSubs = interval(ProjectV2RunComponent.SAFETY_REFRESH_DELAY)
+            .pipe(concatMap(_ => from(this.reload())))
+            .subscribe();
+    }
+
+    private stopSafetyRefresh(): void {
+        if (!this.refreshSubs) {
+            return;
+        }
+        this.refreshSubs.unsubscribe();
+        delete this.refreshSubs;
+    }
+
+    /**
+     * Read a workflow run and everything shown around it. Selection mode and the open panel are
+     * dropped on the way, so that nothing of the previous run carries over to this one.
      */
     async load(workflowRunID: string, runAttempt?: number) {
         this.clearPanel();
-        delete this.workflowGraph;
-        if (this.pollSubs) {
-            this.pollSubs.unsubscribe();
-            delete this.pollSubs;
-        }
+        // The graph of the run being left is kept until the next one is read: emptying it here would
+        // show a blank frame between two runs.
+        this.stopSafetyRefresh();
+        this.clearScheduledRefresh();
+        this.lastEventTimestamps = {};
+        this.loadingRun = true;
+        this.requestedRunID = workflowRunID;
 
         if (this.graph) {
             this.graph.setSelectionModeActive(false);
         }
 
-        await this.loadRun(workflowRunID);
-        this.selectedRunAttempt = runAttempt ?? this.workflowRun.run_attempt;
-        this._titleService.setTitle(`#${this.workflowRun.run_number} [${this.workflowRun.contexts.git.ref_name}] • ${this.workflowRun.vcs_server}/${this.workflowRun.repository}/${this.workflowRun.workflow_name} • Workflow Run`);
+        // Watch every event of this run: the run itself, its jobs, their steps and their results.
+        this._eventV2Service.updateFilter(<WebsocketV2Filter>{
+            type: WebsocketV2FilterType.PROJECT_RUN,
+            project_key: this.projectKey,
+            workflow_run_id: workflowRunID
+        });
 
-        this.workflowGraph = dump(this.workflowRun.workflow_data.workflow, { lineWidth: -1 });
+        // The jobs, the results and the infos of a run are keyed by its id, not by anything the run
+        // carries: they are read at the same time as the run rather than one after the other, so the
+        // whole view is drawn once, complete, after a single round trip.
+        const sequence = this.eventSequence;
+        const [run, jobs, results, infos] = await Promise.all([
+            this.fetchRun(workflowRunID),
+            this.fetchJobs(workflowRunID, runAttempt),
+            this.fetchResults(workflowRunID, runAttempt),
+            this.fetchRunInfos(workflowRunID)
+        ]);
 
+        // Another run was asked for while this one was being read: it is the one the user is waiting
+        // for, this answer is dropped rather than shown on the way.
+        if (this.requestedRunID !== workflowRunID) {
+            return;
+        }
+
+        this.loadingRun = false;
+
+        if (!run) {
+            this._cd.markForCheck();
+            return;
+        }
+
+        // The sidebar lists the runs of one workflow: coming from another one, what it holds has
+        // nothing to do with this run.
+        if (this.workflowRun && ProjectV2RunComponent.workflowPath(this.workflowRun) !== ProjectV2RunComponent.workflowPath(run)) {
+            delete this.runs;
+        }
+
+        // The definition of the run and everything filling it are set together, without an await
+        // between them: no rendering can catch the graph of this run holding the jobs of another,
+        // which would paint its nodes with the statuses of the previous one.
+        this.applyRun(run);
+        this.selectedRunAttempt = runAttempt ?? run.run_attempt;
+        this._titleService.setTitle(`#${run.run_number} [${run.contexts.git.ref_name}] • ${run.vcs_server}/${run.repository}/${run.workflow_name} • Workflow Run`);
+        this.workflowGraph = run.workflow_data.workflow;
+
+        // Nothing of the run being left is kept: what could not be read is shown empty rather than
+        // with the values of the previous run.
+        this.applyJobs(jobs ?? []);
+        this.applyResults(results ?? []);
+        this.applyRunInfos(infos ?? []);
+
+        await this.refreshPanel();
         this._cd.markForCheck();
 
-        await this.loadRuns();
+        if (sequence !== this.eventSequence) {
+            this.scheduleJobsRefresh();
+        }
 
-        this._cd.markForCheck();
-
-        await this.loadJobsAndResults();
+        // The sibling runs of the sidebar are the only thing that needs the run to be read first.
+        // Nothing else waits for them.
+        this.loadRuns();
     }
 
     async loadRuns() {
+        const runID = this.workflowRun.id;
+
         let params = new HttpParams();
         params = params.appendAll({
             workflow: `${this.workflowRun.vcs_server}/${this.workflowRun.repository}/${this.workflowRun.workflow_name}`,
@@ -255,7 +580,11 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         });
 
         try {
-            const res = await lastValueFrom(this._http.get(`/v2/project/${this.projectKey}/run`, { params, observe: 'response' })
+            const res = await lastValueFrom(this._http.get(`/v2/project/${this.projectKey}/run`, {
+                params,
+                headers: RUN_SUMMARY_HEADERS,
+                observe: 'response'
+            })
                 .pipe(map(res => {
                     let headers: HttpHeaders = res.headers;
                     return {
@@ -263,74 +592,178 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
                         runs: res.body as Array<V2WorkflowRun>
                     };
                 })));
+            if (this.isStale(runID)) {
+                return;
+            }
             this.runs = res.runs;
         } catch (e) {
+            if (this.isStale(runID)) {
+                return;
+            }
             this._messageService.error(`Unable to list workflow runs: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            this.runs = [];
+        }
+
+        // Nothing awaits this read: without marking the view, the runs would only appear on the next
+        // interaction.
+        this._cd.markForCheck();
+    }
+
+    private async fetchRun(workflowRunID: string): Promise<V2WorkflowRun> {
+        try {
+            return await lastValueFrom(this._workflowService.getRun(this.projectKey, workflowRunID));
+        } catch (e) {
+            this._messageService.error(`Unable to get workflow run: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            return null;
         }
     }
 
-    async loadRun(workflowRunID: string) {
+    private async fetchJobs(workflowRunID: string, attempt: number): Promise<Array<V2WorkflowRunJob>> {
         try {
-            this.workflowRun = await lastValueFrom(this._workflowService.getRun(this.projectKey, workflowRunID));
-            this.workflowRunIsTerminated = V2WorkflowRunStatusIsTerminated(this.workflowRun.status);
-            this.workflowRunIsActive = !this.workflowRunIsTerminated;
+            return await lastValueFrom(this._workflowService.getJobs(this.projectKey, workflowRunID, attempt));
         } catch (e) {
-            this._messageService.error(`Unable to get workflow run: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            this._messageService.error(`Unable to get jobs: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            return null;
         }
+    }
+
+    private async fetchResults(workflowRunID: string, attempt: number): Promise<Array<WorkflowRunResult>> {
+        try {
+            return await lastValueFrom(this._workflowService.getResults(this.projectKey, workflowRunID, attempt));
+        } catch (e) {
+            this._messageService.error(`Unable to get results: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            return null;
+        }
+    }
+
+    private async fetchRunInfos(workflowRunID: string): Promise<Array<WorkflowRunInfo>> {
+        try {
+            return await lastValueFrom(this._workflowService.getRunInfos(this.projectKey, workflowRunID));
+        } catch (e) {
+            this._messageService.error(`Unable to get run infos: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
+            return null;
+        }
+    }
+
+    private applyRun(run: V2WorkflowRun): void {
+        this.workflowRun = run;
+        this.workflowRunIsTerminated = V2WorkflowRunStatusIsTerminated(run.status);
+        this.workflowRunIsActive = !this.workflowRunIsTerminated;
+        if (this.workflowRunIsActive) {
+            this.startSafetyRefresh();
+        } else {
+            this.stopSafetyRefresh();
+        }
+    }
+
+    private applyJobs(jobs: Array<V2WorkflowRunJob>): void {
+        if (!jobs) {
+            return;
+        }
+        this.jobs = jobs;
+        this.hasJobsFailed = this.jobs.filter(j => V2WorkflowRunJobStatusIsFailed(j.status)).length > 0;
+        this.hasSkippedGateJobs = this.getSkippedGateJobIds().length > 0;
+    }
+
+    private applyResults(results: Array<WorkflowRunResult>): void {
+        if (!results) {
+            return;
+        }
+        this.results = results;
+        if (this.results.find(r => r.type === WorkflowRunResultType.tests)) {
+            this.computeTestsReport();
+        } else {
+            // A run without test result must not keep showing the report of the previous one.
+            delete this.tests;
+        }
+    }
+
+    private applyRunInfos(infos: Array<WorkflowRunInfo>): void {
+        if (!infos) {
+            return;
+        }
+        this.workflowRunInfo = infos.sort((a, b) => moment(a.issued_at).isBefore(moment(b.issued_at)) ? 1 : -1);
     }
 
     async loadJobsAndResults() {
-        try {
-            this.jobs = await lastValueFrom(this._workflowService.getJobs(this.workflowRun, this.selectedRunAttempt));
-        } catch (e) {
-            this._messageService.error(`Unable to get jobs: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
-        }
+        const sequence = this.eventSequence;
+        const runID = this.workflowRun.id;
 
-        try {
-            this.results = await lastValueFrom(this._workflowService.getResults(this.workflowRun, this.selectedRunAttempt));
-            if (!!this.results.find(r => r.type === WorkflowRunResultType.tests)) {
-                this.computeTestsReport();
-            }
-        } catch (e) {
-            this._messageService.error(`Unable to get results: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
-        }
-        try {
-            this.workflowRunInfo = await lastValueFrom(this._workflowService.getRunInfos(this.workflowRun));
-            this.workflowRunInfo.sort((a, b) => moment(a.issued_at).isBefore(moment(b.issued_at)) ? 1 : -1);
-        } catch (e) {
-            this._messageService.error(`Unable to get run infos: ${ErrorUtils.print(e)}`, { nzDuration: 2000 });
-        }
+        const [jobs, results, infos] = await Promise.all([
+            this.fetchJobs(runID, this.selectedRunAttempt),
+            this.fetchResults(runID, this.selectedRunAttempt),
+            this.fetchRunInfos(runID)
+        ]);
 
-        await this.refreshPanel();
-
-        this.hasJobsFailed = this.jobs.filter(j => V2WorkflowRunJobStatusIsFailed(j.status)).length > 0;
-        this.hasSkippedGateJobs = this.getSkippedGateJobIds().length > 0;
-
-        if (this.workflowRunIsActive && !this.pollSubs) {
-            this.pollSubs = interval(5000)
-                .pipe(concatMap(_ => from(this.pollReload())))
-                .subscribe();
-        }
-
-        if (this.workflowRunIsTerminated && this.pollSubs) {
-            this.pollSubs.unsubscribe();
-            delete this.pollSubs;
-        }
-
-        this._cd.detectChanges();
-    }
-
-    async pollReload() {
-        const previousJobsCount = Object.keys(this.workflowRun.workflow_data.workflow.jobs).length;
-        await this.loadRun(this.workflowRun.id);
-
-        // Force redraw of the graph if the count of jobs changed in the workflow definition
-        if (previousJobsCount !== Object.keys(this.workflowRun.workflow_data.workflow.jobs).length) {
-            await this.load(this.workflowRun.id, this.selectedRunAttempt);
+        if (this.isStale(runID)) {
             return;
         }
 
-        await this.loadJobsAndResults();
+        this.applyJobs(jobs);
+        this.applyResults(results);
+        this.applyRunInfos(infos);
+
+        await this.refreshPanel();
+
+        this._cd.markForCheck();
+
+        // An event landed while this was being read: what has just been read is already outdated.
+        if (sequence !== this.eventSequence) {
+            this.scheduleJobsRefresh();
+        }
+    }
+
+    async loadRunInfos(): Promise<void> {
+        const runID = this.workflowRun.id;
+        const infos = await this.fetchRunInfos(runID);
+        if (this.isStale(runID)) {
+            return;
+        }
+        this.applyRunInfos(infos);
+        this._cd.markForCheck();
+    }
+
+    /** Whether what was read is not for the run the view must show anymore. */
+    private isStale(runID: string): boolean {
+        return this.requestedRunID !== runID;
+    }
+
+    /** Read the run and everything shown around it again, the events being trusted for nothing here. */
+    async reload(): Promise<void> {
+        const previousShape = ProjectV2RunComponent.workflowShape(this.workflowRun.workflow_data?.workflow);
+
+        const sequence = this.eventSequence;
+        const runID = this.workflowRun.id;
+        const [run, jobs, results, infos] = await Promise.all([
+            this.fetchRun(runID),
+            this.fetchJobs(runID, this.selectedRunAttempt),
+            this.fetchResults(runID, this.selectedRunAttempt),
+            this.fetchRunInfos(runID)
+        ]);
+
+        if (this.isStale(runID)) {
+            return;
+        }
+
+        if (run) {
+            this.applyRun(run);
+            // Draw the graph again when the definition of the run changed, a template or a matrix
+            // having replaced the job that declared them.
+            if (previousShape !== ProjectV2RunComponent.workflowShape(run.workflow_data?.workflow)) {
+                this.workflowGraph = run.workflow_data.workflow;
+            }
+        }
+        this.applyJobs(jobs);
+        this.applyResults(results);
+        this.applyRunInfos(infos);
+
+        await this.refreshPanel();
+
+        this._cd.markForCheck();
+
+        if (sequence !== this.eventSequence) {
+            this.scheduleJobsRefresh();
+        }
     }
 
     computeTestsReport(): void {

--- a/ui/src/app/views/projectv2/run/run.component.ts
+++ b/ui/src/app/views/projectv2/run/run.component.ts
@@ -366,7 +366,21 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         }
 
         const idx = this.jobs.findIndex(j => j.id === job.id);
-        this.jobs = idx !== -1 ? this.jobs.map((j, i) => i === idx ? job : j) : this.jobs.concat(job);
+        if (idx !== -1) {
+            this.jobs = this.jobs.map((j, i) => i === idx ? job : j);
+        } else {
+            // A retry takes the place of the run job it retries: the list holds the last retry of each
+            // job, as the API returns it.
+            const retried = this.jobs.find(j => ProjectV2RunComponent.isSameJob(j, job) && j.retry < job.retry);
+            this.jobs = retried ? this.jobs.map(j => j === retried ? job : j) : this.jobs.concat(job);
+
+            // The panel was open on the run job that has just been retried: it stays open on the job,
+            // now holding its new retry. Whether it shows that retry or the one being read is the
+            // panel's own decision.
+            if (retried && this.selectedItemType === 'job' && this.selectedJobRun?.id === retried.id) {
+                this.openPanel('job', job.id);
+            }
+        }
 
         if (this.selectedJobRun?.id === job.id) {
             this.selectedJobRun = job;
@@ -420,6 +434,15 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
     private static workflowPath(run: V2WorkflowRun): string {
         return `${run.vcs_server}/${run.repository}/${run.workflow_name}`;
+    }
+
+    /** Two run jobs of the same job of the workflow: same name, and same matrix variant if any. */
+    private static isSameJob(a: V2WorkflowRunJob, b: V2WorkflowRunJob): boolean {
+        if (a.job_id !== b.job_id) {
+            return false;
+        }
+        const variant = (matrix: { [key: string]: string }) => Object.keys(matrix ?? {}).sort().map(k => `${k}=${matrix[k]}`).join(',');
+        return variant(a.matrix) === variant(b.matrix);
     }
 
     /**
@@ -875,7 +898,10 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
         switch (this.selectedItemType) {
             case 'job':
-                const jobToSelect = this.jobs.find(j => j.id === this.selectedJobRun.id);
+                // The run job on screen may have been retried since, in which case the list holds its
+                // retry instead of it: the panel follows the job rather than closing.
+                const jobToSelect = this.jobs.find(j => j.id === this.selectedJobRun.id)
+                    ?? this.jobs.find(j => ProjectV2RunComponent.isSameJob(j, this.selectedJobRun) && j.retry > this.selectedJobRun.retry);
                 if (jobToSelect) {
                     this.openPanel('job', jobToSelect.id);
                 } else {

--- a/ui/src/app/views/projectv2/run/run.html
+++ b/ui/src/app/views/projectv2/run/run.html
@@ -26,16 +26,26 @@
 </ng-template>
 
 @if (workflowRun) {
-  <div class="content" [class.disableSelection]="resizing">
+  <div class="content" [class.disableSelection]="resizing" [@.disabled]="reduceMotion">
     <!--  GRAPH -->
     <div class="graph-wrapper">
       <div class="list">
+        <!-- The runs of the workflow are read after the run itself: hold their place so that they
+             do not push the graph sideways when they arrive. -->
+        @if (!runs) {
+          @for (placeholder of runsPlaceholders; track placeholder) {
+            <span class="item placeholder" aria-hidden="true"></span>
+          }
+        }
         @for (run of runs; track trackRunElement(i, run); let i = $index) {
-          <a class="item" nz-popover
+          <!-- No detail popover over the run being displayed: it has nothing to tell that the page
+               does not, and leaving it open over the run just opened hides it. -->
+          <a class="item" nz-popover #runPopover="nzPopover"
             [nzPopoverContent]="runDetails" [nzPopoverMouseEnterDelay]="0.1" [nzPopoverMouseLeaveDelay]="0.05"
+            [nzPopoverTrigger]="run.id === workflowRun?.id ? null : 'hover'"
             [routerLink]="['/project', projectKey, 'run', run.id]" [class.selected]="run.id === workflowRun?.id"
             [class.append]="!!animatedRuns[run.id]" [@appendToList]="animatedRuns[run.id] ? 'append' : 'active'"
-            (mouseenter)="onMouseEnterRun(run.id)">
+            (mouseenter)="onMouseEnterRun(run.id)" (click)="runPopover.hide()">
             <span [title]="'Number: ' + run.run_number" [class.success]="run.status === 'Success'"
               [class.cancelled]="run.status === 'Cancelled'" [class.fail]="run.status === 'Fail'"
               [class.stopped]="run.status === 'Stopped'" [class.building]="run.status === 'Building'"
@@ -89,7 +99,9 @@
           </a>
         }
       </div>
-      <div class="graph">
+      <!-- Fades on every change of run: two runs of the same workflow in the same state look alike,
+           and the sidebar stays still since that is where the click happened. -->
+      <div class="graph" [@runSwitch]="workflowRun.id" [class.switching]="loadingRun">
         <nz-page-header class="title" nzBackIcon (nzBack)="onBack()">
           <nz-page-header-title>
             <app-workflow-name style="margin-right: 10px;" [name]="workflowRun.workflow_name"
@@ -349,4 +361,21 @@ nzContent="{{workflowRun.contexts.cds.version}}" [nzCopyTooltips]="null"></span>
     }
   </app-resizable-panel>
 }
+}
+@if (!workflowRun && loadingRun) {
+  <!-- The frame of the view, so that reading the run does not leave a blank page and everything
+       does not jump into place at once when it lands. -->
+  <div class="content loading-shell" role="status">
+    <span class="cds-sr-only">Loading the workflow run</span>
+    <div class="graph-wrapper">
+      <div class="list">
+        @for (placeholder of runsPlaceholders; track placeholder) {
+          <span class="item placeholder" aria-hidden="true"></span>
+        }
+      </div>
+      <div class="graph-placeholder" aria-hidden="true">
+        <span nz-icon nzType="loading" nzTheme="outline"></span>
+      </div>
+    </div>
+  </div>
 }

--- a/ui/src/app/views/projectv2/run/run.scss
+++ b/ui/src/app/views/projectv2/run/run.scss
@@ -58,6 +58,27 @@
     }
 }
 
+// Frame shown while the run is being read. The spinner only fades in after a moment, so a run that
+// arrives quickly never shows one.
+.loading-shell {
+    .graph-placeholder {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        color: common.$polar_grey_2;
+        opacity: 0;
+        animation: cds-run-loading-fade-in 200ms ease-out 400ms forwards;
+    }
+}
+
+@keyframes cds-run-loading-fade-in {
+    to {
+        opacity: 1;
+    }
+}
+
 .content {
     flex: 1;
     display: flex;
@@ -75,6 +96,10 @@
         .list {
             overflow-y: auto;
             height: 100%;
+            // Holds its width from the first frame, the runs it lists are read after the run itself
+            // and would otherwise push the graph sideways when they land.
+            min-width: 53px;
+            flex: 0 0 auto;
             border-right: 1px solid;
             border-color: #f0f0f0 !important;
 
@@ -97,6 +122,23 @@
 
                 :host-context(.night) & {
                     border-bottom-color: #303030;
+                }
+
+                &.placeholder {
+                    cursor: default;
+
+                    &::after {
+                        content: '';
+                        height: 14px;
+                        width: 28px;
+                        margin-left: 8px;
+                        border-radius: 3px;
+                        background-color: #f0f0f0;
+
+                        :host-context(.night) & {
+                            background-color: #303030;
+                        }
+                    }
                 }
 
                 &:hover {
@@ -161,6 +203,13 @@
             align-items: center;
             width: 100%;
             overflow: hidden;
+
+            // The graph of the run being left stays until the next one is read. It dims only if that
+            // read takes a moment, and comes back at once, the switch itself being animated.
+            &.switching {
+                opacity: 0.55;
+                transition: opacity 150ms ease-out 250ms;
+            }
 
             .dotted {
                 color: inherit;


### PR DESCRIPTION
### Description

The v2 run view polled itself every 5 seconds — the run, its jobs, its results,
its infos — and the job panel polled on its own. It now follows the run through
the websocket, which the run list already used.

**API**
- New `project-run` websocket filter: a client watching one run receives every
  event carrying that run id (run, jobs, steps, results, deletion). Read access
  is checked once, when the filter is registered, so nothing is checked per
  event — the `queue` filter, the only route for job events until now, checks
  execute on the region and gives a project reader nothing.
- Two events were missing: `RunJobStepUpdated` (a worker reporting step
  progress, kept out of Elasticsearch and notifications since it reports
  progress, not a state change) and `RunUpdated` (the definition of a running
  workflow changed, i.e. a template or a matrix replaced the job that declared
  them).
- Run lists can be asked, through the `Accept` header, for runs without the
  definition they ran: it weighs more than everything else in that answer and
  nothing displays it.
- Fixes: a filter needing no post check now wins over one that does; the v2
  websocket removed failing clients from the v1 server; `RunJobManualTriggered`,
  `RunJobRunResultAdded/Updated` and `RunDeleted` were published but routed
  nowhere; the documented event list was missing half the run and job events.

**Run view**
- Events are applied to what the view holds; a low-frequency refresh remains as
  a safety net, along with a refresh on reconnect, on tab focus and when the run
  ends. Out-of-order events are dropped.
- The graph is only laid out again when the layout would differ; progress is
  refreshed in place, so focus, hover and running durations survive.
- A run whose jobs come from a template or a matrix now redraws by itself
  instead of needing a manual refresh.
- Opening a run is one round trip instead of five, and the definition and the
  jobs are applied together — a graph could previously be drawn with the jobs of
  the run before it, painting its nodes with that run's statuses.
- Switching runs: only the last one clicked is applied, the previous graph stays
  until the next is read, and the switch is animated since two runs of the same
  workflow look alike.

**Explore view**
- Reading a repository was three round trips (branches, tags, entities); the
  entities of a ref only need the ref, so they are read alongside. The
  repository the url points at joins the same batch instead of coming last.
- The tree is kept in memory and redrawn at once when coming back to the view,
  then refreshed in the background; it is tracked by name, so refreshing it no
  longer rebuilds its dom.
- A repository no longer announces "No resource found" while its entities are
  on their way.
- An entity is read together with its vcs, repository and schema; the schema of
  an entity type is read once per session instead of on every entity opened; the
  monaco editor is no longer destroyed and rebuilt each time.

Both sides are additive: an older UI ignores the new filter and events, and the
run view stays correct through its refresh without them.

`ui/specs/workflow-run-graph.md` carries the behaviour — sections *Drawing again
or refreshing in place*, *Opening a run* and *Live updates* read faster than the
diff.

### Related issues

_none_

### About tests

`engine/api/v2_websocket_test.go` covers the event routing and the filter
matching. UI builds and lints clean. Manually: matrix and template workflows
redrawing mid-run, gates, restart from another tab, websocket cut and restored,
background tab, and fast switching between runs.

### Mentions

@ovh/cds