### PR TITLE
fix(hooks): keep the analysis initiator on pull-request events

### DIFF
--- a/engine/hooks/scheduler_repository_event_test.go
+++ b/engine/hooks/scheduler_repository_event_test.go
@@ -184,3 +184,123 @@ func TestManageRepositoryEvent_NonPushEventWorkflowToTrigger(t *testing.T) {
 	k := cache.Key(repositoryEventRootKey, s.Dao.GetRepositoryMemberKey(hr.VCSServerName, hr.RepositoryName), hr.UUID)
 	require.NoError(t, s.manageRepositoryEvent(context.TODO(), k))
 }
+
+// A pull-request event never runs its own analysis: triggerCheckAnalyses only reuses the
+// one created by the push event. The identity that analysis resolved must be copied back on
+// the event, otherwise nothing is left to authorize the run. It matters most for a VCS user
+// (a robot with no CDS account): entity.user_id can only hold a CDS user id, so the event
+// initiator is the only channel able to carry that identity. Losing it made every robot
+// pull-request fail with "unknown user" before reaching the RBAC check.
+func TestManageRepositoryEvent_PullRequestKeepsVCSUserInitiator(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	s, cancel := setupTestHookService(t)
+	defer cancel()
+
+	event := GiteaEventPayload{}
+	event.Repository.FullName = "ovh/cds"
+	event.Ref = "refs/heads/renovate/all"
+	event.After = "abcdef123456"
+
+	bts, _ := json.Marshal(event)
+
+	hr := sdk.HookRepositoryEvent{
+		UUID:           sdk.UUID(),
+		VCSServerName:  "private-github",
+		RepositoryName: "ovh/cds",
+		Status:         sdk.HookEventStatusScheduled,
+		EventName:      sdk.WorkflowHookEventNamePullRequest,
+		Created:        time.Now().UnixNano(),
+		Body:           bts,
+		// A pull-request event carries no signing key: only the analysis knows it.
+		SignKey: "",
+		ExtractData: sdk.HookRepositoryEventExtractData{
+			Commit: "abcdef123456",
+			Ref:    "refs/heads/renovate/all",
+		},
+	}
+	require.NoError(t, s.Dao.SaveRepositoryEvent(context.TODO(), &hr))
+
+	// Create repo
+	_, err := s.Dao.CreateRepository(context.TODO(), hr.VCSServerName, hr.RepositoryName)
+	require.NoError(t, err)
+
+	m := s.Client.(*mock_cdsclient.MockInterface)
+
+	m.EXPECT().HookRepositoriesList(gomock.Any(), gomock.Any(), gomock.Any()).Return([]sdk.ProjectRepository{
+		{
+			ProjectKey: "PROJ",
+		},
+	}, nil)
+
+	// The analysis triggered by the push resolved a VCS user: it holds no CDS user id.
+	m.EXPECT().ProjectRepositoryAnalysisList(gomock.Any(), "PROJ", "private-github", "ovh/cds").Return([]sdk.ProjectRepositoryAnalysis{
+		{
+			ID:     "123456",
+			Commit: "abcdef123456",
+			Status: sdk.RepositoryAnalysisStatusSucceed,
+			Data: sdk.ProjectRepositoryData{
+				SignKeyID: "18E8DDC6067B2F72",
+				Initiator: &sdk.V2Initiator{VCS: "private-github", VCSUsername: "robot-cds"},
+			},
+		},
+	}, nil)
+
+	m.EXPECT().CreateInsightReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	m.EXPECT().ListWorkflowToTrigger(gomock.Any(), gomock.Any()).Return([]sdk.V2WorkflowHook{
+		{
+			ProjectKey:     "PROJ",
+			VCSName:        "private-github",
+			RepositoryName: "ovh/cds",
+			WorkflowName:   "myworkflow",
+		},
+	}, nil)
+
+	// The workflow entity was last updated by the robot, so it carries no CDS user id.
+	m.EXPECT().EntityGet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&sdk.Entity{
+		UserID: nil,
+	}, nil).Times(1)
+
+	// A done operation is required to go past the git info step and reach triggerWorkflows.
+	m.EXPECT().RetrieveHookEventSigningKey(gomock.Any(), gomock.Any()).Return(sdk.Operation{
+		UUID:   sdk.UUID(),
+		Status: sdk.OperationStatusDone,
+	}, nil).Times(1)
+
+	var runRequest sdk.V2WorkflowRunHookRequest
+	m.EXPECT().WorkflowV2RunFromHook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Cond(func(r sdk.V2WorkflowRunHookRequest) bool {
+			runRequest = r
+			return true
+		}), gomock.Any(), gomock.Any()).Return(&sdk.V2WorkflowRun{
+		ID:        sdk.UUID(),
+		RunNumber: 1,
+	}, nil).Times(1)
+
+	// Force dequeue
+	k := cache.Key(repositoryEventRootKey, s.Dao.GetRepositoryMemberKey(hr.VCSServerName, hr.RepositoryName), hr.UUID)
+	require.NoError(t, s.manageRepositoryEvent(context.TODO(), k))
+
+	var hreUpdate sdk.HookRepositoryEvent
+	f, err := s.Cache.Get(k, &hreUpdate)
+	require.NoError(t, err)
+	require.True(t, f)
+
+	// The identity resolved by the analysis must have been copied back on the event...
+	require.NotNil(t, hreUpdate.Initiator)
+	require.Equal(t, "robot-cds", hreUpdate.Initiator.VCSUsername)
+	require.Equal(t, "18E8DDC6067B2F72", hreUpdate.SignKey)
+
+	// Deprecated, but it is the only field the UI reads to display the event initiator:
+	// dropping it would make the identity invisible again in the repository view.
+	require.Equal(t, "private-github/robot-cds", hreUpdate.DeprecatedUsername)
+
+	// ...and must have reached the API, otherwise RBAC cannot evaluate the vcs_users rules.
+	require.NotNil(t, runRequest.Initiator)
+	require.Equal(t, "robot-cds", runRequest.Initiator.VCSUsername)
+
+	// The workflow must have been triggered, not skipped as an unknown user.
+	require.Len(t, hreUpdate.WorkflowHooks, 1)
+	require.NotEqual(t, "unknown user", hreUpdate.WorkflowHooks[0].Error)
+	require.Equal(t, sdk.HookEventWorkflowStatusDone, hreUpdate.WorkflowHooks[0].Status)
+}

--- a/engine/hooks/trigger_analyses.go
+++ b/engine/hooks/trigger_analyses.go
@@ -11,6 +11,24 @@ import (
 	"github.com/ovh/cds/sdk/telemetry"
 )
 
+// setInitiatorFromAnalysis copies back on the event the initiator and the signing key
+// resolved by the analysis. triggerCheckAnalyses only reuses an analysis triggered by a
+// previous push event, so without this the event keeps no identity at all and
+// triggerWorkflows rejects every workflow hook with "unknown user". This is also the only
+// channel able to carry a VCS user (a robot with no CDS account), as entity.user_id can
+// only hold a CDS user id.
+func setInitiatorFromAnalysis(hre *sdk.HookRepositoryEvent, analysis sdk.ProjectRepositoryAnalysis) {
+	// A repository can be analyzed by several projects, but only the one owning the signing
+	// key resolves an initiator: never let a later analysis erase it.
+	if hre.Initiator != nil || analysis.Data.Initiator == nil {
+		return
+	}
+	hre.SignKey = analysis.Data.SignKeyID
+	hre.Initiator = analysis.Data.Initiator
+	// Deprecated, but it is the only field the UI reads to display the event initiator.
+	hre.DeprecatedUsername = analysis.Data.Initiator.Username()
+}
+
 func (s *Service) triggerCheckAnalyses(ctx context.Context, hre *sdk.HookRepositoryEvent) error {
 	allEnded := true
 
@@ -50,6 +68,7 @@ func (s *Service) triggerCheckAnalyses(ctx context.Context, hre *sdk.HookReposit
 				if a.Commit == hre.ExtractData.Commit {
 					hreAnl.AnalyzeID = a.ID
 					hreAnl.Status = a.Status
+					setInitiatorFromAnalysis(hre, a)
 					foundAnl = true
 					break
 				}
@@ -78,6 +97,7 @@ func (s *Service) triggerCheckAnalyses(ctx context.Context, hre *sdk.HookReposit
 				return err
 			}
 			hreAnl.Status = apiAnalysis.Status
+			setInitiatorFromAnalysis(hre, apiAnalysis)
 			if hreAnl.Status == sdk.RepositoryAnalysisStatusInProgress {
 				hreAnl.FindRetryCount++
 				if hreAnl.FindRetryCount > s.Cfg.OldRepositoryEventRetry {

--- a/tests/08_v2_workflow_on_pullrequest.yml
+++ b/tests/08_v2_workflow_on_pullrequest.yml
@@ -159,6 +159,30 @@ testcases:
       retry: 60
       delay: 1
 
+- name: Check the pull-request event kept the identity resolved by the analysis
+  steps:
+    # A pull-request event never runs its own analysis, it only reuses the one created by the
+    # push. If the initiator and the signing key that analysis resolved are not copied back
+    # on the event, nothing is left to authorize the run and every workflow hook is skipped
+    # with "unknown user".
+    - name: Find the pull-request hook event
+      script: "{{.cdsctl}} -f {{.cdsctl.config}} admin hooks repository event list my_vcs_server {{.git.user}}/{{.git_repo}} --filter event_name=pull-request --format json"
+      assertions:
+        - result.code ShouldEqual 0
+        - result.systemoutjson ShouldHaveLength 1
+      retry: 30
+      delay: 2
+      vars:
+        hookEventUUID:
+          from: result.systemoutjson.systemoutjson0.uuid
+
+    - name: The event must carry the signing key and the initiator of the reused analysis
+      script: "{{.cdsctl}} -f {{.cdsctl.config}} admin hooks repository event show my_vcs_server {{.git.user}}/{{.git_repo}} {{.hookEventUUID}} --format json"
+      assertions:
+        - result.code ShouldEqual 0
+        - result.systemoutjson.sign_key ShouldNotBeEmpty
+        - result.systemoutjson.username ShouldNotBeEmpty
+
 - name: Check comment created on forgejo
   steps:
   - name: Get pull-request from forgejo and check comment


### PR DESCRIPTION
A pull-request event never runs its own analysis: triggerCheckAnalyses only reuses the one created by the push event. It copied back the analysis status but dropped Data.Initiator and Data.SignKeyID, unlike triggerAnalyses.

The event was therefore left without any identity: hre.Initiator nil and hre.SignKey empty. With an empty sign key on a non-push event, the RetrieveHookEventUser fallback in triggerWorkflows is short-circuited, so findCommitter is never called again. The only source left is entity.user_id, which can hold a CDS user id and nothing else. A commit signed by a VCS user - a robot with no CDS account - resolves to an initiator with an empty UserID, stored as NULL, so every workflow hook was skipped with "unknown user" before the RBAC check could evaluate the vcs_users rules.

Copy the initiator and the signing key back on the event in both branches that read an analysis: the list lookup, which is the common case when the analysis has already finished by the time the pull-request arrives, and the status polling, for when it is still running. The copy is a no-op once the event carries an initiator, so an analysis from another project cannot erase it, and the per-hook initiator built from the entity owner still wins for a CDS user.
