### PR TITLE
feat(ui): timeline view of a workflow run

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -251,6 +251,29 @@
           "defaultConfiguration": "production"
         }
       }
+    },
+    "timeline": {
+      "projectType": "library",
+      "root": "libs/timeline",
+      "sourceRoot": "libs/timeline/src",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:ng-packagr",
+          "options": {
+            "project": "libs/timeline/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "libs/timeline/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "libs/timeline/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        }
+      }
     }
   },
   "schematics": {

--- a/ui/libs/timeline/.gitignore
+++ b/ui/libs/timeline/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ui/libs/timeline/ng-package.json
+++ b/ui/libs/timeline/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/timeline",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/ui/libs/timeline/package.json
+++ b/ui/libs/timeline/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "timeline",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@angular/cdk": "21.2.14",
+    "@angular/common": "21.2.17",
+    "@angular/core": "21.2.17",
+    "ng-zorro-antd": "21.3.1"
+  },
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
+  "scripts": {
+    "ng": "ng"
+  },
+  "sideEffects": false
+}

--- a/ui/libs/timeline/src/lib/timeline.component.ts
+++ b/ui/libs/timeline/src/lib/timeline.component.ts
@@ -1,0 +1,1373 @@
+import {
+    afterNextRender,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    EventEmitter,
+    inject,
+    Injector,
+    Input,
+    NgZone,
+    OnChanges,
+    OnDestroy,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ViewContainerRef
+} from '@angular/core';
+import { FlexibleConnectedPositionStrategy, Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+    axisEnds,
+    AXIS_BAND_PX,
+    flattenLanes,
+    formatDuration,
+    TimelineActivation,
+    TimelineData,
+    TimelineDetail,
+    shouldFollow,
+    TimelineLane,
+    TimelineMarker,
+    TimelineSegment
+} from './timeline.model';
+import { DEFAULT_SCALE_OPTIONS, TimelineBusy, TimelineScale, TimelineScalePiece } from './timeline.scale';
+import { timelineIcon } from './timeline.icons';
+
+/** Everything below is what the template binds to: plain values, computed once per layout. */
+
+interface RenderedSegment {
+    id: string;
+    kind: string;
+    label: string;
+    /** How long the segment lasted, shown next to the label when the segment can hold both. */
+    duration: string;
+    left: string;
+    width: string;
+    /** The label only fits on a segment wide enough to hold it. */
+    showLabel: boolean;
+    showDuration: boolean;
+    /** Still going: drawn open-ended. */
+    open: boolean;
+}
+
+interface RenderedMarker {
+    id: string;
+    kind: string;
+    icon: string;
+    left: string;
+    /** What it says when hovered: a heading and a few facts, like a lane but about one instant. */
+    label: string;
+    details: Array<TimelineDetail>;
+    /** How many markers this one stands for. More than one means they were too close to tell apart. */
+    count: number;
+    /** The span the markers behind it cover, which is what zooming into it has to show. */
+    from: number;
+    to: number;
+}
+
+/**
+ * A run of segments drawn as one element. It is what the pointer talks to, so that moving from one of
+ * its segments to the next never leaves it. Its segments and the markers that fall inside it are
+ * placed relative to it, not to the track.
+ */
+interface RenderedGroup {
+    id: string;
+    left: string;
+    width: string;
+    segments: RenderedSegment[];
+    markers: RenderedMarker[];
+}
+
+/** One line of the breakdown shown when a lane is hovered. */
+interface RenderedShare {
+    label: string;
+    duration: string;
+    /** Width of the proportion bar, as a percentage. */
+    width: string;
+    percent: string;
+}
+
+interface RenderedLane {
+    id: string;
+    label: string;
+    sublabel: string;
+    status: string;
+    depth: number;
+    expandable: boolean;
+    expanded: boolean;
+    activatable: boolean;
+    highlighted: boolean;
+    /** What the lane holds, read out for whoever cannot see the bars. */
+    description: string;
+    /** How long the lane runs from end to end. */
+    total: string;
+    /** Where that total went, segment by segment. */
+    shares: RenderedShare[];
+    details: Array<TimelineDetail>;
+    groups: RenderedGroup[];
+    /** Markers falling outside every group, placed against the track. */
+    markers: RenderedMarker[];
+    /** Whether anything is pinned on this lane, which is drawn above its bars and needs room for it. */
+    hasMarkers: boolean;
+}
+
+interface RenderedSection {
+    id: string;
+    label: string;
+    lanes: RenderedLane[];
+}
+
+interface RenderedFold {
+    id: string;
+    left: string;
+    width: string;
+    label: string;
+    title: string;
+}
+
+interface RenderedTick {
+    id: number;
+    left: string;
+    label: string;
+}
+
+/** The first and the last instant of the axis, marked so that no one takes them for a cut edge. */
+interface RenderedCap {
+    /** Position on the axis, kept so that graduations can be told to keep their distance. */
+    ratio: number;
+    left: string;
+    label: string;
+    /** The end of an axis whose last segment is still open is the present, and says so. */
+    live: boolean;
+    title: string;
+}
+
+/** Below this, zooming stops: the window would hold less than a pixel of the axis. */
+const MIN_SPAN = 0.0002;
+const ZOOM_FACTOR = 1.3;
+/** Long enough that crossing the timeline on the way somewhere else opens nothing. */
+const CARD_DELAY = 450;
+/** How much room the labels at either end of the axis are given before a graduation may be drawn. */
+const CAP_MARGIN_PX = 46;
+/**
+ * How far apart two markers have to be to be drawn separately. Closer than this they overlap, so they are
+ * drawn as one carrying a count — see `cluster()`.
+ */
+const MARKER_GAP_PX = 17;
+/** How many of them a card lists before it stops and says how many are left. */
+const CLUSTER_LISTED = 8;
+
+/** What the hover card is open on: a group of bars, or one marker. */
+interface CardSubject {
+    label: string;
+    /** Only a group of bars has a span to break down. */
+    total?: string;
+    shares?: RenderedShare[];
+    details: Array<TimelineDetail>;
+}
+
+/**
+ * Draws lanes of segments and markers against a time axis.
+ *
+ * The component knows nothing of what it draws: it is given sections, lanes, segments and markers,
+ * paints them from their `kind` and tells back which one was activated. Everything it owns is about
+ * showing time — the axis, folding idle stretches, zooming, panning, expanding a lane.
+ */
+@Component({
+    standalone: false,
+    selector: 'app-timeline',
+    templateUrl: './timeline.html',
+    styleUrls: ['./timeline.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TimelineComponent implements OnChanges, OnDestroy {
+    @Input() data: TimelineData;
+    /**
+     * Fold the stretches of time where no segment runs, so that a long wait does not squash the rest.
+     * On by default, and there is no control for it: a timeline that cannot fold is unreadable as soon
+     * as anything waits, so this is a property of the host's data rather than a user preference.
+     */
+    @Input() foldIdleGaps: boolean = true;
+    @Input() foldGapsLongerThanMs: number = DEFAULT_SCALE_OPTIONS.foldGapsLongerThanMs;
+    /** Dim every lane that is not highlighted, to bring out the ones that are. */
+    @Input() highlightEnabled: boolean = false;
+    /** Width of the column holding the lane labels. */
+    @Input() labelWidth: string = '260px';
+    @Input() label: string = 'Timeline';
+    @Input() emptyLabel: string = 'Nothing to show yet';
+    /** What several markers drawn as one are called: `12 files`, `12 uploads`, `12 releases`. */
+    @Input() markersLabel: string = 'markers';
+    /** Drawn as hovered, so that pointing at something elsewhere can point at it here. */
+    @Input() hoveredLaneID: string;
+    /** Drawn as the one currently open, so the view says what is being looked at. */
+    @Input() selectedLaneID: string;
+    /**
+     * The present, for segments that have not ended. Left out, the component keeps its own clock so
+     * that an open segment grows on screen.
+     */
+    @Input() now: number;
+
+    @Output() activate = new EventEmitter<TimelineActivation>();
+
+    @ViewChild('cardTemplate') cardTemplate: TemplateRef<any>;
+    /** Moved by hand as the pointer goes, so nothing here is a binding. */
+    @ViewChild('cursorLine') cursorLine: ElementRef<HTMLElement>;
+    @ViewChild('cursorLabel') cursorLabel: ElementRef<HTMLElement>;
+
+    /**
+     * Setters rather than plain queries: the axis and the lanes only exist once there is something to
+     * draw, so whatever watches them has to be attached when they appear, not when the view is built.
+     */
+    @ViewChild('axisTrack') set axisTrackRef(ref: ElementRef<HTMLElement>) {
+        this.axisTrack = ref;
+        this.observeAxis();
+    }
+    private axisTrack: ElementRef<HTMLElement>;
+
+    @ViewChild('viewport') set viewportRef(ref: ElementRef<HTMLElement>) {
+        this.viewport = ref;
+        this.watchPointer();
+    }
+    viewport: ElementRef<HTMLElement>;
+
+    sections: RenderedSection[] = [];
+    ticks: RenderedTick[] = [];
+    folds: RenderedFold[] = [];
+    startCap: RenderedCap;
+    endCap: RenderedCap;
+    empty: boolean = true;
+    /** Total span of the axis, shown next to the controls. */
+    totalLabel: string;
+
+    expandedAll: boolean = false;
+
+    private scale: TimelineScale;
+    private viewFrom: number = 0;
+    private viewTo: number = 1;
+    private expanded: { [laneID: string]: boolean } = {};
+    private trackWidth: number = 0;
+    /** What each end of the axis keeps clear of the track, in pixels. Decided on every layout. */
+    private ends: { start: number, end: number } = { start: AXIS_BAND_PX, end: AXIS_BAND_PX };
+    private clock: any;
+    private tick: number = Date.now();
+    private resizeObserver: ResizeObserver;
+    private destroyed: boolean = false;
+    private panPointer: number = null;
+    private panFrom: { x: number, viewFrom: number, viewTo: number };
+    /** A drag that panned must not be taken for a click on whatever it started over. */
+    private panned: boolean = false;
+
+    // The hover card.
+    private cardTimer: any;
+    private cardOverlay: OverlayRef;
+    private cardPosition: FlexibleConnectedPositionStrategy;
+    private cardContext: { $implicit: CardSubject };
+    /** What the card is open on — `lane:<id>` or `marker:<id>` — so a refresh can keep it up to date. */
+    private cardKey: string;
+    /** Whether the pointer is in the lanes, which holds the clock so nothing slides out from under it. */
+    private pointerInside: boolean = false;
+    /** One scroll to the foot of the lanes pending, so a burst of updates does not queue a dozen. */
+    private followQueued: boolean = false;
+    /** Where the pointer is, in client coordinates: what the guide and the card are placed against. */
+    private pointer = { x: 0, y: 0 };
+    private unwatchPointer: () => void;
+
+    private _cd = inject(ChangeDetectorRef);
+    private _zone = inject(NgZone);
+    private _overlay = inject(Overlay);
+    private _viewContainer = inject(ViewContainerRef);
+    private _injector = inject(Injector);
+
+    ngOnChanges(): void {
+        this.layout();
+    }
+
+    ngOnDestroy(): void {
+        this.destroyed = true;
+        this.stopClock();
+        this.clearCardTimer();
+        this.hideCard();
+        this.unwatchPointer?.();
+        this.cardOverlay?.dispose();
+        this.resizeObserver?.disconnect();
+    }
+
+    /** The width of the axis decides how many graduations fit and which segments can hold a label. */
+    private observeAxis(): void {
+        this.resizeObserver?.disconnect();
+        if (!this.axisTrack || this.destroyed) {
+            return;
+        }
+        this.resizeObserver = new ResizeObserver(entries => {
+            const width = entries[0]?.contentRect?.width ?? 0;
+            if (this.destroyed || Math.abs(width - this.trackWidth) < 1) {
+                return;
+            }
+            // Whether the callback of a ResizeObserver runs inside the zone is not something to rely
+            // on: going through it makes sure the new width is drawn.
+            this._zone.run(() => {
+                this.trackWidth = width;
+                this.layout();
+                this._cd.markForCheck();
+            });
+        });
+        this.resizeObserver.observe(this.axisTrack.nativeElement);
+    }
+
+    get zoomed(): boolean {
+        return this.viewFrom > 0 || this.viewTo < 1;
+    }
+
+    get panning(): boolean {
+        return this.panned;
+    }
+
+    // -- Display controls ----------------------------------------------------------------------
+
+    clickToggleAll(): void {
+        this.expandedAll = !this.expandedAll;
+        this.expanded = {};
+        if (this.expandedAll) {
+            flattenLanes(this.data).filter(l => l.lanes?.length > 0).forEach(l => this.expanded[l.id] = true);
+        }
+        this.layout();
+        this._cd.markForCheck();
+    }
+
+    clickToggleLane(laneID: string, event?: Event): void {
+        event?.stopPropagation();
+        this.expanded[laneID] = !this.expanded[laneID];
+        this.layout();
+        this._cd.markForCheck();
+    }
+
+    /** Zooming is on the wheel and the keys; the only button for it is the one that undoes it. */
+    zoomIn(): void {
+        this.zoomAt(0.5, 1 / ZOOM_FACTOR);
+    }
+
+    zoomOut(): void {
+        this.zoomAt(0.5, ZOOM_FACTOR);
+    }
+
+    resetZoom(): void {
+        this.viewFrom = 0;
+        this.viewTo = 1;
+        this.layout();
+        this._cd.markForCheck();
+    }
+
+    // -- Interactions --------------------------------------------------------------------------
+
+    /**
+     * The row and the bars are asked different questions, and each answers its own.
+     *
+     * The row — the name, and the empty track beside the bars — is *about* the lane: clicking it opens
+     * the lane up and shows what is inside. The bars *are* the lane: clicking them opens the thing
+     * itself. A lane with nothing inside it has only the second answer to give.
+     */
+    clickRow(lane: RenderedLane, event?: Event): void {
+        if (this.panned) {
+            return;
+        }
+        // The click lands on the column around the name rather than on the name itself, so nothing would
+        // be focused and every key that acts on the focused lane would do nothing until something was
+        // tabbed to. Whatever was clicked, the lane it belongs to takes the focus.
+        this.focusLane(event);
+        if (lane.expandable) {
+            this.clickToggleLane(lane.id);
+            return;
+        }
+        this.clickLane(lane);
+    }
+
+    clickGroup(lane: RenderedLane, event: Event): void {
+        event.stopPropagation();
+        this.focusLane(event);
+        this.clickLane(lane);
+    }
+
+    /** Puts the focus on the lane an event happened in, so the keys have something to act on. */
+    private focusLane(event?: Event): void {
+        const row = (event?.currentTarget as HTMLElement)?.closest('.lane');
+        row?.querySelector<HTMLElement>('.lane-label')?.focus({ preventScroll: true });
+    }
+
+    /**
+     * Zooming from the keyboard, wherever the focus is inside the view. A lane deals with these first and
+     * stops them, so this only sees the ones that reached no lane — the focus sitting on one of the
+     * controls, say, which is where it lands after using one.
+     */
+    onTimelineKeyDown(event: KeyboardEvent): void {
+        switch (event.key) {
+            case '+':
+            case '=':
+                event.preventDefault();
+                event.stopPropagation();
+                this.zoomIn();
+                return;
+            case '-':
+                event.preventDefault();
+                event.stopPropagation();
+                this.zoomOut();
+                return;
+            case '0':
+                event.preventDefault();
+                event.stopPropagation();
+                this.resetZoom();
+                return;
+        }
+    }
+
+    clickLane(lane: RenderedLane): void {
+        if (this.panned || !lane.activatable) {
+            return;
+        }
+        this.activate.emit({ laneID: lane.id });
+    }
+
+    clickMarker(lane: RenderedLane, marker: RenderedMarker, event: Event): void {
+        event.stopPropagation();
+        if (this.panned) {
+            return;
+        }
+        // Several drawn as one stand for no single thing to open. Zooming into what they cover pulls them
+        // apart, and each is then its own mark again — which is also why the view, and not the host, is
+        // what decides they were too close in the first place.
+        if (marker.count > 1) {
+            this.zoomToRange(marker.from, marker.to);
+            return;
+        }
+        this.activate.emit({ laneID: lane.id, markerID: marker.id });
+    }
+
+    /**
+     * Bring a stretch of the axis into view, wide enough that what is in it has room to separate. A
+     * stretch of no length cannot be pulled apart by any amount of zoom — those markers really are
+     * simultaneous — so the window is left alone and the card is what tells them apart.
+     */
+    private zoomToRange(from: number, to: number): void {
+        const a = this.scale.ratio(from);
+        const b = this.scale.ratio(to);
+        if (!(b > a)) {
+            return;
+        }
+        const span = Math.min(Math.max((b - a) * 3, MIN_SPAN), 1);
+        this.setWindow((a + b) / 2 - span / 2, span);
+    }
+
+    /**
+     * Keys handled here are stopped from bubbling. A host page is free to listen for arrows and Enter on
+     * the window to drive something of its own, and it must not act on a key that was meant for a lane.
+     */
+    onKeyDown(event: KeyboardEvent, lane: RenderedLane): void {
+        switch (event.key) {
+            case 'ArrowDown':
+            case 'ArrowUp':
+                event.preventDefault();
+                event.stopPropagation();
+                this.moveFocus(event.key === 'ArrowDown' ? 1 : -1);
+                return;
+            case 'ArrowRight':
+                if (lane.expandable && !lane.expanded) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    this.clickToggleLane(lane.id);
+                }
+                return;
+            case 'ArrowLeft':
+                if (lane.expandable && lane.expanded) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    this.clickToggleLane(lane.id);
+                }
+                return;
+            case '+':
+            case '=':
+                event.preventDefault();
+                event.stopPropagation();
+                this.zoomIn();
+                return;
+            case '-':
+                event.preventDefault();
+                event.stopPropagation();
+                this.zoomOut();
+                return;
+            case '0':
+                event.preventDefault();
+                event.stopPropagation();
+                this.resetZoom();
+                return;
+            case 'Enter':
+            case ' ':
+                // Opens the lane, where a click on the row unfolds it. Stopped from turning into a click,
+                // which would reach the row and unfold instead; and from reaching the window, which would
+                // hand it to the host page.
+                event.preventDefault();
+                event.stopPropagation();
+                this.clickLane(lane);
+                return;
+        }
+    }
+
+    /**
+     * Nothing here uses Shift as a modifier, on purpose. A host page may well treat a Shift keydown
+     * anywhere as a shortcut of its own, and the wheel needs no focus, so a Shift wheel over the lanes
+     * would reach it without the pointer ever having been near what it drives.
+     */
+    onWheel(event: WheelEvent): void {
+        if (event.ctrlKey || event.metaKey) {
+            event.preventDefault();
+            const step = event.deltaY !== 0 ? event.deltaY : event.deltaX;
+            const rect = this.axisTrack?.nativeElement?.getBoundingClientRect();
+            const at = rect && rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0.5;
+            this.zoomAt(Math.min(Math.max(at, 0), 1), step > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR);
+            return;
+        }
+        // Sideways on a trackpad pans; straight up and down is left to the panel, which scrolls the lanes.
+        if (this.zoomed && Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+            event.preventDefault();
+            this.panBy(event.deltaX / 800);
+        }
+    }
+
+    onPointerDown(event: PointerEvent): void {
+        this.panned = false;
+        if (!this.zoomed || event.button !== 0) {
+            return;
+        }
+        if ((event.target as HTMLElement)?.closest('button')) {
+            return;
+        }
+        this.panPointer = event.pointerId;
+        this.panFrom = { x: event.clientX, viewFrom: this.viewFrom, viewTo: this.viewTo };
+    }
+
+    onPointerMove(event: PointerEvent): void {
+        if (this.panPointer !== event.pointerId || !this.panFrom) {
+            return;
+        }
+        const delta = event.clientX - this.panFrom.x;
+        if (!this.panned && Math.abs(delta) < 3) {
+            return;
+        }
+        // The pointer is only captured once the press turns out to be a drag. Capturing it on the press
+        // would retarget the click that ends it to the viewport, and clicking a lane while zoomed in
+        // would do nothing at all.
+        if (!this.panned) {
+            this.panned = true;
+            this.hideCard();
+            this.viewport?.nativeElement?.setPointerCapture(event.pointerId);
+        }
+        const span = this.panFrom.viewTo - this.panFrom.viewFrom;
+        const moved = this.trackWidth > 0 ? -(delta / this.trackWidth) * span : 0;
+        this.setWindow(this.panFrom.viewFrom + moved, span);
+    }
+
+    onPointerUp(event: PointerEvent): void {
+        if (this.panPointer !== event.pointerId) {
+            return;
+        }
+        if (this.panned) {
+            this.viewport?.nativeElement?.releasePointerCapture(event.pointerId);
+        }
+        this.panPointer = null;
+        this.panFrom = null;
+        // Released before the click event: the click that ends a pan is dropped, the next one is not.
+        setTimeout(() => this.panned = false);
+    }
+
+    // -- What a lane says when hovered ---------------------------------------------------------
+
+    /**
+     * The card is asked for by the group of bars, not by the row: pointing at the name of a lane, or at
+     * the empty track next to its bars, is not asking how its time was spent.
+     *
+     * It goes in an overlay of its own, anchored above what it is about. Drawn inside the timeline it was
+     * cut off by the panel, which is a few hundred pixels tall and clips what overflows it. It does not
+     * follow the pointer: a card that moves is a card that has to be read while moving, and where it
+     * will appear is worth being able to predict.
+     */
+    onGroupEnter(lane: RenderedLane, event: MouseEvent): void {
+        this.showLaneCard(lane, event.currentTarget as HTMLElement);
+    }
+
+    private showLaneCard(lane: RenderedLane, group: HTMLElement): void {
+        this.askForCard({
+            label: lane.label,
+            total: lane.total,
+            shares: lane.shares,
+            details: lane.details
+        }, group, `lane:${lane.id}`);
+    }
+
+    /**
+     * A marker has something of its own to say — what it is, and when — so it says it instead of letting
+     * the group speak for it. It sits inside the group, so without this, pointing at one would leave the
+     * group's card up over something it is not about.
+     */
+    onMarkerEnter(marker: RenderedMarker, event: MouseEvent): void {
+        event.stopPropagation();
+        this.askForCard({
+            label: marker.label,
+            details: marker.details
+        }, event.currentTarget as HTMLElement, `marker:${marker.id}`);
+    }
+
+    /**
+     * A marker sits inside its group, so leaving it does not leave the group — nothing would fire to put
+     * the group's card back, and it would stay gone until the group was left and entered again. Handing
+     * it back here is what keeps moving from a marker to the bar under it working.
+     */
+    onMarkerLeave(lane: RenderedLane, event: MouseEvent): void {
+        const group = (event.currentTarget as HTMLElement)?.closest('.segment-group') as HTMLElement;
+        if (!group) {
+            this.onCardLeave();
+            return;
+        }
+        this.showLaneCard(lane, group);
+    }
+
+    /**
+     * Going from one segment of a group to the next never gets here: they are one group, and the group is
+     * one element. This is for leaving a group or a marker, and the short wait is only so that going from
+     * one to the next carries the card across instead of starting its delay again.
+     */
+    onCardLeave(): void {
+        this.clearCardTimer();
+        this.cardTimer = setTimeout(() => {
+            this.cardTimer = null;
+            this.hideCard();
+            this._cd.markForCheck();
+        }, 100);
+    }
+
+    /** Drop the card at once, for what has moved the bars out from under it. */
+    dropCard(): void {
+        this.clearCardTimer();
+        this.hideCard();
+    }
+
+    private askForCard(subject: CardSubject, anchor: HTMLElement, key: string): void {
+        this.clearCardTimer();
+        if (this.panPointer !== null || this.destroyed || !anchor) {
+            return;
+        }
+        // Already up on something else: swap it over at once, having already waited once.
+        if (this.cardOverlay?.hasAttached()) {
+            this.showCard(subject, anchor, key);
+            return;
+        }
+        this.cardTimer = setTimeout(() => {
+            this.cardTimer = null;
+            this.showCard(subject, anchor, key);
+        }, CARD_DELAY);
+    }
+
+    private showCard(subject: CardSubject, anchor: HTMLElement, key: string): void {
+        if (this.destroyed || !this.cardTemplate || !anchor.isConnected) {
+            return;
+        }
+
+        // Above what it is about, and lined up with the pointer where it was when the card was asked
+        // for — close to what is being read, and then still. A card placed dead centre of a bar that
+        // spans the view is nowhere near the pointer; one that follows it has to be read while moving.
+        const rect = anchor.getBoundingClientRect();
+        const origin = { x: this.pointer.x, y: rect.top, width: 0, height: rect.height };
+
+        if (!this.cardOverlay) {
+            this.cardPosition = this._overlay.position()
+                .flexibleConnectedTo(origin)
+                .withPositions([
+                    { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetY: -10 },
+                    { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetY: 10 }
+                ])
+                // Pushed back inside the window rather than flipped sideways, so it never jumps corners.
+                .withPush(true)
+                .withFlexibleDimensions(false)
+                .withViewportMargin(8);
+            this.cardOverlay = this._overlay.create({
+                positionStrategy: this.cardPosition,
+                scrollStrategy: this._overlay.scrollStrategies.noop(),
+                hasBackdrop: false,
+                disposeOnNavigation: true
+            });
+            // Nothing on the card is meant to be aimed at.
+            this.cardOverlay.overlayElement.style.pointerEvents = 'none';
+        }
+
+        this.cardKey = key;
+        this.cardPosition.setOrigin(origin);
+
+        // The card is an embedded view of this component's own container, so it is checked when this
+        // component is: marking is enough, and calling detection by hand from inside a pass would be
+        // checking a view that is already being checked.
+        if (this.cardOverlay.hasAttached()) {
+            this.cardContext.$implicit = subject;
+            this.cardOverlay.updatePosition();
+            this._cd.markForCheck();
+            return;
+        }
+        this.cardContext = { $implicit: subject };
+        this.cardOverlay.attach(new TemplatePortal(this.cardTemplate, this._viewContainer, this.cardContext));
+        this._cd.markForCheck();
+    }
+
+    private hideCard(): void {
+        this.cardKey = null;
+        if (this.cardOverlay?.hasAttached()) {
+            this.cardOverlay.detach();
+        }
+    }
+
+    /** Keeps what the card says in step with the data while it stays open on something still going. */
+    private refreshCard(): void {
+        if (!this.cardKey?.startsWith('lane:') || !this.cardContext) {
+            return;
+        }
+        const id = this.cardKey.substring('lane:'.length);
+        const lane = this.sections
+            .reduce((all, section) => all.concat(section.lanes), <RenderedLane[]>[])
+            .find(l => l.id === id);
+        if (!lane) {
+            this.hideCard();
+            return;
+        }
+        this.cardContext.$implicit = {
+            label: lane.label,
+            total: lane.total,
+            shares: lane.shares,
+            details: lane.details
+        };
+    }
+
+    /**
+     * Follows the pointer across the lanes, for two things at once.
+     *
+     * A **guide** is drawn down the lanes where the pointer is, with the time it stands for shown up on
+     * the axis: on a folded axis, working out what a position means is otherwise guesswork.
+     *
+     * And the **clock is held** while the pointer is in there. An axis with an open segment on it redraws
+     * itself every second, which moves every bar a little to the left as it grows, and aiming at something
+     * while it slides away is not something anyone should have to do.
+     *
+     * All of it runs outside the zone, writing the two elements it moves by hand: a mouse move changes
+     * nothing else that has to be rendered, and running change detection on every one of them would cost
+     * the whole page.
+     */
+    private watchPointer(): void {
+        this.unwatchPointer?.();
+        const element = this.viewport?.nativeElement;
+        if (!element) {
+            return;
+        }
+
+        const onMove = (event: MouseEvent) => {
+            this.pointer = { x: event.clientX, y: event.clientY };
+            this.drawGuide();
+        };
+        const onEnter = () => {
+            this.pointerInside = true;
+        };
+        const onLeave = () => {
+            this.pointerInside = false;
+            this.hideGuide();
+            // Catch up on everything the clock did not draw while it was held.
+            this._zone.run(() => {
+                this.layout();
+                this._cd.markForCheck();
+            });
+        };
+
+        this._zone.runOutsideAngular(() => {
+            element.addEventListener('mousemove', onMove, { passive: true });
+            element.addEventListener('mouseenter', onEnter, { passive: true });
+            element.addEventListener('mouseleave', onLeave, { passive: true });
+        });
+        this.unwatchPointer = () => {
+            element.removeEventListener('mousemove', onMove);
+            element.removeEventListener('mouseenter', onEnter);
+            element.removeEventListener('mouseleave', onLeave);
+            this.unwatchPointer = null;
+        };
+    }
+
+    /** Where the pointer is, and what time that is. Written straight to the DOM, outside the zone. */
+    private drawGuide(): void {
+        const line = this.cursorLine?.nativeElement;
+        const label = this.cursorLabel?.nativeElement;
+        const track = this.axisTrack?.nativeElement;
+        if (!line || !label || !track || !this.scale) {
+            return;
+        }
+
+        const rect = track.getBoundingClientRect();
+        const x = this.pointer.x - rect.left;
+        // Only over the part of the track things are drawn in: what the ends keep clear stands for no one
+        // instant, so there is no time to read off it.
+        if (x < this.ends.start || x > rect.width - this.ends.end) {
+            this.hideGuide();
+            return;
+        }
+
+        const ratio = (x - this.ends.start) / Math.max(rect.width - this.ends.start - this.ends.end, 1);
+        const at = this.scale.time(this.viewFrom + ratio * (this.viewTo - this.viewFrom));
+
+        line.style.left = `${x}px`;
+        line.style.display = 'block';
+        label.style.left = `${x}px`;
+        label.style.display = 'block';
+        label.textContent = TimelineComponent.clock(at);
+    }
+
+    private hideGuide(): void {
+        const line = this.cursorLine?.nativeElement;
+        const label = this.cursorLabel?.nativeElement;
+        if (line) {
+            line.style.display = 'none';
+        }
+        if (label) {
+            label.style.display = 'none';
+        }
+    }
+
+    private static clock(at: number): string {
+        const pad = (value: number) => value < 10 ? `0${value}` : `${value}`;
+        const date = new Date(at);
+        return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+    }
+
+    private clearCardTimer(): void {
+        if (this.cardTimer) {
+            clearTimeout(this.cardTimer);
+            this.cardTimer = null;
+        }
+    }
+
+    // -- Layout --------------------------------------------------------------------------------
+
+    private zoomAt(anchor: number, factor: number): void {
+        const span = this.viewTo - this.viewFrom;
+        const next = Math.min(Math.max(span * factor, MIN_SPAN), 1);
+        const focus = this.viewFrom + anchor * span;
+        this.setWindow(focus - (focus - this.viewFrom) * (next / span), next);
+    }
+
+    private panBy(ratio: number): void {
+        const span = this.viewTo - this.viewFrom;
+        this.setWindow(this.viewFrom + ratio * span, span);
+    }
+
+    private setWindow(from: number, span: number): void {
+        this.viewFrom = Math.min(Math.max(from, 0), 1 - span);
+        this.viewTo = this.viewFrom + span;
+        this.layout();
+        this._cd.markForCheck();
+    }
+
+    /** Where a date lands in the window, in [0, 1] of the visible width. */
+    private position(time: number): number {
+        const span = this.viewTo - this.viewFrom || 1;
+        return (this.scale.ratio(time) - this.viewFrom) / span;
+    }
+
+    private static pct(value: number): string {
+        return `${(value * 100).toFixed(4)}%`;
+    }
+
+    /** What each end of the axis keeps clear, as a fraction of the width of the track. */
+    private get endFractions(): { start: number, end: number } {
+        const track = this.trackWidth || 800;
+        return { start: this.ends.start / track, end: this.ends.end / track };
+    }
+
+    /**
+     * Where a position of the axis is drawn across the track. Everything is squeezed into the space the
+     * two ends leave, so nothing is ever drawn into what they keep clear.
+     */
+    private trackPct(ratio: number): string {
+        const ends = this.endFractions;
+        return TimelineComponent.pct(ends.start + ratio * (1 - ends.start - ends.end));
+    }
+
+    /** The same squeeze, applied to a width rather than to a position. */
+    private trackSpan(width: number): string {
+        const ends = this.endFractions;
+        return TimelineComponent.pct(width * (1 - ends.start - ends.end));
+    }
+
+    /** Width of the part of the track things are drawn in, in pixels. */
+    private get plotWidth(): number {
+        return Math.max((this.trackWidth || 800) - this.ends.start - this.ends.end, 1);
+    }
+
+    private layout(): void {
+        const lanes = flattenLanes(this.data);
+        this.empty = lanes.length === 0;
+        if (this.empty) {
+            this.sections = [];
+            this.ticks = [];
+            this.folds = [];
+            this.totalLabel = null;
+            this.stopClock();
+            return;
+        }
+
+        const open = lanes.some(lane => (lane.segments ?? []).some(s => s.end === null || s.end === undefined));
+        if (open && this.now === undefined) {
+            this.startClock();
+        } else {
+            this.stopClock();
+        }
+        const present = this.now !== undefined ? this.now : this.tick;
+
+        const busy: TimelineBusy[] = [];
+        let start = Infinity;
+        let end = -Infinity;
+        // What the ends of the axis have to make room for, on top of the bands themselves: whether
+        // anything on the axis lasted at all, and where the outermost instants are. See `axisEnds`.
+        let lasting = false;
+        let firstMark = Infinity;
+        let lastMark = -Infinity;
+        lanes.forEach(lane => {
+            (lane.segments ?? []).forEach(segment => {
+                const to = segment.end ?? present;
+                // An idle segment still sets the bounds of the axis, but it does not keep its stretch
+                // of time from being folded: waiting is not something happening.
+                if (!segment.idle) {
+                    busy.push({ start: segment.start, end: Math.max(to, segment.start) });
+                }
+                lasting = lasting || to > segment.start;
+                start = Math.min(start, segment.start);
+                end = Math.max(end, to, segment.start);
+            });
+            // A group is indivisible: whatever sits between two of its segments holds the axis open, so
+            // no fold can open inside it and its pieces keep their proportions to one another. This says
+            // nothing about the inside of a segment: a long wait drawn as one idle segment is exactly what
+            // folding is for, and folding straight through it has to stay possible.
+            busy.push(...TimelineComponent.gapsWithinGroups(lane, present));
+            // A marker holds a stretch of no length: it keeps its instant out of a fold, so that what
+            // happened during a long wait stays visible instead of being folded away with it.
+            (lane.markers ?? []).forEach(marker => {
+                busy.push({ start: marker.at, end: marker.at });
+                firstMark = Math.min(firstMark, marker.at);
+                lastMark = Math.max(lastMark, marker.at);
+                start = Math.min(start, marker.at);
+                end = Math.max(end, marker.at);
+            });
+        });
+
+        start = this.data.start ?? (isFinite(start) ? start : present);
+        end = Math.max(this.data.end ?? (isFinite(end) ? end : present), start);
+
+        // How much of the track the ends of the axis need. Decided before anything is placed, since
+        // everything is placed between the two.
+        this.ends = axisEnds({
+            trackWidth: this.trackWidth || 800,
+            lasting,
+            markAtStart: firstMark <= start,
+            markAtEnd: lastMark >= end
+        });
+
+        this.scale = TimelineScale.build(start, end, busy, {
+            foldGapsLongerThanMs: this.foldIdleGaps ? this.foldGapsLongerThanMs : 0,
+            foldedGapShare: DEFAULT_SCALE_OPTIONS.foldedGapShare
+        });
+        this.totalLabel = formatDuration(end - start);
+
+        this.sections = (this.data.sections ?? []).map(section => ({
+            id: section.id,
+            label: section.label,
+            lanes: this.renderLanes(section.lanes, 0, present, false)
+        })).filter(section => section.lanes.length > 0 || !!section.label);
+
+        this.folds = this.scale.folds
+            .map((fold, i) => this.renderFold(fold, i))
+            .filter(fold => !!fold);
+
+        // The ends of the axis are marked rather than left to be guessed: a bar reaching the edge of
+        // the view says nothing about whether there is more of it past that edge. When zoomed in, the marks
+        // fall outside the window and are not drawn, which is itself the answer.
+        this.startCap = this.renderCap(start, 'Start', false);
+        this.endCap = this.renderCap(end, open ? 'Now' : 'End', open);
+
+        const maxTicks = Math.max(Math.floor(this.plotWidth / 90), 2);
+        // The labels at either end have their own room: a graduation crowding them would leave two
+        // times printed on top of one another.
+        const margin = CAP_MARGIN_PX / this.plotWidth;
+        const capsAt = [this.startCap, this.endCap].filter(cap => !!cap).map(cap => cap.ratio);
+        this.ticks = this.scale.ticks(this.viewFrom, this.viewTo, maxTicks)
+            .map(t => ({ id: t.at, ratio: this.position(t.at), label: t.label }))
+            .filter(t => capsAt.every(cap => Math.abs(t.ratio - cap) > margin))
+            .map(t => ({ id: t.id, left: this.trackPct(t.ratio), label: t.label }));
+
+        // A card left open on something still going would otherwise freeze on the numbers it opened with.
+        this.refreshCard();
+
+        // Decided here rather than after drawing: once the new lanes are in, the foot of the list has
+        // moved and there is no telling whether it was being watched.
+        this.keepUpWithTheData(open);
+    }
+
+    /**
+     * Lanes are added at the foot of the list as they begin, so a view that stays where it was shows less
+     * of the whole the longer it goes on. So the lanes are followed down, the way a log tail is.
+     *
+     * Only while nothing has been asked for, though. Zooming in, or scrolling away from the foot of the
+     * list, is someone saying they are reading something in particular — and what they are reading must
+     * not be dragged out from under them. Scrolling back to the foot picks the following up again, which
+     * is why this asks where the list is rather than remembering that it was once left.
+     */
+    private keepUpWithTheData(live: boolean): void {
+        const element = this.viewport?.nativeElement;
+        if (!element?.offsetParent || this.followQueued) {
+            return;
+        }
+        const room = element.scrollHeight - element.scrollTop - element.clientHeight;
+        if (!shouldFollow(live, this.zoomed, this.pointerInside, room)) {
+            return;
+        }
+        this.followQueued = true;
+        afterNextRender(() => {
+            this.followQueued = false;
+            const view = this.viewport?.nativeElement;
+            if (view && !this.pointerInside) {
+                view.scrollTop = view.scrollHeight;
+            }
+        }, { injector: this._injector });
+    }
+
+    private renderCap(at: number, name: string, live: boolean): RenderedCap {
+        const ratio = this.position(at);
+        if (ratio < 0 || ratio > 1) {
+            return null;
+        }
+        return {
+            ratio,
+            left: this.trackPct(ratio),
+            label: name,
+            live,
+            title: `${name} of the timeline — ${new Date(at).toLocaleString()}`
+        };
+    }
+
+    private renderFold(fold: TimelineScalePiece, index: number): RenderedFold {
+        const from = (fold.from - this.viewFrom) / (this.viewTo - this.viewFrom || 1);
+        const to = (fold.to - this.viewFrom) / (this.viewTo - this.viewFrom || 1);
+        if (to < 0 || from > 1) {
+            return null;
+        }
+        const label = TimelineScale.foldLabel(fold);
+        return {
+            id: `fold-${index}`,
+            left: this.trackPct(Math.max(from, -0.05)),
+            width: this.trackSpan(Math.min(to, 1.05) - Math.max(from, -0.05)),
+            label,
+            title: `Nothing ran for ${label}, folded to keep the rest readable`
+        };
+    }
+
+    private renderLanes(lanes: TimelineLane[], depth: number, present: number, parentHighlighted: boolean): RenderedLane[] {
+        const rendered: RenderedLane[] = [];
+        (lanes ?? []).forEach(lane => {
+            const expandable = (lane.lanes ?? []).length > 0;
+            const expanded = expandable && !!this.expanded[lane.id];
+            const span = TimelineComponent.spanOf(lane, present);
+            // What is inside a highlighted lane belongs to it: dimming the lanes nested under a
+            // highlighted one would hide the very thing the highlight was turned on to look at.
+            const highlighted = !!lane.highlighted || parentHighlighted;
+            const track = this.renderTrack(lane, present);
+            rendered.push({
+                id: lane.id,
+                label: lane.label,
+                sublabel: lane.sublabel,
+                status: lane.status ?? '',
+                depth,
+                expandable,
+                expanded,
+                activatable: !!lane.activatable,
+                highlighted,
+                description: TimelineComponent.describe(lane, present),
+                total: span > 0 ? formatDuration(span) : null,
+                shares: TimelineComponent.shares(lane, present, span),
+                details: lane.details ?? [],
+                ...track,
+                hasMarkers: track.markers.length > 0 || track.groups.some(g => g.markers.length > 0)
+            });
+            if (expanded) {
+                rendered.push(...this.renderLanes(lane.lanes, depth + 1, present, highlighted));
+            }
+        });
+        return rendered;
+    }
+
+    /**
+     * What goes in the track of a lane: its groups, each holding the segments it is made of and the
+     * markers that fall inside it, and whatever markers fall outside all of them.
+     *
+     * A group is placed against the track, and everything inside it against the group. Cutting the group
+     * down to the part of it that can be seen keeps its width bounded however far the axis is zoomed in,
+     * and its children move with it, so what is inside stays where it belongs.
+     */
+    private renderTrack(lane: TimelineLane, present: number): { groups: RenderedGroup[], markers: RenderedMarker[] } {
+        const plotPixels = this.plotWidth;
+        const groups: RenderedGroup[] = [];
+        const taken = new Set<string>();
+
+        TimelineComponent.groupsOf(lane).forEach((segments, index) => {
+            const endOf = (segment: TimelineSegment) => Math.max(segment.end ?? present, segment.start);
+            const opensAt = Math.min(...segments.map(s => s.start));
+            const closesAt = Math.max(...segments.map(endOf));
+            const from = this.position(opensAt);
+            const to = this.position(closesAt);
+            if (to < -0.5 || from > 1.5) {
+                return;
+            }
+
+            const left = Math.max(from, -0.5);
+            const right = Math.min(to, 1.5);
+            const width = right - left;
+            /** Where a position of the track falls inside the visible part of the group, in [0, 1]. */
+            const inside = (at: number) => width > 0 ? Math.min(Math.max((at - left) / width, 0), 1) : 0;
+
+            const rendered: RenderedSegment[] = segments.map(segment => {
+                const open = segment.end === null || segment.end === undefined;
+                const ends = endOf(segment);
+                const starts = this.position(segment.start);
+                const stops = this.position(ends);
+                const pixels = (stops - starts) * plotPixels;
+                const at = inside(starts);
+                return <RenderedSegment>{
+                    id: segment.id,
+                    kind: segment.kind,
+                    label: segment.label,
+                    duration: formatDuration(ends - segment.start),
+                    left: TimelineComponent.pct(at),
+                    width: TimelineComponent.pct(Math.max(inside(stops) - at, 0)),
+                    showLabel: !!segment.label && pixels > 44,
+                    // Read straight off the bar when it is wide enough, rather than only on hover.
+                    showDuration: pixels > 96,
+                    open
+                };
+            });
+
+            // A marker sitting in the span of a group is drawn inside it, so that pointing at it is still
+            // pointing at the group rather than dropping out of it.
+            const mine = (lane.markers ?? []).filter(marker => marker.at >= opensAt && marker.at <= closesAt);
+            mine.forEach(marker => taken.add(marker.id));
+            // Inside a group, so placed against the group and already squeezed with it. Its own width in
+            // pixels is what says whether two of them would overlap.
+            const markers = this.cluster(mine, Math.max(width, 0) * plotPixels,
+                marker => inside(this.position(marker.at)), TimelineComponent.pct);
+
+            groups.push({
+                id: `${lane.id}-group-${index}`,
+                left: this.trackPct(left),
+                width: this.trackSpan(Math.max(width, 0)),
+                segments: rendered,
+                markers
+            });
+        });
+
+        // A loose marker is placed against the track, so it takes the squeeze the bands impose.
+        const loose = this.cluster(
+            (lane.markers ?? []).filter(marker => !taken.has(marker.id) && this.position(marker.at) >= -0.02 && this.position(marker.at) <= 1.02),
+            plotPixels,
+            marker => this.position(marker.at),
+            ratio => this.trackPct(ratio));
+
+        return { groups, markers: loose };
+    }
+
+    /**
+     * Markers too close together to be told apart are drawn as one, carrying how many it stands for.
+     *
+     * This belongs to the view and nowhere else: whether two of them collide is a fact about pixels — it
+     * depends on the zoom, on how wide the track is and on how big a marker is drawn — none of which the
+     * side providing the data knows. Forty markers a second apart overlap on an axis spanning an hour and
+     * do not once it is zoomed in, so the same data has to cluster differently from one moment to the next.
+     */
+    private cluster(
+        markers: TimelineMarker[],
+        widthPixels: number,
+        ratioOf: (marker: TimelineMarker) => number,
+        format: (ratio: number) => string
+    ): RenderedMarker[] {
+        if (markers.length === 0) {
+            return [];
+        }
+        const ordered = markers.slice().sort((a, b) => a.at - b.at);
+        const clusters: TimelineMarker[][] = [];
+        let last = -Infinity;
+        ordered.forEach(marker => {
+            const pixels = ratioOf(marker) * widthPixels;
+            if (clusters.length > 0 && pixels - last < MARKER_GAP_PX) {
+                clusters[clusters.length - 1].push(marker);
+            } else {
+                clusters.push([marker]);
+            }
+            last = pixels;
+        });
+
+        return clusters.map(members => {
+            const first = members[0];
+            const left = format(ratioOf(first));
+            if (members.length === 1) {
+                return <RenderedMarker>{
+                    id: first.id,
+                    kind: first.kind ?? 'default',
+                    icon: timelineIcon(first.icon),
+                    left,
+                    label: first.label ?? first.kind ?? '',
+                    details: first.details ?? [],
+                    count: 1,
+                    from: first.at,
+                    to: first.at
+                };
+            }
+
+            // One kind throughout keeps its own icon and its own word; a mixed handful gets a mark saying
+            // only "several", and the general word, since no one kind speaks for the rest.
+            const kinds = new Set(members.map(m => m.kind));
+            const icons = new Set(members.map(m => m.icon));
+            const plurals = new Set(members.map(m => m.plural).filter(word => !!word));
+            const details: Array<TimelineDetail> = members.slice(0, CLUSTER_LISTED)
+                .map(m => ({ label: m.label ?? m.kind ?? '', value: TimelineComponent.clock(m.at) }));
+            if (members.length > CLUSTER_LISTED) {
+                details.push({ label: `and ${members.length - CLUSTER_LISTED} more`, value: '' });
+            }
+            return <RenderedMarker>{
+                id: `cluster-${first.id}`,
+                kind: kinds.size === 1 ? first.kind ?? 'default' : 'cluster',
+                icon: icons.size === 1 ? timelineIcon(first.icon) : 'appstore',
+                left,
+                label: `${members.length} ${plurals.size === 1 ? [...plurals][0] : this.markersLabel}`,
+                details,
+                count: members.length,
+                from: first.at,
+                to: members[members.length - 1].at
+            };
+        });
+    }
+
+    /**
+     * The stretches that separate the segments of one group, which is what makes a group indivisible on
+     * the axis. Where a group's segments run end to end — one phase handing straight over to the next —
+     * there are none, and this earns its place as a guarantee rather than as a fix.
+     */
+    private static gapsWithinGroups(lane: TimelineLane, present: number): TimelineBusy[] {
+        const gaps: TimelineBusy[] = [];
+        TimelineComponent.groupsOf(lane).forEach(segments => {
+            if (segments.length < 2) {
+                return;
+            }
+            const ordered = segments.slice().sort((a, b) => a.start - b.start);
+            for (let i = 1; i < ordered.length; i++) {
+                const previous = Math.max(ordered[i - 1].end ?? present, ordered[i - 1].start);
+                if (ordered[i].start > previous) {
+                    gaps.push({ start: previous, end: ordered[i].start });
+                }
+            }
+        });
+        return gaps;
+    }
+
+    /** The segments of a lane, gathered by group. A segment with no group is a group of its own. */
+    private static groupsOf(lane: TimelineLane): TimelineSegment[][] {
+        const groups = new Map<string, TimelineSegment[]>();
+        (lane.segments ?? []).forEach((segment, index) => {
+            const key = segment.group ?? `${segment.id}#${index}`;
+            if (!groups.has(key)) {
+                groups.set(key, []);
+            }
+            groups.get(key).push(segment);
+        });
+        return Array.from(groups.values());
+    }
+
+    /** From the start of the first segment to the end of the last: the wall clock of the lane. */
+    private static spanOf(lane: TimelineLane, present: number): number {
+        const segments = lane.segments ?? [];
+        if (segments.length === 0) {
+            return 0;
+        }
+        const from = Math.min(...segments.map(s => s.start));
+        const to = Math.max(...segments.map(s => Math.max(s.end ?? present, s.start)));
+        return Math.max(to - from, 0);
+    }
+
+    /**
+     * Where the span of a lane went. This is the point of the whole view: something that took four minutes
+     * of which three were spent waiting is a different matter from one that spent them working.
+     */
+    private static shares(lane: TimelineLane, present: number, span: number): RenderedShare[] {
+        if (span <= 0) {
+            return [];
+        }
+        return (lane.segments ?? []).map(segment => {
+            const length = Math.max((segment.end ?? present) - segment.start, 0);
+            const share = length / span;
+            return <RenderedShare>{
+                label: segment.label ?? segment.kind,
+                duration: formatDuration(length),
+                width: TimelineComponent.pct(share),
+                percent: `${Math.round(share * 100)}%`
+            };
+        });
+    }
+
+    /** What the lane holds, in words: the bars carry it for the eye, this carries it for the rest. */
+    private static describe(lane: TimelineLane, present: number): string {
+        const parts = (lane.segments ?? []).map(segment => {
+            const to = segment.end ?? present;
+            return `${segment.label ?? segment.kind} ${formatDuration(Math.max(to - segment.start, 0))}`;
+        });
+        const markers = (lane.markers ?? []).length;
+        if (markers > 0) {
+            parts.push(`${markers} marker${markers > 1 ? 's' : ''}`);
+        }
+        return parts.join(', ');
+    }
+
+    // -- Clock ---------------------------------------------------------------------------------
+
+    private startClock(): void {
+        if (this.clock) {
+            return;
+        }
+        this.clock = setInterval(() => {
+            // Held while the pointer is in the lanes: growing the axis moves every bar, and nothing
+            // should slide away from under a pointer that is trying to reach it. Held too while the view
+            // is not on screen — a tab kept alive behind another one has nothing to redraw.
+            if (this.pointerInside || !this.viewport?.nativeElement?.offsetParent) {
+                return;
+            }
+            this.tick = Date.now();
+            this.layout();
+            this._cd.markForCheck();
+        }, 1000);
+    }
+
+    private stopClock(): void {
+        if (!this.clock) {
+            return;
+        }
+        clearInterval(this.clock);
+        this.clock = null;
+    }
+
+    // -- Focus ---------------------------------------------------------------------------------
+
+    /** Moves focus to the lane above or below, so that arrows walk the lanes without leaving them. */
+    private moveFocus(direction: number): void {
+        const host = this.viewport?.nativeElement;
+        if (!host) {
+            return;
+        }
+        const items = Array.from(host.querySelectorAll<HTMLElement>('.lane-label'));
+        const current = items.findIndex(item => item === document.activeElement);
+        const next = items[Math.min(Math.max((current === -1 ? 0 : current) + direction, 0), items.length - 1)];
+        next?.focus();
+    }
+}

--- a/ui/libs/timeline/src/lib/timeline.html
+++ b/ui/libs/timeline/src/lib/timeline.html
@@ -1,0 +1,224 @@
+<!-- The keydown here catches what the lanes did not: the zoom keys, wherever the focus happens to be
+     inside the view. It is not itself something to focus — it only listens to what bubbles up. -->
+<!-- eslint-disable-next-line @angular-eslint/template/interactive-supports-focus -->
+<div class="timeline" [class.highlighting]="highlightEnabled" [style.--timeline-label-width]="labelWidth"
+  (keydown)="onTimelineKeyDown($event)">
+
+  <!-- Everything that drives the view sits in the gutter of the axis, above the names: a bar of its own
+       would cost the lanes a row of height for controls used once. -->
+  <div class="axis">
+    <div class="gutter">
+      <div class="controls" role="group" [attr.aria-label]="label + ' display controls'">
+        <button nz-button nzSize="small" (click)="clickToggleAll()" [attr.aria-pressed]="expandedAll"
+          [attr.aria-label]="expandedAll ? 'Collapse every lane' : 'Expand every lane'"
+          [title]="expandedAll ? 'Collapse every lane' : 'Expand every lane'">
+          <span nz-icon [nzType]="expandedAll ? 'shrink' : 'arrows-alt'" nzTheme="outline" aria-hidden="true"></span>
+        </button>
+
+        <ng-content></ng-content>
+
+        <!-- Zooming itself is on the wheel and the keys. The only button for it is the one that puts
+             the whole of the timeline back in view. -->
+        <button nz-button nzSize="small" (click)="resetZoom()" [disabled]="!zoomed"
+          aria-label="Fit the whole timeline" title="Fit the whole timeline (0)">
+          <span nz-icon nzType="aim" nzTheme="outline" aria-hidden="true"></span>
+        </button>
+
+        @if (totalLabel) {
+          <span class="total" title="Total time the timeline spans, from its start to its end">
+            <span nz-icon nzType="field-time" nzTheme="outline" aria-hidden="true"></span><b>{{totalLabel}}</b>
+          </span>
+        }
+
+        <span class="help" nz-tooltip [nzTooltipTitle]="shortcuts" nzTooltipPlacement="bottomLeft" role="img"
+          aria-label="Timeline keyboard and mouse shortcuts">
+          <span nz-icon nzType="question-circle" nzTheme="outline" aria-hidden="true"></span>
+        </span>
+        <ng-template #shortcuts>
+          <div class="timeline-shortcuts">
+            <div><b>Timeline</b></div>
+            <div><kbd>&#8593;</kbd> <kbd>&#8595;</kbd> Move between lanes</div>
+            <div><kbd>&#8592;</kbd> <kbd>&#8594;</kbd> Collapse / expand a lane</div>
+            <div><kbd>Enter</kbd> Open the focused lane</div>
+            <div><kbd>+</kbd> <kbd>-</kbd> <kbd>0</kbd> Zoom in, out, fit</div>
+            <div><kbd>Ctrl</kbd> + wheel Zoom around the pointer</div>
+            <div>Drag, or wheel sideways Pan</div>
+          </div>
+        </ng-template>
+      </div>
+    </div>
+    <div class="axis-track" #axisTrack>
+      @if (!empty) {
+        @for (fold of folds; track fold.id) {
+          <span class="axis-fold" [style.left]="fold.left" [style.width]="fold.width" [title]="fold.title">
+            <span class="axis-fold-label">{{fold.label}}</span>
+          </span>
+        }
+        @for (tick of ticks; track tick.id) {
+          <span class="axis-tick" [style.left]="tick.left">{{tick.label}}</span>
+        }
+        @if (startCap) {
+          <span class="axis-cap start" [style.left]="startCap.left" [title]="startCap.title">{{startCap.label}}</span>
+        }
+        @if (endCap) {
+          <span class="axis-cap end" [class.live]="endCap.live" [style.left]="endCap.left"
+            [title]="endCap.title">{{endCap.label}}</span>
+        }
+      }
+      <!-- The time under the pointer. Moved by hand, so it is not a binding. -->
+      <span class="axis-cursor" #cursorLabel aria-hidden="true"></span>
+    </div>
+  </div>
+
+  @if (empty) {
+    <div class="empty" role="status">{{emptyLabel}}</div>
+  } @else {
+    <div class="viewport" #viewport [class.panning]="panning" [class.pannable]="zoomed"
+      (wheel)="onWheel($event)" (pointerdown)="onPointerDown($event)" (pointermove)="onPointerMove($event)"
+      (pointerup)="onPointerUp($event)" (pointercancel)="onPointerUp($event)" (scroll)="dropCard()">
+      <div class="canvas">
+        <div class="grid" aria-hidden="true">
+          @for (fold of folds; track fold.id) {
+            <span class="grid-fold" [style.left]="fold.left" [style.width]="fold.width"></span>
+          }
+          @for (tick of ticks; track tick.id) {
+            <span class="grid-line" [style.left]="tick.left"></span>
+          }
+          <!-- Hatched bands at both ends, marked like a fold is: the extent of the timeline is something
+               to be seen rather than an edge to be trusted. Each one runs from where the content stops to
+               the edge of the view, so when the axis is wider than what it holds the whole of the outside
+               is hatched rather than left as blank space nothing accounts for. -->
+          @if (startCap) {
+            <span class="grid-cap start" [style.width]="startCap.left"></span>
+          }
+          @if (endCap) {
+            <span class="grid-cap end" [class.live]="endCap.live" [style.left]="endCap.left"></span>
+          }
+          <span class="grid-cursor" #cursorLine></span>
+        </div>
+
+        @for (section of sections; track section.id) {
+          <div class="section">
+            @if (section.label) {
+              <div class="section-header"><span>{{section.label}}</span></div>
+            }
+            <ul class="lanes" role="list" [attr.aria-label]="section.label ?? label">
+              @for (lane of section.lanes; track lane.id) {
+                <li class="lane" [class.highlighted]="lane.highlighted" [class.child]="lane.depth > 0"
+                  [class.hovered]="lane.id === hoveredLaneID" [class.selected]="lane.id === selectedLaneID"
+                  [class.marked]="lane.hasMarkers" [attr.data-status]="lane.status">
+                  <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
+                  <div class="lane-gutter" [class.expandable]="lane.expandable"
+                    [style.padding-left.px]="6 + lane.depth * 16" (click)="clickRow(lane, $event)">
+                    @if (lane.expandable) {
+                      <span class="lane-caret" nz-icon [nzType]="lane.expanded ? 'down' : 'right'"
+                      nzTheme="outline" aria-hidden="true"></span>
+                    } @else {
+                      <span class="lane-caret placeholder" aria-hidden="true"></span>
+                    }
+                    <!-- The row asks what is inside the lane. The bars, further along, are the lane
+                         itself. -->
+                    <button class="lane-label" [class.inert]="!lane.expandable && !lane.activatable"
+                      (keydown)="onKeyDown($event, lane)"
+                      [attr.aria-expanded]="lane.expandable ? lane.expanded : null"
+                      [attr.aria-label]="lane.label + (lane.sublabel ? ', ' + lane.sublabel : '') + (lane.description ? ', ' + lane.description : '')"
+                      [title]="lane.expandable ? (lane.expanded ? 'Hide what is inside ' + lane.label : 'Show what is inside ' + lane.label) : lane.label">
+                      <span class="name">{{lane.label}}</span>
+                      @if (lane.sublabel) {
+                        <span class="sub">{{lane.sublabel}}</span>
+                      }
+                    </button>
+                    <!-- Dotted rule carrying the eye from the name across to the bars. -->
+                    <span class="leader" aria-hidden="true"></span>
+                  </div>
+                  <!-- Empty track answers to the row: unfolding it. The bars answer for themselves. -->
+                  <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
+                  <div class="lane-track" [class.expandable]="lane.expandable" (click)="clickRow(lane, $event)">
+                    <span class="leader" aria-hidden="true"></span>
+                    <!-- One element per group of segments, since a group is one thing. Clicking it opens
+                         what it stands for, and hovering it says where its time went. -->
+                    @for (group of lane.groups; track group.id) {
+                      <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
+                      <span class="segment-group" [class.activatable]="lane.activatable"
+                        [style.left]="group.left" [style.width]="group.width"
+                        (click)="clickGroup(lane, $event)" (mouseenter)="onGroupEnter(lane, $event)"
+                        (mouseleave)="onCardLeave()">
+                        @for (segment of group.segments; track segment.id) {
+                          <span class="segment" [class.open]="segment.open" [attr.data-kind]="segment.kind"
+                            [style.left]="segment.left" [style.width]="segment.width">
+                            @if (segment.showLabel) {
+                              <span class="segment-label">{{segment.label}}</span>
+                            }
+                            @if (segment.showDuration) {
+                              <span class="segment-duration">{{segment.duration}}</span>
+                            }
+                          </span>
+                        }
+                        @for (marker of group.markers; track marker.id) {
+                          <button class="marker" [class.iconic]="!!marker.icon" [class.crowd]="marker.count > 1" [attr.data-kind]="marker.kind"
+                            [style.left]="marker.left" [attr.aria-label]="marker.label" [title]="marker.count > 1 ? marker.label + ' — click to zoom in on them' : marker.label" tabindex="-1"
+                            (click)="clickMarker(lane, marker, $event)"
+                            (mouseenter)="onMarkerEnter(marker, $event)" (mouseleave)="onMarkerLeave(lane, $event)">
+                            @if (marker.icon) {
+                              <span nz-icon [nzType]="marker.icon" nzTheme="outline" aria-hidden="true"></span>
+                            }
+                            @if (marker.count > 1) {
+                              <span class="count" aria-hidden="true">{{marker.count}}</span>
+                            }
+                          </button>
+                        }
+                      </span>
+                    }
+                    <!-- Markers with no bar to stand on: a lane that is only a point in time. -->
+                    @for (marker of lane.markers; track marker.id) {
+                      <button class="marker loose" [class.iconic]="!!marker.icon" [class.crowd]="marker.count > 1" [attr.data-kind]="marker.kind"
+                        [style.left]="marker.left" [attr.aria-label]="marker.label" [title]="marker.count > 1 ? marker.label + ' — click to zoom in on them' : marker.label" tabindex="-1"
+                        (click)="clickMarker(lane, marker, $event)"
+                        (mouseenter)="onMarkerEnter(marker, $event)" (mouseleave)="onMarkerLeave(lane, $event)">
+                        @if (marker.icon) {
+                          <span nz-icon [nzType]="marker.icon" nzTheme="outline" aria-hidden="true"></span>
+                        }
+                        @if (marker.count > 1) {
+                          <span class="count" aria-hidden="true">{{marker.count}}</span>
+                        }
+                      </button>
+                    }
+                  </div>
+                </li>
+              }
+            </ul>
+          </div>
+        }
+      </div>
+    </div>
+  }
+</div>
+
+<!-- Shown in an overlay of its own, above what it is about. Inside the timeline it was clipped by the
+     panel; attached to the row it landed in the middle of the page, a row being as wide as the view. -->
+<ng-template #cardTemplate let-subject>
+  <div class="hover-card" role="tooltip">
+    <div class="tip-title">{{subject.label}}</div>
+    @if (subject.total) {
+      <div class="tip-total">Total <b>{{subject.total}}</b></div>
+    }
+    @for (share of subject.shares; track share.label) {
+      <div class="tip-share">
+        <span class="tip-name">{{share.label}}</span>
+        <span class="tip-gauge"><span [style.width]="share.width"></span></span>
+        <span class="tip-value">{{share.duration}}</span>
+        <span class="tip-percent">{{share.percent}}</span>
+      </div>
+    }
+    @if (subject.details.length > 0) {
+      <div class="tip-details" [class.alone]="!subject.total">
+        @for (detail of subject.details; track detail.label) {
+          <div class="tip-detail">
+            <span class="tip-detail-label">{{detail.label}}</span>
+            <span class="tip-detail-value">{{detail.value}}</span>
+          </div>
+        }
+      </div>
+    }
+  </div>
+</ng-template>

--- a/ui/libs/timeline/src/lib/timeline.icons.ts
+++ b/ui/libs/timeline/src/lib/timeline.icons.ts
@@ -1,0 +1,78 @@
+import { IconDefinition } from '@ant-design/icons-angular';
+import {
+    AimOutline,
+    AppstoreOutline,
+    ArrowsAltOutline,
+    BranchesOutline,
+    BuildOutline,
+    ClockCircleOutline,
+    CloseCircleOutline,
+    CodeOutline,
+    ContainerOutline,
+    DownOutline,
+    ExperimentOutline,
+    FieldTimeOutline,
+    FileOutline,
+    GlobalOutline,
+    InboxOutline,
+    PieChartOutline,
+    QuestionCircleOutline,
+    RedoOutline,
+    RightOutline,
+    RocketOutline,
+    ShrinkOutline,
+    SyncOutline,
+    TagOutline,
+    ThunderboltOutline,
+    UnlockOutline,
+    UserOutline
+} from '@ant-design/icons-angular/icons';
+
+/**
+ * The controls of the view, plus the icons a marker may be drawn with. Which of the latter a marker gets
+ * is the host's decision — the library only makes sure they are all registered.
+ */
+export const TIMELINE_ICONS: IconDefinition[] = [
+    AimOutline,
+    AppstoreOutline,
+    ArrowsAltOutline,
+    BranchesOutline,
+    BuildOutline,
+    ClockCircleOutline,
+    CloseCircleOutline,
+    CodeOutline,
+    ContainerOutline,
+    DownOutline,
+    ExperimentOutline,
+    FieldTimeOutline,
+    FileOutline,
+    GlobalOutline,
+    InboxOutline,
+    PieChartOutline,
+    QuestionCircleOutline,
+    RedoOutline,
+    RightOutline,
+    RocketOutline,
+    ShrinkOutline,
+    SyncOutline,
+    TagOutline,
+    ThunderboltOutline,
+    UnlockOutline,
+    UserOutline
+];
+
+/** The names those are drawn by, which is what a marker asks for. */
+const NAMES: ReadonlySet<string> = new Set(TIMELINE_ICONS.map(icon => icon.name));
+
+/**
+ * The icon a marker is drawn with, or nothing when it asks for one this view does not carry — in which
+ * case it is drawn as a plain mark instead.
+ *
+ * Asking is not enough on purpose. An unregistered name is not a missing icon: the icon component goes and
+ * fetches `assets/<theme>/<name>.svg` and puts what comes back on the page, so a name that reached here
+ * from data would be a way of choosing a URL to load and render. Nothing outside the list above is ever
+ * passed on, whoever asked for it and however it got here.
+ */
+export function timelineIcon(name: string): string {
+    return name && NAMES.has(name) ? name : null;
+}

--- a/ui/libs/timeline/src/lib/timeline.model.ts
+++ b/ui/libs/timeline/src/lib/timeline.model.ts
@@ -1,0 +1,239 @@
+/**
+ * What a timeline is drawn from. Nothing here knows what any of it means: whoever provides the data
+ * decides what a lane, a segment and a marker stand for, and gets told back which one was activated.
+ */
+
+/** A stretch of time on a lane. */
+export interface TimelineSegment {
+    id: string;
+    /** Milliseconds since epoch. */
+    start: number;
+    /** Milliseconds since epoch, or left out while the stretch is still going. */
+    end?: number;
+    /**
+     * Free-form. Becomes a `kind-<value>` class on the segment, which is how the host paints it:
+     * the view gives it no meaning of its own.
+     */
+    kind: string;
+    /**
+     * Drawn inside the segment when it is wide enough, and read out as part of the lane. Hovering a
+     * segment shows the whole breakdown of its lane rather than anything about the segment alone, so a
+     * segment carries no tooltip of its own.
+     */
+    label?: string;
+    /**
+     * Waiting rather than working. The segment is drawn like any other, but it does not hold the axis
+     * open: a stretch of time covered by nothing but idle segments can be folded.
+     *
+     * This is what lets a wait of days be drawn at all. Without it, a bar spanning that wait would
+     * count as something happening, and the axis would have to give the wait its full length.
+     */
+    idle?: boolean;
+    /**
+     * Segments sharing a group are one thing that happens to be drawn in several pieces — successive
+     * phases of the same activity, say. A group is:
+     *
+     * - **one thing to the pointer.** It is drawn as a single element holding its segments, so going
+     *   from one piece of it to the next never leaves it, and whatever it shows on hover does not
+     *   blink at every boundary.
+     * - **indivisible on the axis.** No fold may open between two of its segments, so its pieces keep
+     *   their true proportions to one another however much is folded away elsewhere.
+     *
+     * A segment with no group is its own group.
+     */
+    group?: string;
+}
+
+/** A fact the view cannot work out for itself, shown when what carries it is hovered. */
+export interface TimelineDetail {
+    label: string;
+    value: string;
+}
+
+/** A point in time on a lane. */
+export interface TimelineMarker {
+    id: string;
+    /** Milliseconds since epoch. */
+    at: number;
+    /** Free-form. Becomes a `kind-<value>` class on the marker. */
+    kind?: string;
+    /** What the marker stands for, the heading of what it says when hovered. */
+    label?: string;
+    /**
+     * Name of an icon to draw instead of the default lozenge. Which one to ask for is the host's business,
+     * but only the ones this view carries are drawn — see `timelineIcon`, which says why asking is not
+     * enough. Anything else is drawn as a plain mark.
+     */
+    icon?: string;
+    /** Shown under the label when the marker is hovered. */
+    details?: Array<TimelineDetail>;
+    /**
+     * What several of this kind of marker are called, when they are too close together to draw apart and
+     * are drawn as one. Left out, they take whatever the view was told markers are called in general.
+     */
+    plural?: string;
+}
+
+export interface TimelineLane {
+    id: string;
+    label: string;
+    /** Second line under the label, for whatever the host wants to tell about the lane. */
+    sublabel?: string;
+    /**
+     * Shown under the breakdown of the lane when it is hovered. The view works out how long each
+     * segment lasted and what share of the lane it took; anything else worth saying about the lane is
+     * only known to the host.
+     */
+    details?: Array<TimelineDetail>;
+    /** Free-form. Becomes a `status-<value>` class on the lane. */
+    status?: string;
+    segments: TimelineSegment[];
+    markers?: TimelineMarker[];
+    /** Lanes drawn under this one when it is expanded. */
+    lanes?: TimelineLane[];
+    /** Kept bright while the others are dimmed, when the view is asked to highlight. */
+    highlighted?: boolean;
+    /** Whether activating the lane means anything to the host. A lane that is not stays inert. */
+    activatable?: boolean;
+}
+
+/** A run of lanes under a common heading. A timeline without headings holds a single unlabelled section. */
+export interface TimelineSection {
+    id: string;
+    /** No heading is drawn when left out. */
+    label?: string;
+    lanes: TimelineLane[];
+}
+
+export interface TimelineData {
+    sections: TimelineSection[];
+    /** Bounds of the axis. Taken from the segments and the markers when left out. */
+    start?: number;
+    end?: number;
+}
+
+/** What the user activated, either a lane or one of its markers. */
+export interface TimelineActivation {
+    laneID: string;
+    markerID?: string;
+}
+
+/** Every lane of a timeline, sections and nesting flattened, parents before their children. */
+export function flattenLanes(data: TimelineData): TimelineLane[] {
+    const flat: TimelineLane[] = [];
+    const walk = (lanes: TimelineLane[]) => (lanes ?? []).forEach(lane => {
+        flat.push(lane);
+        walk(lane.lanes);
+    });
+    (data?.sections ?? []).forEach(section => walk(section.lanes));
+    return flat;
+}
+
+const DURATION_UNITS: Array<[number, string]> = [[86400000, 'd'], [3600000, 'h'], [60000, 'm'], [1000, 's']];
+
+/** How close to the foot of the lanes still counts as being at it, for following them down. */
+export const FOLLOW_SLACK_PX = 24;
+
+/**
+ * Whether a view should keep up with data that is still arriving, given where its lanes are sitting and
+ * what has been asked of it.
+ *
+ * Lanes are added at the foot of the list as they begin, so a view that stays where it was shows less of
+ * the whole the longer it goes on — hence following them down, the way a log tail is. Every clause below
+ * is a case where moving the view would be wrong rather than helpful.
+ *
+ * Note what this does *not* do: remember that the view was once left alone. It asks where the lanes are
+ * sitting now, so scrolling back to the foot picks the following up again by itself.
+ */
+export function shouldFollow(live: boolean, zoomed: boolean, hovering: boolean, roomBelowPx: number): boolean {
+    // Nothing is arriving anymore, so there is nothing to keep up with.
+    if (!live) {
+        return false;
+    }
+    // Zoomed in on something, or pointing at something: both mean someone is reading.
+    if (zoomed || hovering) {
+        return false;
+    }
+    // Scrolled away from the foot of the list: they went to look at something further up, and it is not
+    // to be dragged away from them.
+    return roomBelowPx <= FOLLOW_SLACK_PX;
+}
+
+/** Width of the band walling off either end of the axis. */
+export const AXIS_BAND_PX = 12;
+/** How much more is kept clear on a side where a marker sits on the bound. */
+export const MARKER_ROOM_PX = 14;
+
+/** What decides how much room the ends of an axis need. */
+export interface AxisRoom {
+    /** Width of the whole track, in pixels. */
+    trackWidth: number;
+    /** Whether anything on the axis lasted, rather than everything on it being an instant. */
+    lasting: boolean;
+    /** Whether a marker sits on the first, respectively the last, instant the axis covers. */
+    markAtStart: boolean;
+    markAtEnd: boolean;
+}
+
+/**
+ * How much of the track is kept clear at either end, in pixels. Everything else is drawn between the two.
+ *
+ * This is the only way an axis is given room, and deliberately so: taking it out of the *track* leaves
+ * time meaning what it means. Making room by widening the stretch of time instead would invent time that
+ * has to be either drawn to scale — where a long axis turns a few pixels of room into hours that then take
+ * the whole view — or folded away, which is the room being taken straight back.
+ *
+ * Beyond the bands themselves, two things ask for room. A marker sitting on a bound is drawn half outside
+ * the axis, being a glyph with a size but no length. And content that never lasted — a handful of instants
+ * and not one bar, which is what a run that failed before queueing a job comes to — leaves an axis that is
+ * nothing but its own two ends: its marks would sit against the two edges of an otherwise empty view, so
+ * it is given the middle third and reads as being somewhere instead.
+ */
+export function axisEnds(axis: AxisRoom): { start: number, end: number } {
+    let start = AXIS_BAND_PX + (axis.markAtStart ? MARKER_ROOM_PX : 0);
+    let end = AXIS_BAND_PX + (axis.markAtEnd ? MARKER_ROOM_PX : 0);
+    const track = Math.max(axis.trackWidth, 1);
+
+    if (!axis.lasting) {
+        const third = Math.max((track - start - end) / 3, 0);
+        start += third;
+        end += third;
+    }
+
+    // However narrow the view gets, the plot keeps a fifth of it: a view with no room left to draw in
+    // answers nothing at all.
+    const room = track * 0.8;
+    if (start + end > room) {
+        const shrink = room / (start + end);
+        return { start: start * shrink, end: end * shrink };
+    }
+    return { start, end };
+}
+
+/**
+ * Compact rendering of a duration: the largest unit that carries something, and the one below it. Two
+ * days and two seconds reads as `2d`, not as `2d 2s` — at that scale the seconds say nothing.
+ */
+export function formatDuration(ms: number): string {
+    if (!isFinite(ms) || ms < 0) {
+        return '';
+    }
+    const rounded = Math.floor(ms / 1000) * 1000;
+    const largest = DURATION_UNITS.findIndex(([size]) => rounded >= size);
+    if (largest === -1) {
+        return '<1s';
+    }
+
+    const [size, suffix] = DURATION_UNITS[largest];
+    const value = Math.floor(rounded / size);
+    const parts = [`${value}${suffix}`];
+
+    const below = DURATION_UNITS[largest + 1];
+    if (below) {
+        const rest = Math.floor((rounded - value * size) / below[0]);
+        if (rest > 0) {
+            parts.push(`${rest}${below[1]}`);
+        }
+    }
+    return parts.join(' ');
+}

--- a/ui/libs/timeline/src/lib/timeline.module.ts
+++ b/ui/libs/timeline/src/lib/timeline.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTooltipModule } from 'ng-zorro-antd/tooltip';
+import { TimelineComponent } from './timeline.component';
+import { TIMELINE_ICONS } from './timeline.icons';
+
+@NgModule({
+    declarations: [
+        TimelineComponent
+    ],
+    imports: [
+        CommonModule,
+        OverlayModule,
+        NzButtonModule,
+        NzIconModule.forRoot(TIMELINE_ICONS),
+        NzSpaceModule,
+        NzTooltipModule
+    ],
+    exports: [
+        TimelineComponent
+    ]
+})
+export class TimelineModule { }

--- a/ui/libs/timeline/src/lib/timeline.scale.ts
+++ b/ui/libs/timeline/src/lib/timeline.scale.ts
@@ -1,0 +1,250 @@
+import { formatDuration } from './timeline.model';
+
+/** A stretch of time something occupies. Zero-length is allowed, for a point in time. */
+export interface TimelineBusy {
+    start: number;
+    end: number;
+}
+
+export interface TimelineScaleOptions {
+    /**
+     * Idle stretches longer than this are folded: they keep a fixed, small share of the axis whatever
+     * their real length. Left at 0, time is drawn strictly proportional.
+     */
+    foldGapsLongerThanMs: number;
+    /** Share of the axis given to a folded stretch. */
+    foldedGapShare: number;
+}
+
+export const DEFAULT_SCALE_OPTIONS: TimelineScaleOptions = {
+    // Short waits are worth seeing to scale; past a few minutes, a wait only needs to be readable.
+    foldGapsLongerThanMs: 300000,
+    foldedGapShare: 0.03
+};
+
+/** A run of time drawn at a single rate. Folded pieces are drawn at a much smaller one. */
+export interface TimelineScalePiece {
+    start: number;
+    end: number;
+    folded: boolean;
+    /** Where the piece starts on the axis, in [0, 1]. */
+    from: number;
+    /** Where the piece ends on the axis, in [0, 1]. */
+    to: number;
+}
+
+export interface TimelineTick {
+    at: number;
+    /** Position on the axis, in [0, 1]. */
+    ratio: number;
+    label: string;
+}
+
+/** The steps a time axis is allowed to be graduated with, from a second to a week. */
+const TICK_STEPS = [
+    1000, 2000, 5000, 10000, 15000, 30000,
+    60000, 120000, 300000, 600000, 900000, 1800000,
+    3600000, 7200000, 10800000, 21600000, 43200000,
+    86400000, 172800000, 604800000
+];
+
+/**
+ * Maps time to a position on the axis.
+ *
+ * What is being drawn may sit idle for hours or days between two things worth seeing, which to scale
+ * would squash everything that did happen into a few pixels. Stretches where nothing happens are
+ * therefore folded: they are still drawn, so that the wait is visible and stays in order, but they no
+ * longer cost the axis anything near their real length. Time remains strictly proportional everywhere
+ * else, so comparing two segments on either side of a fold is still comparing like with like as long as
+ * no fold sits between them — which is what the fold marks are for.
+ */
+export class TimelineScale {
+    readonly start: number;
+    readonly end: number;
+    readonly pieces: TimelineScalePiece[];
+
+    private constructor(start: number, end: number, pieces: TimelineScalePiece[]) {
+        this.start = start;
+        this.end = end;
+        this.pieces = pieces;
+    }
+
+    static build(start: number, end: number, busy: TimelineBusy[], options: TimelineScaleOptions = DEFAULT_SCALE_OPTIONS): TimelineScale {
+        // A timeline of no length still has to place its segments somewhere: one millisecond wide is
+        // enough for everything to land at the same spot instead of dividing by zero.
+        if (!(end > start)) {
+            end = start + 1;
+        }
+
+        const merged = TimelineScale.merge(busy, start, end);
+        const threshold = options.foldGapsLongerThanMs > 0 ? options.foldGapsLongerThanMs : Infinity;
+
+        // Walk the axis once, emitting what is busy and, between two busy stretches, the gap that
+        // separates them. Adjacent unfolded pieces are joined so that graduations run through them.
+        const pieces: Array<{ start: number, end: number, folded: boolean }> = [];
+        const push = (from: number, to: number, folded: boolean) => {
+            if (to < from) {
+                return;
+            }
+            const last = pieces[pieces.length - 1];
+            if (last && !last.folded && !folded) {
+                last.end = to;
+                return;
+            }
+            pieces.push({ start: from, end: to, folded });
+        };
+
+        let cursor = start;
+        merged.forEach(interval => {
+            if (interval.start > cursor) {
+                push(cursor, interval.start, interval.start - cursor > threshold);
+            }
+            push(Math.max(cursor, interval.start), interval.end, false);
+            cursor = Math.max(cursor, interval.end);
+        });
+        if (cursor < end) {
+            push(cursor, end, end - cursor > threshold);
+        }
+        if (pieces.length === 0) {
+            pieces.push({ start, end, folded: false });
+        }
+
+        // Folded stretches are sized against what is left drawn to scale, so that they stay a small
+        // part of the axis however long the wait was.
+        const unfolded = pieces.filter(p => !p.folded).reduce((total, p) => total + (p.end - p.start), 0);
+        const foldedCount = pieces.filter(p => p.folded).length;
+        const share = Math.max(options.foldedGapShare, 0);
+        // Everything folded, or nothing but points: fall back to equal shares rather than a zero-length axis.
+        const foldedWidth = unfolded > 0 ? unfolded * share : (foldedCount > 0 ? 1 / foldedCount : 1);
+        const widths = pieces.map(p => p.folded ? foldedWidth : Math.max(p.end - p.start, 0));
+        const total = widths.reduce((a, b) => a + b, 0) || 1;
+
+        let offset = 0;
+        const scaled: TimelineScalePiece[] = pieces.map((p, i) => {
+            const from = offset / total;
+            offset += widths[i];
+            return { start: p.start, end: p.end, folded: p.folded, from, to: offset / total };
+        });
+
+        return new TimelineScale(start, end, scaled);
+    }
+
+    /** Where a date sits on the axis, in [0, 1]. */
+    ratio(time: number): number {
+        if (time <= this.start) {
+            return 0;
+        }
+        if (time >= this.end) {
+            return 1;
+        }
+        for (const piece of this.pieces) {
+            if (time > piece.end) {
+                continue;
+            }
+            const length = piece.end - piece.start;
+            if (length <= 0) {
+                return piece.from;
+            }
+            return piece.from + ((time - piece.start) / length) * (piece.to - piece.from);
+        }
+        return 1;
+    }
+
+    /** The date at a position of the axis. Inverse of ratio(). */
+    time(ratio: number): number {
+        if (ratio <= 0) {
+            return this.start;
+        }
+        if (ratio >= 1) {
+            return this.end;
+        }
+        for (const piece of this.pieces) {
+            if (ratio > piece.to) {
+                continue;
+            }
+            const width = piece.to - piece.from;
+            if (width <= 0) {
+                return piece.start;
+            }
+            return piece.start + ((ratio - piece.from) / width) * (piece.end - piece.start);
+        }
+        return this.end;
+    }
+
+    get folds(): TimelineScalePiece[] {
+        return this.pieces.filter(p => p.folded);
+    }
+
+    /** How long the fold at this piece stands for, ready to be shown. */
+    static foldLabel(piece: TimelineScalePiece): string {
+        return formatDuration(piece.end - piece.start);
+    }
+
+    /**
+     * Graduations for the visible part of the axis. Only unfolded stretches are graduated: a label
+     * inside a fold would claim a precision the fold does not have.
+     */
+    ticks(from: number, to: number, maxCount: number): TimelineTick[] {
+        if (maxCount <= 0 || !(to > from)) {
+            return [];
+        }
+
+        // The step is chosen from the time actually drawn to scale in the window, so that graduations
+        // keep an even spacing on screen whatever is folded away.
+        let drawn = 0;
+        this.pieces.filter(p => !p.folded).forEach(piece => {
+            const overlap = Math.min(piece.to, to) - Math.max(piece.from, from);
+            if (overlap > 0) {
+                drawn += (overlap / (piece.to - piece.from)) * (piece.end - piece.start);
+            }
+        });
+        if (drawn <= 0) {
+            return [];
+        }
+
+        const wanted = drawn / maxCount;
+        const step = TICK_STEPS.find(s => s >= wanted) ?? TICK_STEPS[TICK_STEPS.length - 1];
+        const format = TimelineScale.labelFormat(step);
+
+        const ticks: TimelineTick[] = [];
+        this.pieces.filter(p => !p.folded).forEach(piece => {
+            for (let at = Math.ceil(piece.start / step) * step; at <= piece.end; at += step) {
+                const ratio = this.ratio(at);
+                if (ratio >= from && ratio <= to) {
+                    ticks.push({ at, ratio, label: format(new Date(at)) });
+                }
+            }
+        });
+        return ticks;
+    }
+
+    private static labelFormat(step: number): (date: Date) => string {
+        const pad = (value: number) => value < 10 ? `0${value}` : `${value}`;
+        if (step < 60000) {
+            return d => `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+        }
+        if (step < 86400000) {
+            return d => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+        }
+        return d => `${pad(d.getDate())}/${pad(d.getMonth() + 1)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    /** Overlapping and touching stretches joined into one, clamped to the bounds of the axis. */
+    private static merge(busy: TimelineBusy[], start: number, end: number): TimelineBusy[] {
+        const clamped = (busy ?? [])
+            .map(b => ({ start: Math.max(b.start, start), end: Math.min(Math.max(b.end, b.start), end) }))
+            .filter(b => b.start <= b.end && b.start <= end && b.end >= start)
+            .sort((a, b) => a.start - b.start);
+
+        const merged: TimelineBusy[] = [];
+        clamped.forEach(b => {
+            const last = merged[merged.length - 1];
+            if (last && b.start <= last.end) {
+                last.end = Math.max(last.end, b.end);
+                return;
+            }
+            merged.push({ ...b });
+        });
+        return merged;
+    }
+}

--- a/ui/libs/timeline/src/lib/timeline.scss
+++ b/ui/libs/timeline/src/lib/timeline.scss
@@ -1,0 +1,785 @@
+/**
+ * The timeline draws its own shape and nothing more. Every colour comes from a custom property the
+ * host sets, and the colours of a segment or a marker — whose `kind` only the host understands — are
+ * left to the host entirely, through `[data-kind]`.
+ */
+
+:host {
+  display: block;
+  height: 100%;
+  overflow: hidden;
+}
+
+.timeline {
+  --timeline-label-width: 260px;
+  --timeline-row-height: 40px;
+  --timeline-child-row-height: 32px;
+  // A lane carrying markers is no taller than any other: its marks sit above its bars and overflow into
+  // the row above rather than every such row growing to hold them. A timeline is read by comparing rows,
+  // and rows of two heights are harder to compare than marks are to look past. To give the room back
+  // instead: 62px / 54px here, and 18px for the two insets under `.marked` below.
+  --timeline-marked-row-height: var(--timeline-row-height);
+  --timeline-marked-child-row-height: var(--timeline-child-row-height);
+
+  --timeline-text: rgba(0, 0, 0, .85);
+  // Kept dark enough for small text to stay readable against the panel.
+  --timeline-muted: rgba(0, 0, 0, .55);
+  --timeline-border: #f0f0f0;
+  --timeline-grid: #f5f5f5;
+  --timeline-leader: rgba(0, 0, 0, .12);
+  --timeline-cap: rgba(0, 0, 0, .1);
+  --timeline-hover: rgba(0, 0, 0, .04);
+  --timeline-fold: rgba(0, 0, 0, .06);
+  --timeline-now: #4fa3e3;
+  --timeline-segment: #d9d9d9;
+  --timeline-marker: #6b6f7b;
+  --timeline-focus: #1668dc;
+  --timeline-accent: #1668dc;
+  --timeline-surface: #ffffff;
+  // The resting border of a small control, so a focused one can be put back to looking untouched.
+  --timeline-control-border: #d9d9d9;
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  color: var(--timeline-text);
+}
+
+.empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--timeline-muted);
+}
+
+// -- Axis, and the controls that share its row -------------------------------------------------
+
+.axis {
+  display: flex;
+  flex-direction: row;
+  flex: 0 0 auto;
+  height: 36px;
+  border-bottom: 1px solid var(--timeline-border);
+
+  .gutter {
+    flex: 0 0 var(--timeline-label-width);
+    overflow: hidden;
+  }
+
+  .controls {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    height: 100%;
+    padding: 0 10px;
+
+    // Only the controls of the view itself. A control projected in here belongs to whoever projected
+    // it — these rules are scoped to this component and cannot reach it — so what it looks like on and
+    // off is stated in the host stylesheet, next to the button it is about.
+    [nz-button] {
+      cursor: pointer;
+
+      &[disabled] {
+        cursor: not-allowed;
+      }
+
+      // Clicking a button with the pointer leaves it focused, and the button styles the UI ships paint a
+      // focused button exactly like a hovered one — so a control stayed lit long after it had been let
+      // go of. Only a pointer focus is put back: a keyboard one still shows, through :focus-visible.
+      &:not([disabled]):focus:not(:focus-visible) {
+        color: var(--timeline-text);
+        border-color: var(--timeline-control-border);
+      }
+    }
+
+    .total {
+      font-size: .78em;
+      color: var(--timeline-muted);
+      white-space: nowrap;
+      margin-left: 2px;
+
+      b {
+        color: var(--timeline-text);
+        margin-left: 4px;
+      }
+    }
+
+    .help {
+      color: var(--timeline-muted);
+      cursor: help;
+      display: inline-flex;
+      margin-left: auto;
+    }
+  }
+
+  .axis-track {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+    // Carries the column separator through the header, so the line is unbroken top to bottom.
+    border-left: 1px solid var(--timeline-border);
+  }
+
+  .axis-tick {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: .75em;
+    color: var(--timeline-muted);
+    white-space: nowrap;
+    padding: 0 3px;
+  }
+
+  // Sits on the band marking that end of the axis. Graduations are kept away from it in the layout, so
+  // that two times are never printed on top of one another.
+  .axis-cap {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: .68em;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    // A signpost, not a headline: it says where the axis stops and then gets out of the way.
+    color: var(--timeline-muted);
+    background-color: var(--timeline-surface);
+    padding: 2px 6px;
+    border: 1px solid var(--timeline-border);
+    border-radius: 2px;
+    white-space: nowrap;
+    cursor: help;
+
+    &.start {
+      margin-left: 5px;
+    }
+
+    &.end {
+      transform: translate(-100%, -50%);
+      margin-left: -5px;
+    }
+
+    // The end of an axis still growing is the present, and is worth telling apart from one that is not.
+    &.live {
+      color: var(--timeline-now);
+      border-color: var(--timeline-now);
+    }
+  }
+
+  // The time the pointer is on. On a folded axis, working out what a position means is otherwise
+  // guesswork, so it is read out where the graduations are.
+  .axis-cursor {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    display: none;
+    z-index: 1;
+    font-size: .72em;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    padding: 2px 5px;
+    border-radius: 2px;
+    background-color: var(--timeline-accent);
+    color: var(--timeline-surface);
+  }
+
+  .axis-fold {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--timeline-fold);
+    cursor: help;
+
+    .axis-fold-label {
+      font-size: .7em;
+      color: var(--timeline-muted);
+      white-space: nowrap;
+      // The label of a narrow fold has to stay readable, so it is allowed out of its band.
+      overflow: visible;
+    }
+  }
+}
+
+// -- Lanes ---------------------------------------------------------------------------------------
+
+.viewport {
+  flex: 1;
+  // Up and down only. Sideways is this view's own gesture, never a scrollbar: the names column and the
+  // bars have to stay lined up with each other whatever the axis is doing.
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: relative;
+  touch-action: pan-y;
+
+  &.pannable {
+    cursor: grab;
+  }
+
+  &.panning {
+    cursor: grabbing;
+    user-select: none;
+  }
+}
+
+.canvas {
+  position: relative;
+  min-height: 100%;
+  // The first row has no row above it to hang over, so the canvas gives it the same room.
+  padding-top: 12px;
+  padding-bottom: 8px;
+}
+
+.grid {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--timeline-label-width);
+  right: 0;
+  overflow: hidden;
+  pointer-events: none;
+  // The names and the bars are two columns and always read as two, even zoomed in past the point where
+  // the band marking the start of the axis is still in view.
+  border-left: 1px solid var(--timeline-border);
+
+  .grid-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-color: var(--timeline-grid);
+  }
+
+  // A band, not a line, and hatched like a fold: the ends of the timeline read as walls the lanes stop
+  // against, rather than as an edge that might be hiding something. Faint, and with no hard rule down its
+  // side — these say where the axis stops, they are not the subject.
+  .grid-cap {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-image: repeating-linear-gradient(-45deg,
+        transparent 0 4px,
+        var(--timeline-cap) 4px 5px);
+
+    // Each band runs from where the axis stops to the edge of the view, so that whatever the ends keep
+    // clear of the track is walled off rather than left as blank space nothing accounts for.
+    &.start {
+      left: 0;
+    }
+
+    &.end {
+      right: 0;
+    }
+
+    // The wall at the present, on an axis that is still growing into it.
+    &.live {
+      background-image: repeating-linear-gradient(-45deg,
+          transparent 0 4px,
+          var(--timeline-now) 4px 5px);
+      opacity: .5;
+    }
+  }
+
+  // Where the pointer is. Moved by hand outside change detection, hidden until there is one.
+  .grid-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    display: none;
+    background-color: var(--timeline-accent);
+    opacity: .65;
+  }
+
+  .grid-fold {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-color: var(--timeline-fold);
+    // The pattern says the time in there is not to scale.
+    background-image: repeating-linear-gradient(-45deg,
+        transparent 0 4px,
+        var(--timeline-grid) 4px 5px);
+  }
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 10px 4px;
+  font-size: .8em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--timeline-muted);
+  position: relative;
+}
+
+.lanes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lane {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  height: var(--timeline-row-height);
+  position: relative;
+  --timeline-bar-top: 7px;
+  --timeline-bar-bottom: 7px;
+
+  // What is pinned on a lane is drawn above its bars, so a lane carrying anything is taller by the room
+  // that takes — at both ends, so the bars do not move off the middle of the line. Centred on the bar,
+  // an icon covered the very label it was sitting next to.
+  &.marked {
+    height: var(--timeline-marked-row-height);
+    --timeline-bar-top: 7px;
+    --timeline-bar-bottom: 7px;
+  }
+
+  &:hover,
+  &.hovered {
+    background-color: var(--timeline-hover);
+  }
+
+  // Pointed at from somewhere else, another view of the same thing. Stronger than a hover, since the
+  // pointer is not here to say where it is.
+  &.hovered {
+    box-shadow: inset 0 0 0 1px var(--timeline-accent);
+  }
+
+  // The lane whose panel is open. Says what is being looked at, and outranks a passing hover.
+  &.selected {
+    background-color: var(--timeline-hover);
+    box-shadow: inset 3px 0 0 var(--timeline-accent);
+
+    .lane-label .name {
+      color: var(--timeline-accent);
+    }
+  }
+
+  &.child {
+    height: var(--timeline-child-row-height);
+
+    .lane-label .name {
+      font-weight: normal;
+    }
+
+    &.marked {
+      height: var(--timeline-marked-child-row-height);
+      --timeline-bar-top: 7px;
+      --timeline-bar-bottom: 7px;
+    }
+  }
+}
+
+.lane-gutter {
+  flex: 0 0 var(--timeline-label-width);
+  // The column answers the click, all the way across, not only where the name happens to end.
+  &.expandable {
+    cursor: pointer;
+  }
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+// Dotted rule running from the name across to the bars, so a lane reads as one line. It runs to the very
+// edge of the gutter and starts again at the very edge of the track, so the two halves join instead of
+// leaving a blank where the columns meet.
+.leader {
+  flex: 1 1 8px;
+  min-width: 8px;
+  height: 0;
+  border-bottom: 1px dotted var(--timeline-leader);
+  margin-left: 6px;
+}
+
+.lane-caret {
+  flex: 0 0 18px;
+  width: 18px;
+  text-align: center;
+  color: var(--timeline-muted);
+  font-size: .7em;
+  line-height: 1;
+}
+
+.lane-label {
+  flex: 0 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  text-align: left;
+  overflow: hidden;
+  // Whatever the column around it does, since that is what the click reaches.
+  cursor: inherit;
+
+  &:focus-visible {
+    outline: 2px solid var(--timeline-focus);
+    outline-offset: -2px;
+  }
+
+  .name {
+    font-size: .88em;
+    font-weight: bold;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .sub {
+    font-size: .75em;
+    color: var(--timeline-muted);
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.lane-track {
+  flex: 1;
+  position: relative;
+  // Cut off at the sides of the column and nowhere else, so a mark standing above a bar can hang over the
+  // row above it. `hidden` cannot say this — hiding one axis makes the other clip too — but `clip` can,
+  // and unlike a clip path it also keeps what it cuts from counting towards the scrollable area. With a
+  // clip path, a bar wider than the column gave the view something to scroll sideways, and scrolling it
+  // dragged the names along with the bars.
+  overflow-x: clip;
+  overflow-y: visible;
+  display: flex;
+  align-items: center;
+  cursor: default;
+
+  // Empty track answers to the row, which unfolds the lane.
+  &.expandable {
+    cursor: pointer;
+  }
+
+  .leader {
+    // The rule carries on behind the bars, tying the two halves of the row together.
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
+}
+
+// The box a run of segments is drawn in. It carries no look of its own — it is there to be one element
+// where there are several bars, so the pointer never falls between them. It is inset to the height of
+// the bars, so that it covers what is coloured and nothing else.
+.segment-group {
+  position: absolute;
+  top: var(--timeline-bar-top);
+  bottom: var(--timeline-bar-bottom);
+  min-width: 2px;
+
+  // The bars are the lane itself: clicking them opens it.
+  &.activatable {
+    cursor: pointer;
+  }
+}
+
+.segment {
+  position: absolute;
+  // Filling the group, which is what holds the height: the bars are what is read here, the rows only
+  // have to be told apart.
+  top: 0;
+  bottom: 0;
+  min-width: 2px;
+  border-radius: 2px;
+  background-color: var(--timeline-segment);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+
+  // Still going: the trailing edge is left open instead of squared off.
+  &.open {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .segment-label {
+    font-size: .72em;
+    padding: 0 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // The duration where the eye already is, instead of only on hover.
+  .segment-duration {
+    font-size: .7em;
+    padding-right: 5px;
+    margin-left: auto;
+    opacity: .75;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+// A point in time. Without an icon it is a lozenge; with one it is that icon, which says what kind of
+// thing was produced without having to be hovered.
+.marker {
+  // Standing on the top edge of the bar rather than laid across it: a mark in the middle of a short bar
+  // covers the name of the very thing it belongs to. Held a little clear of it, so the stem between the
+  // two is visible, and placed with `bottom` rather than a transform so hovering can scale it without
+  // moving it.
+  //
+  // Everything here has to fit in the room the row keeps above its bars, because the track clips what
+  // overflows it — and it must, to cut the bars off at its edges. So a mark that has more to say grows
+  // sideways, never upwards.
+  position: absolute;
+  bottom: calc(100% + 3px);
+  width: 10px;
+  height: 10px;
+  margin: 0 0 0 -5px;
+  padding: 0;
+  border: 1px solid var(--timeline-marker);
+  background-color: var(--timeline-marker);
+  transform: rotate(45deg);
+  cursor: pointer;
+
+  &:hover {
+    transform: rotate(45deg) scale(1.3);
+  }
+
+  &.iconic {
+    width: 14px;
+    height: 14px;
+    margin-left: -7px;
+    box-sizing: border-box;
+    border-radius: 3px;
+    transform: none;
+    // The icon carries the colour; the box behind it only has to lift it off whatever is underneath.
+    background-color: var(--timeline-surface);
+    border-color: var(--timeline-marker);
+    color: var(--timeline-marker);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    font-size: 9px;
+    line-height: 1;
+
+    &:hover {
+      transform: scale(1.15);
+      z-index: 1;
+    }
+
+    // A stem across the gap to the bar, meeting its top edge exactly. Inside the bar it was hidden by
+    // it; in the gap it is what makes the mark read as belonging to that bar.
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      width: 2px;
+      height: 3px;
+      margin-left: -1px;
+      background-color: var(--timeline-marker);
+    }
+  }
+
+  // Several drawn as one, because they would have overlapped. It says so by carrying the number, which
+  // makes it wider than a single mark — the one direction it has room to grow in. A badge hung off the
+  // corner was the obvious thing to reach for and the wrong one: it needed height the row does not have,
+  // so it came out clipped.
+  &.crowd {
+    width: auto;
+    min-width: 14px;
+    height: 14px;
+    padding: 0 3px;
+    box-sizing: border-box;
+    // Stated here rather than left to `.iconic`, so that a crowd is a legible pill even where the host
+    // gave its markers no icon to draw.
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    border-radius: 3px;
+    background-color: var(--timeline-surface);
+    border-color: var(--timeline-marker);
+    color: var(--timeline-marker);
+    line-height: 1;
+    // Centred on its instant whatever its width, which a fixed negative margin cannot do. The shift is
+    // the same in both states, so hovering still scales without moving it.
+    margin-left: 0;
+    transform: translateX(-50%);
+
+    &:hover {
+      transform: translateX(-50%) scale(1.15);
+    }
+
+    .count {
+      font-size: 9px;
+      font-weight: bold;
+      line-height: 1;
+      font-variant-numeric: tabular-nums;
+      color: var(--timeline-marker);
+    }
+  }
+
+  // Nothing to stand on: a lane that is only a point in time has no bar under its mark, so it sits in
+  // the middle of the row and has nothing to be welded to.
+  &.loose {
+    bottom: auto;
+    top: 50%;
+    margin-top: -5px;
+
+    &.iconic {
+      margin-top: -7px;
+    }
+
+    &::after {
+      display: none;
+    }
+  }
+}
+
+// Highlighting brings out a few lanes by holding the others back, rather than by painting them.
+.timeline.highlighting {
+
+  .lane:not(.highlighted) {
+    .segment,
+    .marker {
+      opacity: .2;
+    }
+
+    // Held back with them: left alone it showed straight through the bars it runs behind, which drew
+    // more attention than the bars themselves.
+    .leader {
+      opacity: .3;
+    }
+
+    .lane-label {
+      color: var(--timeline-muted);
+    }
+  }
+}
+
+// -- What a lane says when hovered ---------------------------------------------------------------
+
+// Lives in an overlay, which owns its position: this only says what it looks like.
+.hover-card {
+  width: 320px;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border-radius: 4px;
+  // The overlay is outside the timeline, so the theme cannot reach it through a custom property:
+  // these two are the only colours the component states outright.
+  background-color: #262626;
+  color: #ffffff;
+  font-size: 12px;
+  line-height: 1.5;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, .35);
+  pointer-events: none;
+
+  .tip-title {
+    font-weight: bold;
+    margin-bottom: 2px;
+    word-break: break-all;
+  }
+
+  .tip-total {
+    margin-bottom: 6px;
+    opacity: .85;
+  }
+
+  .tip-share {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+
+    .tip-name {
+      flex: 0 0 78px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    // A neutral gauge rather than the colour of the segment: what a `kind` looks like is the host's
+    // business, and repeating it here would mean repeating its stylesheet.
+    .tip-gauge {
+      flex: 1 1 auto;
+      height: 6px;
+      border-radius: 3px;
+      background-color: rgba(255, 255, 255, .18);
+      overflow: hidden;
+
+      span {
+        display: block;
+        height: 100%;
+        background-color: currentColor;
+        opacity: .75;
+      }
+    }
+
+    .tip-value {
+      flex: 0 0 auto;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .tip-percent {
+      flex: 0 0 34px;
+      text-align: right;
+      opacity: .7;
+      font-variant-numeric: tabular-nums;
+    }
+  }
+
+  .tip-details {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(255, 255, 255, .18);
+    opacity: .85;
+
+    // A marker has no breakdown above it, so there is nothing to be separated from.
+    &.alone {
+      margin-top: 2px;
+      padding-top: 0;
+      border-top: none;
+    }
+  }
+
+  // Label against the left edge, value against the right, so the values read down a single column.
+  .tip-detail {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+
+    .tip-detail-value {
+      text-align: right;
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
+    }
+  }
+}
+
+.timeline-shortcuts {
+  kbd {
+    display: inline-block;
+    padding: 0 4px;
+    border-radius: 2px;
+    background-color: rgba(255, 255, 255, .2);
+  }
+}

--- a/ui/libs/timeline/src/public-api.ts
+++ b/ui/libs/timeline/src/public-api.ts
@@ -1,0 +1,9 @@
+/*
+ * Public API Surface of timeline
+ */
+
+export * from './lib/timeline.icons';
+export * from './lib/timeline.model';
+export * from './lib/timeline.scale';
+export * from './lib/timeline.component';
+export * from './lib/timeline.module';

--- a/ui/libs/timeline/tsconfig.lib.json
+++ b/ui/libs/timeline/tsconfig.lib.json
@@ -1,0 +1,19 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "rootDir": "../../",
+    "baseUrl": "../../",
+    "paths": {
+      "@model/*": ["src/app/model/*"]
+    },
+  },
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/ui/libs/timeline/tsconfig.lib.prod.json
+++ b/ui/libs/timeline/tsconfig.lib.prod.json
@@ -1,0 +1,15 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false,
+    "rootDir": "../../",
+    "baseUrl": "../../",
+    "paths": {
+      "@model/*": ["src/app/model/*"]
+    },
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/ui/libs/workflow-graph/src/lib/graph.component.ts
+++ b/ui/libs/workflow-graph/src/lib/graph.component.ts
@@ -165,6 +165,9 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
     /** Emitted when selection mode is entered or exited. */
     @Output() onSelectionModeChange = new EventEmitter<boolean>();
 
+    /** The run job being pointed at, or null when the pointer left it. */
+    @Output() onHoverJobRun = new EventEmitter<string>();
+
     /** Current selection of run job IDs, managed internally. */
     selectedRunJobIds: Array<string> = [];
     /** Whether the graph is currently in selection (restart) mode. */
@@ -270,21 +273,27 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
             }
         }
 
-        // Selection-mode shortcuts (handled regardless of navigationDisabled)
-        switch (event.key) {
-            case 'Shift':
-                if (this.selectionDisabled) { return; }
-                if (!this.selectionModeActive) {
-                    this.setSelectionModeActive(true);
-                }
-                this.enableLassoSelection();
-                return;
-            case 'Enter':
-                if (this.selectionModeActive) {
-                    this.onSelectionValidate.emit([...this.selectedRunJobIds]);
+        // Selection-mode shortcuts. Only when this graph is what is being used: listening for them on the
+        // window meant a Shift pressed anywhere on the page — as a modifier for something else entirely,
+        // in another view of the same run — armed the lasso here and flipped the graph into selection
+        // mode. Focus is one way of being used; the pointer being over it is the other, and it matters
+        // because the lasso is a drag: it has to be armed before there is anything to have clicked on.
+        if (focusInGraph || this.pointerOver) {
+            switch (event.key) {
+                case 'Shift':
+                    if (this.selectionDisabled) { return; }
+                    if (!this.selectionModeActive) {
+                        this.setSelectionModeActive(true);
+                    }
+                    this.enableLassoSelection();
                     return;
-                }
-                break;
+                case 'Enter':
+                    if (this.selectionModeActive) {
+                        this.onSelectionValidate.emit([...this.selectedRunJobIds]);
+                        return;
+                    }
+                    break;
+            }
         }
 
         // Arrow / Enter navigation (guarded)
@@ -375,6 +384,22 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
         return description;
     }
 
+    /**
+     * Whether the pointer is over this graph. Kept because the keyboard shortcuts that arm the lasso are
+     * only meant for whoever is using this graph, and a drag has to be armed before it begins.
+     */
+    pointerOver: boolean = false;
+
+    @HostListener('mouseenter')
+    onMouseEnterGraph() {
+        this.pointerOver = true;
+    }
+
+    @HostListener('mouseleave')
+    onMouseLeaveGraph() {
+        this.pointerOver = false;
+    }
+
     @HostListener('window:keyup', ['$event'])
     handleKeyUp(event: KeyboardEvent) {
         if (event.key === 'Shift' && this.selectionModeActive) {
@@ -383,6 +408,49 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
                 this.setSelectionModeActive(false);
             }
         }
+    }
+
+    /**
+     * Select the node holding a run job and bring it into view, as clicking it would, without acting
+     * on it again. This is how another view of the same run — the timeline — keeps the graph in step
+     * with what it opened.
+     */
+    selectRunJob(runJobID: string): void {
+        const found = this.findRunJobNode(runJobID);
+        if (!found || !this.graph) {
+            return;
+        }
+        const baseKey = found.node.job?.stage ? `${found.node.job.stage}-${found.node.name}` : found.node.name;
+        this.selectedNodeNavigationKey = found.matrixKey ? `${baseKey}-${found.matrixKey}` : baseKey;
+        this.graph.selectNode(this.selectedNodeNavigationKey);
+        this.graph.centerNode(baseKey);
+        this._cd.markForCheck();
+    }
+
+    /** The node a run job is drawn on, and the matrix variant it stands for when the node is a matrix. */
+    private findRunJobNode(runJobID: string): { node: GraphNode, matrixKey: string } {
+        const match = (node: GraphNode): { node: GraphNode, matrixKey: string } => {
+            if (node.run?.id === runJobID) {
+                return { node, matrixKey: null };
+            }
+            const run = (node.runs ?? []).find(r => r.id === runJobID);
+            if (!run) {
+                return null;
+            }
+            // The matrix node keys its variants this way, and the key is what selection goes by.
+            const matrixKey = Object.keys(run.matrix ?? {}).sort().map(k => `${k}: ${run.matrix[k]}`).join(', ');
+            return { node, matrixKey };
+        };
+
+        for (const node of this.nodes ?? []) {
+            const found = node.sub_graph
+                ? node.sub_graph.map(match).find(m => !!m)
+                : match(node);
+            if (found) {
+                return found;
+            }
+        }
+        return null;
     }
 
     unSelect() {
@@ -609,9 +677,11 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
         switch (type) {
             case GraphNodeAction.Enter:
                 this.graph.nodeMouseEvent(NodeMouseEvent.Enter, n.name, options);
+                this.onHoverJobRun.emit(options?.['jobRunID'] ?? null);
                 break;
             case GraphNodeAction.Out:
                 this.graph.nodeMouseEvent(NodeMouseEvent.Out, n.name, options);
+                this.onHoverJobRun.emit(null);
                 break;
             case GraphNodeAction.Click:
                 const baseKey = (n.job && n.job.stage) ? `${n.job.stage}-${n.name}` : n.name;

--- a/ui/libs/workflow-graph/src/lib/node/job-node.html
+++ b/ui/libs/workflow-graph/src/lib/node/job-node.html
@@ -71,27 +71,10 @@
     }
   }
 
+  <!-- Only the duration here. The dates behind it, and where that duration went, are on the lane of
+       this job in the Timeline tab, which shows them without having to be hovered one node at a time. -->
   @if (duration && selectionMode === 'disabled') {
-    <div class="duration" nz-tooltip
-      [nzTooltipTitle]="durationTooltip">
-      {{duration}}
-      <ng-template #durationTooltip>
-        <div class="durationTooltip">
-          @if (dates.queued) {
-            <div><b>Queued:</b>&nbsp;{{dates.queued | date: 'long'}}</div>
-          }
-          @if (dates.scheduled) {
-            <div><b>Scheduled:</b>&nbsp;{{dates.scheduled | date: 'long'}}</div>
-          }
-          @if (dates.started) {
-            <div><b>Started:</b>&nbsp;{{dates.started | date: 'long'}}</div>
-          }
-          @if (dates.ended) {
-            <div><b>Ended:</b>&nbsp;{{dates.ended | date: 'long'}}</div>
-          }
-        </div>
-      </ng-template>
-    </div>
+    <div class="duration">{{duration}}</div>
   }
   @if (node?.run?.status && selectionMode === 'disabled') {
     <div class="status">

--- a/ui/libs/workflow-graph/src/lib/node/job-node.scss
+++ b/ui/libs/workflow-graph/src/lib/node/job-node.scss
@@ -81,11 +81,6 @@
         margin-right: 10px;
     }
 
-    .durationTooltip {
-        display: flex;
-        flex-direction: column;
-    }
-
     .status {
         position: absolute;
         bottom: 5px;

--- a/ui/libs/workflow-graph/src/lib/node/matrix-node.html
+++ b/ui/libs/workflow-graph/src/lib/node/matrix-node.html
@@ -91,34 +91,11 @@
             </div>
           }
           <div class="infos">
+            <!-- Only the duration here. The dates behind it, and where that duration went, are on the
+                 lane of this variant in the Timeline tab. -->
             @if (durations[key] && selectionMode === 'disabled') {
-              <div class="duration" nz-tooltip
-                [nzTooltipTitle]="durationTooltip">
-                {{durations[key]}}
-                <ng-template #durationTooltip>
-                  <div class="durationTooltip">
-                    @if (dates[key].queued) {
-                      <div><b>Queued:</b>&nbsp;{{dates[key].queued | date: 'long'}}
-                    </div>
-                  }
-                  @if (dates[key].scheduled) {
-                    <div><b>Scheduled:</b>&nbsp;{{dates[key].scheduled | date:
-                    'long'}}
-                  </div>
-                }
-                @if (dates[key].started) {
-                  <div><b>Started:</b>&nbsp;{{dates[key].started | date:
-                  'long'}}
-                </div>
-              }
-              @if (dates[key].ended) {
-                <div><b>Ended:</b>&nbsp;{{dates[key].ended | date: 'long'}}
-              </div>
+              <div class="duration">{{durations[key]}}</div>
             }
-          </div>
-        </ng-template>
-      </div>
-    }
     @if (status[key] && selectionMode === 'disabled') {
       <div class="status">
         {{status[key].toLowerCase()}}

--- a/ui/libs/workflow-graph/src/lib/node/matrix-node.scss
+++ b/ui/libs/workflow-graph/src/lib/node/matrix-node.scss
@@ -188,11 +188,6 @@
                         line-height: 0.7em;
                     }
 
-                    .durationTooltip {
-                        display: flex;
-                        flex-direction: column;
-                    }
-
                     .status {
                         margin-top: 4px;
                         font-size: 0.5em;

--- a/ui/libs/workflow-graph/src/lib/v2.workflow.run.model.ts
+++ b/ui/libs/workflow-graph/src/lib/v2.workflow.run.model.ts
@@ -276,6 +276,10 @@ export class WorkflowRunInfo {
 
 export class WorkflowRunResult {
     id: string;
+    /** The run job that created the result, which is what puts it on the timeline of that job. */
+    workflow_run_job_id: string;
+    /** When the result was created. */
+    issued_at: string;
     type: WorkflowRunResultType | string;
     detail: WorkflowRunResultDetail;
     metadata: { [key: string]: WorkflowRunResultMetadata };

--- a/ui/specs/workflow-run-graph.md
+++ b/ui/specs/workflow-run-graph.md
@@ -4,6 +4,10 @@
 
 The workflow run view renders an interactive **directed acyclic graph (DAG)** that visualizes the complete structure of a CDS workflow: its jobs, stages, matrix expansions, dependency edges, and runtime status. The graph is the central element of the run page — it drives navigation, status monitoring, and operational features such as **job restart** and **gate management**.
 
+The graph shows the run as structure. The same run seen as time — how long each job waited and ran, and
+when it produced what — is the Timeline tab of the bottom panel, specified in
+[workflow-run-timeline.md](workflow-run-timeline.md).
+
 ---
 
 ## 1 — Graph Rendering
@@ -47,6 +51,10 @@ A rectangular node representing a single workflow job.
 - Duration (live-updating while active, static when terminated)
 - Status label (success, fail, building, inactive, etc.)
 - Condition tooltip showing gate and if-expressions when defined
+
+The duration is a number and nothing more. The dates behind it — queued, scheduled, started, ended —
+and how the duration was split between waiting and working are on the job's lane in the Timeline tab,
+which shows them for every job at once instead of one hovered node at a time.
 
 **Action buttons** (in the commands area):
 - **Gate button**: Shown when the job defines a gate and the workflow is not active. For gates without inputs, a popconfirm triggers the gate directly. For gates with inputs, a button opens a drawer.
@@ -103,7 +111,8 @@ Edges represent dependencies between jobs. The rendering pipeline:
 5. Colors edges based on source node status (green for success, red for fail, grey for inactive)
 6. Active-status edges are drawn thicker for emphasis
 
-On **hover**, all edges connected to the hovered node are highlighted.
+On **hover**, all edges connected to the hovered node are highlighted, and the graph reports which run
+job is being pointed at so that the timeline can bring out the same one.
 
 ---
 
@@ -168,6 +177,12 @@ The graph maintains a **navigation graph** — a flattened representation of the
 ### 5.3 Help Tooltip
 
 A help icon (?) in the toolbar shows a tooltip listing all keyboard shortcuts with styled key caps. The Shift shortcut line is only visible when the workflow run has terminated, since selection mode is only relevant for terminated runs.
+
+The Shift and Enter shortcuts of selection mode only act when **this graph is the thing being used**: the
+focus is inside it, or the pointer is over it. They are listened for on the window, so without that a Shift
+pressed anywhere on the page — as a modifier for something else entirely, in another view of the same run —
+armed the lasso and flipped the graph into selection mode. The pointer counts as well as the focus because
+the lasso is a drag, and a drag has to be armed before there is anything to have clicked on.
 
 ---
 

--- a/ui/specs/workflow-run-timeline.md
+++ b/ui/specs/workflow-run-timeline.md
@@ -1,0 +1,595 @@
+# Specification: Workflow Run Timeline
+
+## Overview
+
+The run page shows a workflow twice, from two angles. The **graph** shows its structure: which jobs
+there are, what they depend on, how they ended. The **timeline** shows the same run as time: how long
+each job waited before anything happened to it, how long it actually ran, and when it produced what.
+
+The graph answers *what happened*. The timeline answers *where the time went* — which job held the run
+back, how much of a job's wall clock was spent queueing rather than working, and whether an artifact
+appeared early or at the very end.
+
+The timeline is the **default tab of the bottom panel of the run page**, beside Info, Results and Tests.
+It is fed by the same jobs and results the rest of the view is fed by, so it follows a running workflow
+live over the websocket, with no reads of its own.
+
+It does not replace the Info tab, which holds the run infos — every message, warning and error the engine
+writes while crafting and running the workflow, in full. Of those the timeline marks the **errors** only,
+at the moment each was written, and activating one goes to that tab (§2.4).
+
+---
+
+## 1 — Separation Of Concerns
+
+The timeline is split in two, deliberately, and the split is enforced by the build: the view is its own
+Angular library and is built on its own (`ng build timeline`), which it could not be if it knew
+anything about CDS.
+
+| | Knows about | Does not know about |
+|---|---|---|
+| **`libs/timeline`** — the view | sections, lanes, segments, markers, a time axis, folding, zooming, expanding | jobs, runs, results, stages, gates, statuses |
+| **`run-timeline.builder.ts`** — the adapter | run jobs, run results, stages, statuses, `needs` | pixels, positions, zoom, the axis |
+
+The view paints a segment or a marker from the free-form `kind` the adapter gives it, exposed as a
+`data-kind` attribute. What `queued`, `blocked` or `running-success` should look like is decided by the
+host stylesheet (`run-timeline.scss`), never by the library.
+
+The same goes for controls the host **projects** into the view, such as the critical path toggle: a
+projected element belongs to the host, and the library's rules — scoped to its own template — cannot
+reach it. What such a control looks like on and off is therefore stated in the host stylesheet, beside
+the button it is about.
+
+Activation works the same way in reverse: the view reports which lane or marker the user activated, by
+id, and the adapter keeps the map from those ids to what they stand for — a run job or a run result —
+and opens the matching panel.
+
+### 1.1 The View Model
+
+- A **segment** is a stretch of time on a lane, with a start and an end. An end left unset means it is
+  still going, and the segment grows on screen.
+- A **group** is several segments that are one thing — see below.
+- A **marker** is a point in time on a lane, drawn as an icon saying what it is, or as a plain
+  lozenge when it is given none.
+- A **lane** holds segments, markers, and possibly lanes of its own, shown when it is expanded.
+- A **section** is a run of lanes under an optional heading.
+
+### 1.2 Groups: Several Bars, One Thing
+
+The phases of a job are not three things that happened, they are one job. Segments sharing a **group**
+say so, and the group is what the view then works with:
+
+- **One thing to the pointer.** The group is drawn as a single element holding its segments, and the
+  markers falling inside its span are drawn inside it too. Going from the queued bar to the running bar,
+  or onto an artifact marker, never leaves the group — so what it shows on hover cannot blink at every
+  boundary. This is a structural guarantee, not a delay tuned until the flicker stopped.
+- **Indivisible on the axis.** Whatever separates two segments of a group holds the axis open, so no fold
+  can be inserted between them and the pieces of a group keep their true proportions to one another
+  however much is folded away elsewhere.
+
+The second property says nothing about the *inside* of a segment, and that distinction is what makes it
+safe: a job held by a gate is a **single** segment spanning days, and folding straight through it is the
+whole point of §3. Only the gaps *between* segments are claimed.
+
+On CDS data there are no such gaps — a job leaving one status takes the next in the same instant — so
+indivisibility costs nothing here and is a guarantee rather than a fix. It is asserted in the tests both
+ways: that the phases of a job are contiguous, and that a group with a real gap in it keeps that gap to
+scale where it would otherwise have been folded away.
+
+A segment with no group is a group of its own.
+
+---
+
+## 2 — What A Job Looks Like
+
+Each run job holds one lane, split into the phases it went through:
+
+| Phase | From | To | Reads as |
+|---|---|---|---|
+| Queued | `queued` | `scheduled` | Waiting in the queue for a hatchery to take it |
+| Blocked | `queued` | — | Same wait, for a job held by a gate or a concurrency rule |
+| Scheduling | `scheduled` | `started` | A hatchery starting a worker |
+| Running | `started` | `ended` | The job itself |
+
+The queued and blocked phases are drawn hatched: no time is being spent on the job during them. This is
+the point of the view — a job whose bar is mostly hatching cost the run a lot of wall clock without
+doing any work.
+
+A job that never reached the queue has no place on a time axis and is left out.
+
+The lane label carries nothing but the job name and its matrix variant when it has one. There is no
+second line: the status is already in the colour of the bars, and a bare duration under a name says
+neither what it measured nor between which two points. Both are in the hover card, where there is room
+to name them.
+
+Durations are read off the bars themselves — a segment wide enough shows its own duration next to its
+name — so the common question is answered without hovering anything.
+
+### 2.1 The Row Asks, The Bars Answer
+
+A row and its bars are asked different questions, and each answers its own:
+
+| Clicking | Does | Because |
+|---|---|---|
+| The **row** — the whole name column, and the empty track beside its bars | Unfolds the lane, showing its steps | The row is *about* the lane |
+| The **bars** | Opens the job, on its logs | The bars *are* the lane |
+
+The name column answers all the way across, not only where the name happens to end: a click to the right
+of a short job name is still a click on that row.
+
+A lane with nothing inside it — a step, a result — has only the second answer to give, so its row opens
+it. A dotted leader runs from the name across to the bars so the row reads as one line; it meets the edge
+of the name column and starts again at the edge of the track, with no blank where the two columns join.
+
+Opening a job opens the job panel, which *is* the log view — its blocks start expanded — so a click on
+the bars lands on the logs.
+
+From the keyboard the row is one tab stop: `←` and `→` unfold it, `Enter` opens it. The caret is a mark,
+not a target of its own.
+
+### 2.2 Expanding A Job, And Which Step Made What
+
+Expanding a job lane reveals one lane per **step**, each spanning that step's own start and end and
+coloured from its conclusion.
+
+A result **says which job made it, never which step**. But it is created by the step that is running at
+the time, and both timestamps come off the same worker, so the step whose run covers the moment a result
+was created is the step that created it. Results are pinned on that step, which is what makes unfolding a
+job worth doing: it says not only how long each step took but which of them produced what.
+
+A result no step accounts for — one created between two steps, which should not happen but would
+otherwise be lost — falls back to a lane of its own under the job. Nothing is dropped for want of a step
+to hang it on.
+
+The job's own lane keeps every one of its results, wherever they are pinned below: that is the glanceable
+view. A test report and a container image are not the same thing and are not drawn as the same mark.
+
+A marker sits **just above the bars**, not laid across them: centred on a short bar, it covered the name
+of the very thing it belonged to. A short stem crosses the gap and meets the top edge of the bar exactly,
+so the mark reads as belonging to that bar rather than floating above the row. The gap is what makes the
+stem worth having — run down inside the bar it was hidden by it.
+
+A lane carrying markers is taller than one that does not, by the room they take. It is grown **at both
+ends**, so its bars stay centred on the line and keep exactly the height they have on a lane carrying
+none — a lane with artifacts is a taller lane, not a lane whose bars have moved.
+
+A marker with no bar under it — a lane that is only a point in time, which is what an unaccounted-for
+result falls back to — sits in the middle of its row instead, with nothing to be welded to.
+
+### 2.3 The Gate That Let A Job Start
+
+A gated job carries a **mark at the head of its lane** for the gate that held it, alongside whatever it
+produced. Hovering it gives what was answered to let the job through — the values the gate was triggered
+with — and the condition the gate was declared with. A job still waiting says so instead of showing an
+empty list.
+
+The two halves come from different places: the condition and the shape of the inputs are on the workflow
+definition, the values actually used are on the run job. The gate is set apart from the results sharing
+the lane, being the thing that let the job start rather than something it made.
+
+### 2.4 The Lane Of The Run Itself
+
+Above the jobs sits a lane for the **run itself**, holding what set it off and anything it logged as an
+error. Neither belongs to any one job — a run info carries no job reference at all — and both are instants
+rather than stretches, so the lane has markers and no bars.
+
+It sits in a **section of its own**, before every other, and never inside one of the stages: the run is
+not part of the first stage, and putting its lane there said that it was. Its name is `RUN` — not the name
+of the workflow, which read as the name of a job — and it is set like the heading of a section rather than
+like a lane, which is what it is: the run, above the jobs it ran. It turns red once the run has logged an
+error, and says how many.
+
+**What set off what is being shown** is the first mark of the lane.
+
+On a first attempt that is the **hook** that started the run, at the moment it did. Its heading names the
+event in prose (`Started by a push`, `Started by hand`), and under it: the kind of hook behind it, who
+started it, the ref and the commit, and whatever else the event carries. The icon says which kind it was at
+a glance — a branch for the repository events, a clock for the scheduler, a person for a manual run — so
+the kinds can be told apart without hovering. Activating it opens the **hook panel**, the same one the hook
+nodes of the graph open, which writes the whole event out.
+
+On a later attempt it is the **restart**, marked at the head of what was restarted rather than at the start
+of the run. The run was set off however long before that attempt — days, for a job restarted after a wait —
+and a mark there would drag the axis back to a moment that has nothing to do with what is being shown,
+which is exactly what §5.1 avoids. It says who asked and for which jobs; the API records one event per job
+asked for, stamped with the attempt it created. Nothing opens from it: there is no panel for a restart, so
+like a gate it is a mark to hover.
+
+A run **error** is marked the same way, at the moment it was written. The **message is the heading**, since
+the message is the whole of it, with the time underneath. Activating it opens the **Info tab**, which is
+where the full text of everything the run logged lives — there is no panel for a run info, and a long
+message would not fit in a card.
+
+Warnings and plain infos are left out on purpose. They are the ordinary chatter of a run, and a mark for
+each would bury the one kind worth stopping at. The Info tab still has all of them.
+
+This lane is also all a run that failed while being crafted ever has: no job was queued, so the trigger
+and the error are the only two things that happened. See §5.2 for what the axis does with content that
+thin.
+
+### 2.5 Too Many To Draw: Markers Drawn As One
+
+A job can produce a great many results at once — one junit report per test suite is an ordinary thing to
+do — and drawn one mark each they would pile into an unreadable smear. So **markers too close together to
+be told apart are drawn as one**, stacked, carrying how many it stands for.
+
+This belongs to the **view**, and the reasoning is worth keeping because it is not obvious. Whether two
+markers collide is a fact about *pixels*: it depends on the zoom, on how wide the track is, and on how big
+a marker is drawn. None of that is known to the side providing the data. Forty results a second apart
+overlap on a run that took an hour and are perfectly distinct once it is zoomed in — the same data has to
+cluster differently from one moment to the next, so only the view can decide, and it decides again on
+every layout.
+
+What the adapter contributes is the **word**: `12 results` rather than `12 markers`. What a marker stands
+for is the host's to name — and a kind of marker may name its own plural, so a cluster of run errors reads
+`3 errors` instead of borrowing the word this timeline uses for everything else.
+
+- A cluster of one kind keeps that kind's icon; a mixed one gets a neutral mark, since the icon would
+  otherwise claim they were all the same thing.
+- It carries the count **beside** the icon, growing sideways into a pill. Everything a marker draws has
+  to fit in the room the row keeps above its bars, because the track clips what overflows it — and it
+  must, to cut the bars off at its edges. A badge hung off the corner was the obvious thing to reach for
+  and the wrong one: it needed height the row does not have, so it came out clipped. Sideways is the one
+  direction a marker has room to grow in.
+- Hovering it lists the first few by name and time, then says how many are left.
+- **Clicking it zooms into what it covers**, which pulls it apart into the individual marks — the natural
+  way out, given that the crowding was a matter of scale to begin with. It stands for no single thing, so
+  there is nothing else for a click to open.
+- Results created at the very same instant cannot be pulled apart by any zoom. Those stay one mark, and
+  the card is what tells them apart.
+
+A result is called by its **key** — `generic:binary.tar.gz`, `tests:unit.xml` — which is what the Results
+tab lists it under and what someone would search a log for. The sentence the API also offers, filename and
+size in prose, says less in more room; the filename and the size are in the detail instead.
+
+The **icon** a marker asks for is not simply put on the page: only the ones the view carries are drawn, and
+anything else is drawn as a plain mark. An unregistered name is not a missing icon — the icon component
+fetches `assets/<theme>/<name>.svg` and renders what comes back — so a name that reached the view from data,
+a result type or a file name, would be a way of choosing a URL to load and render. The adapter maps to a
+fixed set already; the view refuses anything outside its own list whatever the host asked for.
+
+### 2.6 What A Lane Says When Hovered
+
+Hovering **one of the bars** of a lane gives what the bars can only suggest:
+
+- its **total**, from the start of its first segment to the end of its last;
+- **where that total went** — every phase, how long it lasted, and what share of the lane it took, on a
+  gauge. This is the point of the whole view: a job that took four minutes of which three were spent
+  queueing is a different problem from one that spent them working;
+- the **dates** behind it, and its retry count when it is not the first attempt. Labels to the left,
+  values to the right, so the values read down one column.
+
+Nothing else goes in there. The status is already in the colour of the bars, how long the job took is the
+breakdown itself, and the worker and the region belong to the job panel — repeating them would only make
+the card longer to read.
+
+The share breakdown is worked out by the view, which can see the segments. The dates are given by the
+adapter, which is the only side that knows what they are.
+
+The card is asked for by the **group of bars**, not by the row: pointing at the name of a lane, or at the
+empty track beside its bars, is not asking how its time was spent. Because the group is one element
+(§1.2), moving between the phases of a job never leaves it, so nothing has to be smoothed over. Leaving
+the group is given a brief moment, only so that going from one job's bars to another's carries the card
+across rather than starting its delay again.
+
+A **marker has its own card** — which artifact, made when, how big. It sits inside the group, so without
+one of its own the group's card would stay up over something it is not about. Pointing at a marker
+therefore replaces the card rather than leaving it, and **leaving the marker hands it back** to the group:
+a marker leaving does not leave the group, so nothing else would put the group's card back, and moving
+from a result to the bar under it would show nothing at all.
+
+### 2.7 Where The Card Appears
+
+- **Above what it is about**, lined up with the pointer where it was when the card was asked for. Below
+  only when there is no room above. Dead centre of a bar spanning the view is nowhere near the pointer;
+  the pointer's own position is.
+- Then it **stays put**. A card that follows the pointer has to be read while moving; knowing where it
+  will appear before it does is worth more than staying under the cursor.
+- Pushed back inside the window rather than flipped sideways, so it never jumps corners.
+- It waits before appearing, long enough that crossing the timeline on the way somewhere else opens
+  nothing. Once it is up, going from one thing to the next swaps it over at once, having already waited.
+- It is dropped as soon as the lanes scroll or a pan starts, and what a group's card says is kept in step
+  with the run while it stays open on a live job.
+
+The card is shown in an **overlay of its own, placed against the pointer and following it**. Two things
+rule out the simpler options:
+
+- A tooltip centres itself on the element it is attached to, and a row spans the whole width of the
+  view — which puts the card in the middle of the page rather than next to the job.
+- Drawn inside the timeline, it is clipped: the bottom panel is a few hundred pixels tall and hides what
+  overflows it, so a card taller than what is left below the row is cut off.
+
+An overlay sits outside the panel, so nothing clips it, and it is placed against the pointer rather than
+against a row that says nothing about where the pointer is. It flips above the pointer when there is no
+room below, is pushed back inside the window rather than flipped sideways — so following the pointer
+never makes it jump between corners — and takes no pointer events, since it sits under the cursor.
+
+It appears after a short wait, so that crossing the lanes does not flash a card on every bar on the way,
+but once it is up, moving between bars swaps what it says at once. It is dropped as soon as the lanes
+scroll or a pan starts, and what it says is kept in step with the run while it stays open on a live job.
+
+The pointer is followed through a listener registered **outside the Angular zone**: a mouse move changes
+nothing that has to be rendered, and running change detection on every one of them would cost the whole
+page.
+
+### 2.8 Stages
+
+Jobs are grouped under their stage, and the stages are drawn in the order they were reached, which for
+a timeline is also the order they read in. A workflow without stages gets a single unlabelled section
+and no headings.
+
+---
+
+## 3 — Folding Idle Time
+
+A workflow run can sit doing nothing for hours or days — a gate waiting on a human, a concurrency rule
+holding a job back. Drawn strictly to scale, everything that actually happened would be squashed into
+a few pixels at either end of a mostly empty axis.
+
+So stretches of the axis where **nothing is being worked on** are folded: they keep a small, fixed share
+of the width whatever their real length. The wait is still drawn, still in order, still labelled with
+how long it really was — it just no longer costs the axis anything near its real length.
+
+Time stays strictly proportional everywhere else. Two segments can be compared by eye as long as no
+fold sits between them, which is exactly what the hatched fold bands and their labels mark.
+
+### 3.1 Waiting Is Not Something Happening
+
+A job held by a gate is created the moment the run reaches it, so its `Blocked` bar spans the whole
+wait — days of it. Were that bar taken for something happening, the wait could never be folded, and
+the gate case, the one folding exists for, would be the one case it did not cover.
+
+So segments say whether they are **working or waiting**: the queued and blocked phases are marked idle.
+An idle segment is drawn like any other and still sets the bounds of the axis, but it does not hold its
+stretch of time open. A stretch covered by nothing but idle segments can be folded, and the bar is then
+drawn folded across it — hatched, compressed, with the fold band behind it saying how long the wait
+really was, and its own tooltip and screen reader text still giving the true duration.
+
+Rules:
+
+- Only gaps longer than the fold threshold are folded, and the threshold is a few minutes: a short wait
+  for a hatchery is worth seeing to scale, a wait of hours only needs to be readable.
+- A stretch is only foldable if **every** lane over it is idle or has nothing there. One job running is
+  enough to keep the whole stretch to scale.
+- A stretch between two segments of one group is never folded, since a group is indivisible (§1.2).
+
+Folding is **always on, and there is no control for it**. A timeline that cannot fold is unreadable as
+soon as anything waits, which on a workflow with gates is most of the time. The one thing turning it off
+would buy — comparing two segments on either side of a fold by eye — is already answered better by the
+durations on the bars and in the hover card. It stays an input of the library, so a host with data that
+never waits can turn it off, but the run view does not offer it.
+- An instant — a result created during a long wait — keeps its own moment out of the fold, splitting
+  the wait into two folds around it rather than being folded away with it.
+- Graduations are only placed on stretches drawn to scale. A time label inside a fold would claim a
+  precision the fold does not have.
+- Folding can be turned off, which puts the axis back to strict proportion.
+
+---
+
+## 4 — Critical Path
+
+The critical path is the chain of jobs that set the total duration of the run: the last job to end,
+then whichever of the jobs it waited on ended last, and so on back to the start. Shortening any job
+outside that chain would not have made the run any shorter.
+
+Predecessors are read from the workflow definition — a job's `needs`, plus every job of the stages its
+stage needs. For a matrixed job, the variant that ended last is the one on the chain.
+
+Highlighting it brings those lanes out by holding the others back: everything off the chain is dimmed —
+its bars, its markers, its name, and the dotted rule behind them, which left alone showed straight through
+the faded bars and drew more attention than they did.
+
+The control is a toggle that reads on or off the way the filters of the Results tab do.
+
+It is **disabled when the highlight would say nothing**, which is more often than it first appears. The
+highlight works by holding back what is *not* on the chain, so it needs something to leave out: a chain of
+one job says nothing, and neither does a chain holding *every* job of the run — which is what a workflow
+that is one job after another comes to. The tooltip says which of the two it is.
+
+Only jobs that **did work** are on the chain. A skipped job is terminated and carries an end date like
+any other — the engine stamps one on whatever it finishes with — so without this it could be credited
+with setting a duration it spent none of, and could even head the chain by being skipped last. Where a
+job on the chain waited on one that was skipped, the chain carries on through whatever *that* one waited
+on, so it neither stops at the skip nor credits it.
+
+What is **inside** a highlighted lane is highlighted with it. Dimming the lanes nested under a highlighted
+one would hide the very thing the highlight was turned on to look at.
+
+**What it does not account for.** The chain answers "why did the run end when it did", so it follows wall
+clock — and a gate answered days later genuinely is why. Trigger a job that had been skipped and it
+becomes the last to end, so it heads the chain and everything that ran while the gate sat unanswered is
+off it. Correct, since none of that decided when the run ended, but the resulting highlight then says
+more about when somebody clicked than about any job's work.
+
+---
+
+## 5 — Reading The Axis
+
+### 5.1 Where It Starts
+
+On a first attempt the axis starts with the run, so that the crafting that happens before any job is
+queued is part of what is shown.
+
+A restart bumps the attempt without moving the start date of the run, so on a later attempt that date
+sits however long ago the first attempt began — and the timeline would open on a fold with nothing in
+it. On a later attempt the axis therefore starts with the earliest job of that attempt. Jobs kept from a
+previous attempt keep their original dates, so a restart that kept some jobs legitimately spans both.
+
+Everything drawn has to respect that, not only the jobs: anything left at the start of the run would pull
+the axis back there by itself and undo all of this, which is why what set the run off becomes a mark for
+the restart instead (§2.4).
+
+### 5.2 Where It Ends, And That It Ends
+
+The first and last instants of the axis are marked with a **faintly hatched band** spanning the lanes,
+patterned like a fold and labelled `START` and `END` — `NOW`, in the colour of the present, while the
+run is going. A band rather than a line, so a bar reaching the edge of the view is never taken for a bar
+running off it; but faint, and with no hard rule down its edge — these say where the axis stops, they are
+not the subject. The band at the present is the only mark for it; a separate line beside it would have
+been the same instant twice.
+
+The names and the bars are two columns and always read as two, whatever the zoom is doing: a **separator**
+runs the height of the view at the boundary, so zooming in past the start band does not leave the two
+sides touching.
+
+Graduations are kept clear of those labels by the width of a label, so that two times are never printed
+on top of one another.
+
+The bands are given **space of their own** at either end: everything else is drawn between them, so a bar
+can never run under one. Nothing is squeezed out by this — the space is simply not part of the plot.
+
+When zoomed in, the bands fall outside the window and are not drawn, which is itself the answer: there is
+more on that side.
+
+#### Room at the ends, taken out of the track
+
+How much of the track each end keeps clear is decided per layout, and everything else is drawn between the
+two. Beyond the bands themselves, two things ask for room:
+
+- a **marker sitting on a bound**. A bar reaching the edge of the axis still reads as a bar; a marker is a
+  glyph with a size but no length, so one centred on the edge is half drawn outside it. That side keeps
+  more clear — and only that side.
+- **content that never lasted**: a handful of instants and not one bar, which is what a run that failed
+  before queueing a job comes to. Its bounds *are* the instants, so drawn across the whole track they sit
+  against its two edges with nothing between them. Such content is given the **middle third** instead,
+  where it reads as being somewhere rather than at an end.
+
+Each hatched band then runs from where the content stops to the edge of the view, so what the ends keep
+clear is hatched rather than left as blank space nothing accounts for. However narrow the view gets, the
+plot keeps a fifth of it.
+
+This room is taken out of the **track**, in pixels, and never out of the stretch of time the axis covers —
+and that is the whole point. Time taken has to be either drawn to scale, where a few pixels of room on a
+two-day axis is an hour of invented time that then takes the whole view, or folded away, which is the room
+being taken straight back. Taking it out of the track leaves time meaning what it means, and leaves §3
+deciding what it is worth.
+
+### 5.3 Where The Pointer Is
+
+Moving the pointer across the lanes draws a **guide** down them at that position, with the time it stands
+for read out on the axis. On an axis with folds in it, working out what a position means is otherwise
+guesswork.
+
+The guide covers the plotted part of the axis only: the bands at either end stand for no one instant, so
+there is no time to read off them. Both the guide and its readout are moved by writing to them directly,
+outside change detection — a mouse move changes nothing else that has to be drawn, and running change
+detection on every one of them would cost the whole page.
+
+### 5.4 Zoom And Pan
+
+Zooming is on the wheel and the keys, as on the graph. The only **button** for it is the one that puts the
+whole run back in view — there is no in and out to click, since the wheel does it better and the buttons
+cost a row of chrome.
+
+- **Fit** shows the whole run. Zooming in narrows the window; the graduations follow, from weeks down
+  to seconds.
+- Zooming with the wheel keeps the point under the pointer where it is.
+- Panning is a drag, or the wheel sideways. Straight up and down is left to the panel, which scrolls
+  the lanes. Nothing uses `Shift` as a modifier: a host page is free to treat one as a shortcut of its
+  own, and the wheel needs no focus, so a `Shift` wheel over the lanes would reach it without the pointer
+  ever having been near what it drives. (The graph now only acts on `Shift` when it is itself focused or
+  hovered, so this is caution rather than a live conflict.)
+- A drag only captures the pointer once it has moved far enough to be a drag. Capturing it on the press
+  would retarget the click that ends it, and clicking a lane while zoomed in would do nothing at all.
+
+### 5.5 Where The Controls Live
+
+The lanes are what the view is for, so everything else lives **in the gutter of the axis row**, above the
+lane names, where it costs no row of its own: expand all, the critical path toggle, fit-to-view, the span
+of the timeline, and the shortcuts help. Nothing floats over the lanes.
+
+---
+
+## 6 — Keeping Step With The Graph
+
+The graph and the timeline show one run, and must never disagree about what is being looked at.
+
+- Opening a job from the timeline **selects its node in the graph** and brings it into view, exactly as
+  clicking that node would, without acting on it twice. For a matrixed job it is the variant that was
+  opened, not the job, that gets selected.
+- The lane whose panel is open is **marked as selected**, whichever view opened it, so the timeline says
+  what is being looked at rather than only what was last hovered.
+- Hovering a job in the graph **brings out its lane** in the timeline, marked more strongly than a plain
+  hover since the pointer is elsewhere and cannot say where it is.
+
+---
+
+## 7 — Keyboard And Screen Readers
+
+| Key | Does |
+|---|---|
+| `Tab` | Move through the controls and the lane names |
+| Clicking a lane | Focuses it, so the keys below act on what was just clicked |
+| `↑` `↓` | Move between lanes |
+| `→` `←` | Expand / collapse the focused lane |
+| `Enter` `Space` | Open the focused lane |
+| `+` `-` `0` | Zoom in, out, fit |
+
+The zoom keys work wherever the focus is inside the view, not only on a lane: a lane deals with them first
+and stops them, so anywhere else — the focus sitting on a control after using it — they still reach the
+axis. And **clicking a lane focuses it**, since the click lands on the column around the name rather than
+on the name itself; without that, none of the keys above would do anything until something had been tabbed
+to, which is how they came to look broken.
+
+Every key the timeline handles is stopped from bubbling: the graph listens for arrows and `Enter` on
+the window, and must not move because the timeline was being used.
+
+Each lane label is read out with what the lane holds — every phase and its duration, and how many
+markers sit on it — so the durations the bars carry for the eye are carried in words too. The diamonds
+themselves are hidden from screen readers, the result lanes saying the same thing better.
+
+---
+
+## 8 — Live Updates
+
+The timeline is given the same `jobs` and `results` arrays the graph and the panels are given, which
+the run view replaces on every websocket event. Nothing is read for the timeline's sake:
+
+- A job moving from `Waiting` to `Scheduling` to `Building` grows a new phase on its lane.
+- A result being created adds a marker, and a lane under its job.
+- The axis grows with the present, which moves every bar a little to the left each second. That is fine
+  while the view is only being watched, and no good at all while it is being used: aiming at a bar that
+  is sliding away is not something anyone should have to do. **The clock is therefore held while the
+  pointer is in the lanes**, and catches up when it leaves. Changes the run itself reports still land —
+  those are real, and rare enough not to move the ground under a click.
+
+### 8.1 Keeping Up With A Run
+
+A run still going grows *downwards* as its jobs are queued, and a view that stays where it was shows less
+of the run the longer it goes on. So the lanes are **followed down**, the way a log tail is.
+
+Only while nothing has been asked of the view, though. Every one of these means someone is reading
+something in particular, which is not to be dragged out from under them:
+
+| Following stops when | Because |
+|---|---|
+| The lanes are scrolled away from their foot | They went to look at something further up |
+| The axis is zoomed | They are looking at a stretch of it in particular |
+| The pointer is in the lanes | They are pointing at something |
+| The run has finished | Nothing is being added to it |
+
+Note what it does **not** do: remember that it was once left alone. It asks where the lanes are sitting
+now, so scrolling back to the foot picks the following up again by itself — no control to find, and no
+state to get stuck in.
+
+The decision is taken *before* the new lanes are drawn: once they are in, the foot of the list has moved
+and there is no longer any way to tell whether it was being watched.
+- The zoom window, the folding and which lanes are expanded survive those updates. Expanded state is
+  keyed by lane id, not by position.
+- Leaving the tab and coming back rebuilds the view: the zoom window is not kept across that.
+
+---
+
+## 9 — Source File Reference
+
+| Area | Key files |
+|---|---|
+| Generic timeline view (axis, folding, zoom, lanes, keyboard) | `libs/timeline/src/lib/timeline.component.ts`, `timeline.html`, `timeline.scss` |
+| Time axis and gap folding | `libs/timeline/src/lib/timeline.scale.ts` |
+| View model, and the rules pulled out of the view to be testable (`axisEnds`, `shouldFollow`) | `libs/timeline/src/lib/timeline.model.ts` |
+| The icons a marker may be drawn with, and why nothing else is | `libs/timeline/src/lib/timeline.icons.ts` |
+| CDS adapter (trigger, phases, stages, results, critical path) | `run-timeline.builder.ts` |
+| Host component (panels, critical path toggle, graph hover) | `run-timeline.component.ts`, `run-timeline.html` |
+| Selecting a graph node from elsewhere, reporting hover | `libs/workflow-graph/src/lib/graph.component.ts` |
+| Theming of the kinds | `run-timeline.scss` |
+| Tests | `run-timeline.spec.ts` |

--- a/ui/src/app/views/project/project.module.ts
+++ b/ui/src/app/views/project/project.module.ts
@@ -52,7 +52,9 @@ import { RunResultsComponent } from '../projectv2/run/run-results.component';
 import { RunSourcesComponent } from '../projectv2/run/run-sources.component';
 import { RunTestComponent } from '../projectv2/run/run-test.component';
 import { RunTestsComponent } from '../projectv2/run/run-tests.component';
+import { RunTimelineComponent } from '../projectv2/run/run-timeline.component';
 import { GraphModule } from '../../../../libs/workflow-graph/src/public-api';
+import { TimelineModule } from '../../../../libs/timeline/src/public-api';
 
 @NgModule({
     declarations: [
@@ -104,6 +106,7 @@ import { GraphModule } from '../../../../libs/workflow-graph/src/public-api';
         RunSourcesComponent,
         RunTestComponent,
         RunTestsComponent,
+        RunTimelineComponent,
         RunTriggerComponent
     ],
 
@@ -112,6 +115,7 @@ import { GraphModule } from '../../../../libs/workflow-graph/src/public-api';
         RouterModule,
         DragDropModule,
         GraphModule,
+        TimelineModule,
         projectRouting
     ],
     providers: [

--- a/ui/src/app/views/projectv2/run/run-timeline.builder.ts
+++ b/ui/src/app/views/projectv2/run/run-timeline.builder.ts
@@ -1,0 +1,716 @@
+import { TimelineData, TimelineDetail, TimelineLane, TimelineMarker, TimelineSection, TimelineSegment } from "../../../../../libs/timeline/src/public-api";
+import { V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunJobStatus, WorkflowRunResult, WorkflowRunResultType, WorkflowRunInfo } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
+
+/** What a lane or a marker of the timeline stands for, so that activating it opens the right panel. */
+export interface RunTimelineTarget {
+    type: 'job' | 'result' | 'info' | 'hook';
+    id: string;
+}
+
+export interface RunTimelineBuild {
+    data: TimelineData;
+    targets: { [key: string]: RunTimelineTarget };
+    /** Run job IDs of the chain that set the total duration of the run. */
+    criticalPath: Array<string>;
+    /** How many jobs the timeline drew, which is what the critical path has to be shorter than to say anything. */
+    jobCount: number;
+}
+
+/** Lanes of jobs without a stage are gathered here when the workflow also declares stages. */
+const NO_STAGE = '__nostage__';
+
+/**
+ * A date the API left unset. The engine writes a zero time rather than nothing for some of them,
+ * which lands before the epoch once parsed.
+ */
+function toMs(value: string): number {
+    if (!value) {
+        return null;
+    }
+    const ms = Date.parse(value);
+    return isNaN(ms) || ms < 0 ? null : ms;
+}
+
+/** `os=linux, go=1.22` — what tells two run jobs of the same matrixed job apart. */
+function variant(job: V2WorkflowRunJob): string {
+    const keys = Object.keys(job.matrix ?? {}).sort();
+    return keys.length === 0 ? '' : keys.map(k => `${k}=${job.matrix[k]}`).join(', ');
+}
+
+function jobLabel(job: V2WorkflowRunJob): string {
+    const v = variant(job);
+    return v ? `${job.job_id} (${v})` : job.job_id;
+}
+
+/**
+ * Turns a workflow run into what the timeline draws.
+ *
+ * Every job holds one lane, split into the phases it went through: the wait in the queue — which for
+ * a job behind a gate can last days — the time a hatchery spent starting a worker, and the run
+ * itself. The results of the job are pinned on that lane at the moment they were created, and its
+ * steps and results become lanes of their own under it.
+ */
+export function buildRunTimeline(
+    run: V2WorkflowRun,
+    jobs: Array<V2WorkflowRunJob>,
+    results: Array<WorkflowRunResult>,
+    infos: Array<WorkflowRunInfo> = [],
+    runAttempt?: number
+): RunTimelineBuild {
+    const targets: { [key: string]: RunTimelineTarget } = {};
+    const criticalPath = computeCriticalPath(run, jobs ?? []);
+    const start = timelineStart(run, runAttempt);
+
+    const resultsByJob = new Map<string, Array<WorkflowRunResult>>();
+    const orphanResults: Array<WorkflowRunResult> = [];
+    (results ?? []).forEach(result => {
+        if (toMs(result.issued_at) === null) {
+            return;
+        }
+        const jobID = result.workflow_run_job_id;
+        if (!jobID || !(jobs ?? []).some(j => j.id === jobID)) {
+            orphanResults.push(result);
+            return;
+        }
+        if (!resultsByJob.has(jobID)) {
+            resultsByJob.set(jobID, []);
+        }
+        resultsByJob.get(jobID).push(result);
+    });
+
+    const lanes = (jobs ?? [])
+        .map(job => buildJobLane(run, job, resultsByJob.get(job.id) ?? [], criticalPath, targets))
+        .filter(entry => !!entry)
+        .sort((a, b) => a.at - b.at || a.lane.label.localeCompare(b.lane.label));
+
+    // Stages are drawn in the order they were reached, which is also the order they read in.
+    const stages = new Map<string, { label: string, at: number, lanes: Array<TimelineLane> }>();
+    lanes.forEach(entry => {
+        const stage = entry.stage || NO_STAGE;
+        if (!stages.has(stage)) {
+            stages.set(stage, { label: stage === NO_STAGE ? null : stage, at: entry.at, lanes: [] });
+        }
+        stages.get(stage).lanes.push(entry.lane);
+    });
+
+    const named = Array.from(stages.entries()).filter(([key]) => key !== NO_STAGE);
+    const sections: Array<TimelineSection> = Array.from(stages.entries())
+        .sort((a, b) => a[1].at - b[1].at)
+        .map(([key, stage]) => <TimelineSection>{
+            id: `stage-${key}`,
+            // A run without stages needs no heading; one with stages must not leave the rest unlabelled.
+            label: stage.label ?? (named.length > 0 ? 'Jobs' : null),
+            lanes: stage.lanes
+        });
+
+    if (orphanResults.length > 0) {
+        sections.push({
+            id: 'results',
+            label: 'Results',
+            lanes: orphanResults.map(result => buildResultLane(result, targets))
+        });
+    }
+
+    // What set off what is being shown: the hook that started the run where the axis begins with the run,
+    // and otherwise the restart that began this attempt, at the head of what it restarted. A mark left at
+    // the start of the run on a later attempt would pull the axis back days — see `timelineStart`.
+    const trigger = start !== undefined
+        ? triggerMarker(run, targets)
+        : restartMarker(run, runAttempt ?? run?.run_attempt, lanes.map(entry => entry.at));
+    // It goes on a lane of the run itself, in a section of its own above every other: the run belongs to
+    // no stage, and putting its lane in the first one said that it was part of it.
+    const runLane = buildRunLane(run, infos, targets, trigger);
+    if (runLane) {
+        sections.unshift({ id: 'run', lanes: [runLane] });
+    }
+
+    return {
+        data: {
+            sections,
+            start
+        },
+        targets,
+        criticalPath,
+        jobCount: lanes.length
+    };
+}
+
+/**
+ * Where the axis begins.
+ *
+ * On a first attempt this is the start of the run, so that the crafting that happens before any job is
+ * queued is part of what the timeline shows. A restart does not move that date — it only bumps the
+ * attempt — so on a later attempt it would sit hours or days before anything of that attempt happened,
+ * and the whole timeline would open on a fold. There, the jobs speak for themselves.
+ */
+function timelineStart(run: V2WorkflowRun, runAttempt?: number): number {
+    const attempt = runAttempt ?? run?.run_attempt ?? 1;
+    return attempt > 1 ? undefined : (toMs(run?.started) ?? undefined);
+}
+
+function buildJobLane(
+    run: V2WorkflowRun,
+    job: V2WorkflowRunJob,
+    jobResults: Array<WorkflowRunResult>,
+    criticalPath: Array<string>,
+    targets: { [key: string]: RunTimelineTarget }
+): { at: number, stage: string, lane: TimelineLane } {
+    const queued = toMs(job.queued);
+    const scheduled = toMs(job.scheduled);
+    const started = toMs(job.started);
+    const ended = toMs(job.ended);
+
+    // A job that never reached the queue has nothing to show on a time axis.
+    const at = queued ?? scheduled ?? started;
+    if (at === null) {
+        return null;
+    }
+
+    const laneID = `job-${job.id}`;
+    targets[laneID] = { type: 'job', id: job.id };
+
+    const segments: Array<TimelineSegment> = [];
+    const blocked = job.status === V2WorkflowRunJobStatus.Blocked;
+    const waitEnd = scheduled ?? started ?? (isTerminated(job.status) ? ended : null);
+    // The phases of a job are one job: grouped, they are drawn as a single thing, so the timeline can
+    // neither fold between them nor lose the pointer as it goes from one to the next.
+    const group = laneID;
+    if (queued !== null) {
+        segments.push({
+            id: `${laneID}-queued`,
+            group,
+            start: queued,
+            end: waitEnd,
+            // A job held by a gate or a concurrency rule waits in the queue like any other, but for a
+            // reason worth naming: that wait is the one that can last days.
+            kind: blocked ? 'blocked' : 'queued',
+            label: blocked ? 'Blocked' : 'Queued',
+            // Nothing is being spent on the job while it waits, so the axis is free to fold that
+            // wait — which is the only way a gate held for days can be drawn alongside the rest.
+            idle: true
+        });
+    }
+    if (scheduled !== null) {
+        segments.push({
+            id: `${laneID}-scheduling`,
+            group,
+            start: scheduled,
+            end: started ?? (isTerminated(job.status) ? ended : null),
+            kind: 'scheduling',
+            label: 'Scheduling'
+        });
+    }
+    if (started !== null) {
+        segments.push({
+            id: `${laneID}-running`,
+            group,
+            start: started,
+            end: ended,
+            kind: `running-${(job.status ?? '').toLowerCase()}`,
+            label: 'Running'
+        });
+    }
+
+    const markers: Array<TimelineMarker> = [];
+    const gate = gateMarker(run, job, at);
+    if (gate) {
+        markers.push(gate);
+    }
+    markers.push(...jobResults.map(result => {
+        const markerID = `result-${result.id}`;
+        targets[markerID] = { type: 'result', id: result.id };
+        return resultMarker(markerID, result);
+    }));
+
+    /**
+     * A result says which job made it, never which step. But it is created by the step that is running at
+     * the time, and both timestamps come off the same worker, so the step whose run covers the moment the
+     * result was created is the step that created it. Results whose moment matches no step — there should
+     * be none, but a result created between two steps would be one — keep a lane of their own below.
+     */
+    const stepOf = (result: WorkflowRunResult): string => {
+        const at = toMs(result.issued_at);
+        const match = Object.entries(job.steps_status ?? {}).find(([, status]) => {
+            const from = toMs(status.started);
+            const to = toMs(status.ended);
+            return from !== null && at >= from && (to === null || at <= to);
+        });
+        return match ? match[0] : null;
+    };
+    const resultsByStep = new Map<string, Array<WorkflowRunResult>>();
+    const looseResults: Array<WorkflowRunResult> = [];
+    jobResults.forEach(result => {
+        const step = stepOf(result);
+        if (!step) {
+            looseResults.push(result);
+            return;
+        }
+        if (!resultsByStep.has(step)) {
+            resultsByStep.set(step, []);
+        }
+        resultsByStep.get(step).push(result);
+    });
+
+    const steps: Array<TimelineLane> = Object.entries(job.steps_status ?? {})
+        .map(([name, status]) => ({ name, status, at: toMs(status.started) }))
+        .filter(step => step.at !== null)
+        .sort((a, b) => a.at - b.at)
+        .map(step => <TimelineLane>{
+            id: `${laneID}-step-${step.name}`,
+            label: step.name,
+            status: (step.status.conclusion ?? '').toLowerCase(),
+            segments: [{
+                id: `${laneID}-step-${step.name}-run`,
+                start: step.at,
+                end: toMs(step.status.ended),
+                kind: `step-${(step.status.conclusion ?? 'running').toLowerCase()}`,
+                label: step.name
+            }],
+            // Pinned on the step that made them, so unfolding a job says which of its steps produced what.
+            markers: (resultsByStep.get(step.name) ?? []).map(result => {
+                const markerID = `result-${result.id}-step`;
+                targets[markerID] = { type: 'result', id: result.id };
+                return resultMarker(markerID, result);
+            })
+        });
+
+    // The dates the graph used to show on hovering a node. Only the dates: the status is in the colour
+    // of the bars, and how long each phase took is already the breakdown above them.
+    const details: Array<TimelineDetail> = [
+        { label: 'Queued', at: queued },
+        { label: 'Scheduled', at: scheduled },
+        { label: 'Started', at: started },
+        { label: 'Ended', at: ended }
+    ].filter(entry => entry.at !== null)
+        .map(entry => ({ label: `${entry.label}:`, value: new Date(entry.at).toLocaleString() }));
+    if (job.retry > 0) {
+        details.push({ label: 'Retry:', value: `${job.retry}` });
+    }
+
+    return {
+        at,
+        stage: job.job?.stage,
+        lane: {
+            id: laneID,
+            label: jobLabel(job),
+            // No second line under the name: the status is in the colour of the bars, and a bare
+            // duration there raised more questions than it answered. Both are in the hover card, where
+            // there is room to say what they are.
+            details,
+            status: (job.status ?? '').toLowerCase(),
+            segments,
+            markers,
+            // Results sit on the step that made them. Only the ones no step accounts for get a lane, so
+            // that nothing is ever dropped for want of a step to hang it on.
+            lanes: steps.concat(looseResults.map(result => buildResultLane(result, targets))),
+            highlighted: criticalPath.indexOf(job.id) !== -1,
+            activatable: true
+        }
+    };
+}
+
+/**
+ * The lane of the run itself: what set it off, and what it logged as an error. Neither is about any one
+ * job — a run info carries no job of its own — and both are instants, so the lane has markers and no bars.
+ *
+ * Warnings and plain infos are left out on purpose: they are the ordinary chatter of a run, and a mark for
+ * each of them would bury the one kind worth stopping at. The Info tab still has all of them.
+ */
+function buildRunLane(
+    run: V2WorkflowRun,
+    infos: Array<WorkflowRunInfo>,
+    targets: { [key: string]: RunTimelineTarget },
+    trigger: TimelineMarker
+): TimelineLane {
+    const errors = (infos ?? [])
+        .filter(info => info.level === 'error' && toMs(info.issued_at) !== null)
+        .sort((a, b) => toMs(a.issued_at) - toMs(b.issued_at));
+
+    const markers: Array<TimelineMarker> = [];
+    if (trigger) {
+        markers.push(trigger);
+    }
+    errors.forEach(info => {
+        const markerID = `info-${info.id}`;
+        targets[markerID] = { type: 'info', id: info.id };
+        markers.push(<TimelineMarker>{
+            id: markerID,
+            at: toMs(info.issued_at),
+            kind: 'error',
+            icon: 'close-circle',
+            // The message is the whole of it, so it is the heading rather than a line of detail.
+            label: info.message,
+            plural: 'errors',
+            details: [{ label: 'Logged:', value: new Date(toMs(info.issued_at)).toLocaleString() }]
+        });
+    });
+    if (markers.length === 0) {
+        return null;
+    }
+
+    return {
+        id: 'run',
+        // Not the name of the workflow, which reads like the name of a job. This lane is the run.
+        label: 'Run',
+        sublabel: errors.length > 0 ? `${errors.length} error${errors.length > 1 ? 's' : ''}` : null,
+        status: errors.length > 0 ? 'error' : 'run',
+        segments: [],
+        markers
+    };
+}
+
+/** What set the run off, at the moment it started. */
+function triggerMarker(run: V2WorkflowRun, targets: { [key: string]: RunTimelineTarget }): TimelineMarker {
+    const at = toMs(run?.started);
+    if (at === null) {
+        return null;
+    }
+
+    const event = run?.event;
+    const name = event?.event_name ?? '';
+    const markerID = 'run-trigger';
+    // The hook panel is opened the way the graph opens it, by the name of the hook that fired.
+    targets[markerID] = { type: 'hook', id: name };
+
+    const details: Array<TimelineDetail> = [];
+    if (event?.hook_type) {
+        details.push({ label: 'Hook:', value: hookLabel(event.hook_type) });
+    }
+    if (run?.username) {
+        details.push({ label: 'By:', value: run.username });
+    }
+    if (event?.ref) {
+        details.push({ label: 'Ref:', value: shortRef(event.ref) });
+    }
+    if (event?.sha) {
+        details.push({ label: 'Commit:', value: event.sha.substring(0, 8) });
+    }
+    if (event?.entity_updated) {
+        details.push({ label: 'Updated:', value: event.entity_updated });
+    }
+    details.push({ label: 'Started:', value: new Date(at).toLocaleString() });
+
+    return {
+        id: markerID,
+        at,
+        kind: 'trigger',
+        icon: triggerIcon(name),
+        label: triggerLabel(name),
+        details
+    };
+}
+
+/**
+ * What set a later attempt off: someone asking for jobs to be run again. It sits at the head of what was
+ * restarted, which is where the axis of that attempt begins.
+ *
+ * Nothing opens from it — there is no panel for a restart — so like a gate it is a mark to hover. Who
+ * asked, and for what, is on the run: the API records one event per job asked for, stamped with the
+ * attempt it created.
+ */
+function restartMarker(run: V2WorkflowRun, attempt: number, laneStarts: Array<number>): TimelineMarker {
+    const at = Math.min(...laneStarts.filter(value => value !== null && isFinite(value)));
+    if (!isFinite(at)) {
+        return null;
+    }
+
+    const asked = (run?.job_events ?? []).filter(event => event.run_attempt === attempt);
+    const by = asked.map(event => event.username).filter(name => !!name);
+    const jobs = asked.map(event => event.job_id).filter(id => !!id);
+
+    const details: Array<TimelineDetail> = [];
+    if (jobs.length > 0) {
+        details.push({ label: jobs.length > 1 ? 'Jobs:' : 'Job:', value: [...new Set(jobs)].join(', ') });
+    }
+    details.push({ label: 'Attempt:', value: `${attempt}` });
+    details.push({ label: 'Started:', value: new Date(at).toLocaleString() });
+
+    return {
+        id: 'run-restart',
+        at,
+        kind: 'trigger',
+        icon: 'redo',
+        label: by.length > 0 ? `Restarted by ${by[0]}` : 'Restarted',
+        details
+    };
+}
+
+/** How the run came to be, as it reads to someone who did not start it. */
+function triggerLabel(eventName: string): string {
+    switch (eventName) {
+        case 'manual': return 'Started by hand';
+        case 'push': return 'Started by a push';
+        case 'pull-request': return 'Started by a pull request';
+        case 'pull-request-comment': return 'Started by a comment on a pull request';
+        case 'webhook': return 'Started by a web hook';
+        case 'scheduler': return 'Started by the scheduler';
+        case 'workflow-run': return 'Started by another run';
+        case 'workflow-update': return 'Started by a change to the workflow';
+        case 'model-update': return 'Started by a change to a worker model';
+        default: return eventName ? `Started by ${eventName}` : 'Run started';
+    }
+}
+
+/** The kind of hook behind the event, as the API names it. */
+function hookLabel(hookType: string): string {
+    switch (hookType) {
+        case 'RepositoryWebHook': return 'Repository web hook';
+        case 'WorkerModelUpdate': return 'Worker model update';
+        case 'WorkflowUpdate': return 'Workflow update';
+        case 'WorkflowRun': return 'Workflow run';
+        case 'Webhook': return 'Web hook';
+        default: return hookType;
+    }
+}
+
+function triggerIcon(eventName: string): string {
+    switch (eventName) {
+        case 'manual': return 'user';
+        case 'push':
+        case 'pull-request':
+        case 'pull-request-comment':
+            return 'branches';
+        case 'scheduler': return 'clock-circle';
+        case 'webhook': return 'global';
+        case 'workflow-run': return 'appstore';
+        case 'workflow-update':
+        case 'model-update':
+            return 'sync';
+        default: return 'thunderbolt';
+    }
+}
+
+function shortRef(ref: string): string {
+    return ref.replace(/^refs\/(heads|tags)\//, '');
+}
+
+function buildResultLane(result: WorkflowRunResult, targets: { [key: string]: RunTimelineTarget }): TimelineLane {
+    const laneID = `result-lane-${result.id}`;
+    targets[laneID] = { type: 'result', id: result.id };
+    return {
+        id: laneID,
+        label: resultLabel(result),
+        sublabel: result.type,
+        details: resultDetails(result),
+        status: 'result',
+        segments: [],
+        markers: [resultMarker(`${laneID}-marker`, result)],
+        activatable: true
+    };
+}
+
+/**
+ * What a result looks like on a lane: an icon saying what kind of thing it is, and enough about it to
+ * tell it from the others without opening it.
+ */
+function resultMarker(id: string, result: WorkflowRunResult): TimelineMarker {
+    return {
+        id,
+        at: toMs(result.issued_at),
+        kind: `result-${result.type}`,
+        icon: resultIcon(result.type),
+        label: resultLabel(result),
+        details: resultDetails(result)
+    };
+}
+
+function resultDetails(result: WorkflowRunResult): Array<TimelineDetail> {
+    // No type: the key already begins with it.
+    const details: Array<TimelineDetail> = [
+        { label: 'Created:', value: new Date(toMs(result.issued_at)).toLocaleString() }
+    ];
+    const name = result.detail?.data?.name;
+    if (name && name !== result.identifier) {
+        details.push({ label: 'File:', value: `${name}` });
+    }
+    const size = result.detail?.data?.size;
+    if (typeof size === 'number' && size > 0) {
+        details.push({ label: 'Size:', value: formatBytes(size) });
+    }
+    return details;
+}
+
+/**
+ * The icon standing for a kind of result. A test report and a Docker image are not the same thing and
+ * should not be the same lozenge; anything unrecognised is a file, which every result ultimately is.
+ */
+function resultIcon(type: WorkflowRunResultType | string): string {
+    switch (type) {
+        case 'tests': return 'experiment';
+        case 'coverage': return 'pie-chart';
+        case 'release': return 'tag';
+        case 'variable': return 'code';
+        case 'docker': return 'container';
+        case 'deployment': return 'rocket';
+        case 'staticFiles': return 'global';
+        case 'helm': return 'build';
+        case 'debian':
+        case 'python':
+        case 'npm':
+        case 'maven':
+        case 'gradle':
+        case 'sbt':
+        case 'nuget':
+        case 'conan':
+        case 'puppet':
+        case 'terraformModule':
+        case 'terraformProvider':
+            return 'inbox';
+        default: return 'file';
+    }
+}
+
+function formatBytes(size: number): string {
+    const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+    let value = size;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    return `${unit === 0 ? value : value.toFixed(1)} ${units[unit]}`;
+}
+
+/**
+ * What a result is called here. `identifier` is what the API calls its name — `generic:binary.tar.gz`,
+ * `tests:unit.xml` — which is what the Results tab lists it under and what someone looking for it in a
+ * log would search for. `label` is a sentence about it instead, and its size and filename are already in
+ * the detail, so the key is what belongs on the timeline.
+ */
+function resultLabel(result: WorkflowRunResult): string {
+    return result.identifier || result.label || result.type;
+}
+
+function isTerminated(status: V2WorkflowRunJobStatus): boolean {
+    switch (status) {
+        case V2WorkflowRunJobStatus.Cancelled:
+        case V2WorkflowRunJobStatus.Fail:
+        case V2WorkflowRunJobStatus.Stopped:
+        case V2WorkflowRunJobStatus.Success:
+        case V2WorkflowRunJobStatus.Skipped:
+            return true;
+    }
+    return false;
+}
+
+/**
+ * The chain of jobs that set the total duration of the run: the last one to end, then whichever of
+ * the jobs it waited on ended last, and so on back to the start. Shortening any other job would not
+ * have made the run shorter.
+ */
+export function computeCriticalPath(run: V2WorkflowRun, jobs: Array<V2WorkflowRunJob>): Array<string> {
+    const workflow = run?.workflow_data?.workflow;
+    // Every job that ran and finished. A skipped job is terminated and carries an end date like any
+    // other — the engine stamps one on whatever it finishes with — but it did no work, and a chain of
+    // the jobs that set the duration of the run has no business claiming one of those set anything.
+    const worked = (jobs ?? []).filter(job => toMs(job.ended) !== null && didWork(job.status));
+    if (!workflow || worked.length === 0) {
+        return [];
+    }
+
+    const endOf = (job: V2WorkflowRunJob) => toMs(job.ended);
+    const latest = (candidates: Array<V2WorkflowRunJob>) =>
+        candidates.reduce((best, job) => endOf(job) > endOf(best) ? job : best, candidates[0]);
+
+    /**
+     * The jobs a job waited on that actually ran. A job it waited on which was skipped did not hold it
+     * up by working, so the chain carries on through whatever *that* one waited on instead, rather than
+     * stopping at it or crediting it.
+     */
+    const workingPredecessors = (jobID: string, guard: Set<string>): Array<V2WorkflowRunJob> => {
+        const found: Array<V2WorkflowRunJob> = [];
+        needsOf(workflow, jobID).forEach(name => {
+            if (guard.has(name)) {
+                return;
+            }
+            guard.add(name);
+            const ran = worked.filter(job => job.job_id === name);
+            if (ran.length > 0) {
+                found.push(...ran);
+                return;
+            }
+            found.push(...workingPredecessors(name, guard));
+        });
+        return found;
+    };
+
+    const path: Array<string> = [];
+    const seen = new Set<string>();
+    let current = latest(worked);
+
+    while (current && !seen.has(current.id)) {
+        seen.add(current.id);
+        path.push(current.id);
+        const predecessors = workingPredecessors(current.job_id, new Set<string>([current.job_id]))
+            .filter(job => !seen.has(job.id));
+        current = predecessors.length > 0 ? latest(predecessors) : null;
+    }
+
+    return path;
+}
+
+/** Whether a job spent time doing something, as opposed to being passed over. */
+function didWork(status: V2WorkflowRunJobStatus): boolean {
+    return status !== V2WorkflowRunJobStatus.Skipped;
+}
+
+/**
+ * The mark at the head of a gated job's lane: what held it, and what was answered to let it through.
+ *
+ * The definition of the gate lives on the workflow, the values it was triggered with on the run job. A
+ * job still waiting has none of the latter, and says so rather than showing an empty list.
+ */
+function gateMarker(run: V2WorkflowRun, job: V2WorkflowRunJob, at: number): TimelineMarker {
+    const name = job.job?.gate;
+    if (!name) {
+        return null;
+    }
+    const definition = run?.workflow_data?.workflow?.gates?.[name];
+    const answered = job.gate_inputs ?? {};
+    const details: Array<TimelineDetail> = Object.keys(answered).sort()
+        .map(key => ({ label: `${key}:`, value: formatGateInput(answered[key]) }));
+
+    if (details.length === 0) {
+        details.push({
+            label: job.status === V2WorkflowRunJobStatus.Blocked ? 'Waiting to be triggered' : 'No inputs',
+            value: ''
+        });
+    }
+    if (definition?.if) {
+        details.push({ label: 'Condition:', value: definition.if });
+    }
+
+    return {
+        id: `gate-${job.id}`,
+        at,
+        kind: 'gate',
+        icon: 'unlock',
+        label: `Gate ${name}`,
+        details
+    };
+}
+
+function formatGateInput(value: any): string {
+    if (value === null || value === undefined || value === '') {
+        return '—';
+    }
+    return typeof value === 'object' ? JSON.stringify(value) : `${value}`;
+}
+
+/** The jobs a job waits on: the ones it needs, plus every job of the stages its stage needs. */
+function needsOf(workflow: any, jobID: string): Array<string> {
+    const definition = workflow?.jobs?.[jobID];
+    if (!definition) {
+        return [];
+    }
+    const needs: Array<string> = [...(definition.needs ?? [])];
+    const stageNeeds: Array<string> = definition.stage ? (workflow.stages?.[definition.stage]?.needs ?? []) : [];
+    if (stageNeeds.length > 0) {
+        Object.keys(workflow.jobs ?? {}).forEach(other => {
+            if (stageNeeds.indexOf(workflow.jobs[other]?.stage) !== -1) {
+                needs.push(other);
+            }
+        });
+    }
+    return needs;
+}

--- a/ui/src/app/views/projectv2/run/run-timeline.component.ts
+++ b/ui/src/app/views/projectv2/run/run-timeline.component.ts
@@ -1,0 +1,105 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, inject, Input, OnChanges, Output } from "@angular/core";
+import { TimelineActivation, TimelineData } from "../../../../../libs/timeline/src/public-api";
+import { V2WorkflowRun, V2WorkflowRunJob, WorkflowRunInfo, WorkflowRunResult } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
+import { buildRunTimeline, RunTimelineTarget } from "./run-timeline.builder";
+
+/**
+ * The run seen as time rather than as structure: how long each job waited, how long it ran and when
+ * it produced what. Everything about drawing time belongs to the timeline component, everything about
+ * what a lane means belongs here.
+ */
+@Component({
+    standalone: false,
+    selector: 'app-run-timeline',
+    templateUrl: './run-timeline.html',
+    styleUrls: ['./run-timeline.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class RunTimelineComponent implements OnChanges {
+    @Input() workflowRun: V2WorkflowRun;
+    @Input() jobs: Array<V2WorkflowRunJob>;
+    @Input() results: Array<WorkflowRunResult>;
+    /** What the run logged. Only its errors are drawn, at the moment each was written. */
+    @Input() infos: Array<WorkflowRunInfo>;
+    @Input() runAttempt: number;
+    /** The run job being pointed at in the graph, so that both views point at the same thing. */
+    @Input() hoveredJobRunID: string;
+    /** The run job whose panel is open. */
+    @Input() selectedJobRunID: string;
+
+    @Output() onSelectJobRun = new EventEmitter<string>();
+    @Output() onSelectResult = new EventEmitter<string>();
+    /** An error of the run was activated: it is written down in full in the Info tab, not in a panel. */
+    @Output() onSelectInfo = new EventEmitter<string>();
+    /** What set the run off was activated, named by the hook that fired. */
+    @Output() onSelectHook = new EventEmitter<string>();
+
+    data: TimelineData;
+    criticalPathEnabled: boolean = false;
+    hasCriticalPath: boolean = false;
+    /** What the toggle is for, or why it is not available on this run. */
+    criticalPathHint: string;
+
+    private targets: { [key: string]: RunTimelineTarget } = {};
+
+    private _cd = inject(ChangeDetectorRef);
+
+    /** The lane of a run job, named the same way the builder names it. */
+    get hoveredLaneID(): string {
+        return this.hoveredJobRunID ? `job-${this.hoveredJobRunID}` : null;
+    }
+
+    get selectedLaneID(): string {
+        return this.selectedJobRunID ? `job-${this.selectedJobRunID}` : null;
+    }
+
+    ngOnChanges(): void {
+        const build = buildRunTimeline(this.workflowRun, this.jobs, this.results, this.infos, this.runAttempt);
+        this.data = build.data;
+        this.targets = build.targets;
+
+        /**
+         * The highlight works by holding back what is *not* on the chain, so it only says something when
+         * something is left out. A chain of one says nothing; so does a chain holding every job of the
+         * run, which is what a workflow that is one job after another comes to.
+         */
+        const onTheChain = build.criticalPath.length;
+        this.criticalPathHint = onTheChain <= 1
+            ? 'No chain to bring out on this run'
+            : onTheChain >= build.jobCount
+                ? 'Every job of this run is on the critical path, so there is nothing to bring out'
+                : 'Highlight the chain of jobs that set the total duration of the run';
+        this.hasCriticalPath = onTheChain > 1 && onTheChain < build.jobCount;
+
+        if (!this.hasCriticalPath) {
+            this.criticalPathEnabled = false;
+        }
+        this._cd.markForCheck();
+    }
+
+    clickToggleCriticalPath(): void {
+        this.criticalPathEnabled = !this.criticalPathEnabled;
+        this._cd.markForCheck();
+    }
+
+    onActivate(activation: TimelineActivation): void {
+        const target = this.targets[activation.markerID ?? activation.laneID];
+        if (!target) {
+            return;
+        }
+        switch (target.type) {
+            case 'job':
+                this.onSelectJobRun.emit(target.id);
+                return;
+            case 'result':
+                this.onSelectResult.emit(target.id);
+                return;
+            case 'info':
+                this.onSelectInfo.emit(target.id);
+                return;
+            case 'hook':
+                this.onSelectHook.emit(target.id);
+                return;
+        }
+    }
+}

--- a/ui/src/app/views/projectv2/run/run-timeline.html
+++ b/ui/src/app/views/projectv2/run/run-timeline.html
@@ -1,0 +1,10 @@
+<app-timeline [data]="data" label="Workflow run timeline" [highlightEnabled]="criticalPathEnabled"
+  [hoveredLaneID]="hoveredLaneID" [selectedLaneID]="selectedLaneID"
+  markersLabel="results" emptyLabel="No job has reached the queue yet" (activate)="onActivate($event)">
+  <button class="critical-path" nz-button nzSize="small" [class.active]="criticalPathEnabled"
+    [disabled]="!hasCriticalPath" (click)="clickToggleCriticalPath()"
+    [attr.aria-pressed]="criticalPathEnabled" aria-label="Highlight the critical path"
+    [title]="criticalPathHint">
+    <span nz-icon nzType="branches" nzTheme="outline" aria-hidden="true"></span>
+  </button>
+</app-timeline>

--- a/ui/src/app/views/projectv2/run/run-timeline.scss
+++ b/ui/src/app/views/projectv2/run/run-timeline.scss
@@ -1,0 +1,280 @@
+@use '../../../../common' as common;
+
+/**
+ * The timeline component draws the shape and leaves every colour to whoever uses it: what a `kind`
+ * means is only known here. The frame is themed through the custom properties it reads, the segments
+ * and the markers through the `data-kind` they carry.
+ */
+
+// The bottom panel is a flex column holding the tabs and then this: take what is left of it, and no more.
+:host {
+  display: block;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/**
+ * The critical path toggle is projected into the timeline's controls, so it is styled here rather than
+ * there: a projected element belongs to this component, and the library's own rules — scoped to its own
+ * template — cannot reach it. On and off read the way the filters of the Results tab do.
+ */
+.critical-path {
+  &.active {
+    color: common.$cds_color_green;
+    border-color: common.$cds_color_green;
+
+    :host-context(.night) & {
+      color: common.$darkTheme_green;
+      border-color: common.$darkTheme_green;
+    }
+  }
+
+  // Clicking with the pointer leaves the button focused, and the button styles the UI ships paint a
+  // focused button exactly like a hovered one — so the control stayed lit whether it was on or not,
+  // which is the one thing it is there to tell you. A keyboard focus still shows, through :focus-visible.
+  &:not(.active):not([disabled]):focus:not(:focus-visible) {
+    color: rgba(0, 0, 0, .85);
+    border-color: #d9d9d9;
+
+    :host-context(.night) & {
+      color: rgba(255, 255, 255, .85);
+      border-color: #434343;
+    }
+  }
+}
+
+app-timeline {
+  display: block;
+  height: 100%;
+
+  ::ng-deep .timeline {
+    --timeline-text: rgba(0, 0, 0, .85);
+    --timeline-muted: rgba(0, 0, 0, .55);
+    --timeline-border: #f0f0f0;
+    --timeline-grid: #f0f0f0;
+    --timeline-leader: rgba(0, 0, 0, .12);
+    --timeline-cap: rgba(0, 0, 0, .09);
+    --timeline-hover: rgba(0, 0, 0, .04);
+    --timeline-fold: rgba(0, 0, 0, .05);
+    // What the axis caps and the marker icons sit on, so they read as opaque over the lanes.
+    --timeline-surface: #ffffff;
+    --timeline-control-border: #d9d9d9;
+    --timeline-now: #{common.$cds_color_teal};
+    --timeline-segment: #{common.$cds_color_light_grey};
+    --timeline-marker: #{common.$polar_grey_0};
+    --timeline-focus: #{common.$polar_grey_0};
+    --timeline-accent: #{common.$cds_color_teal};
+  }
+
+  :host-context(.night) & ::ng-deep .timeline {
+    --timeline-text: #{common.$darkTheme_grey_6};
+    --timeline-muted: #{common.$darkTheme_grey_5};
+    --timeline-border: #303030;
+    --timeline-grid: #303030;
+    --timeline-leader: rgba(255, 255, 255, .18);
+    --timeline-cap: rgba(255, 255, 255, .13);
+    --timeline-hover: rgba(255, 255, 255, .05);
+    --timeline-fold: rgba(255, 255, 255, .05);
+    --timeline-surface: #{common.$darkTheme_grey_1};
+    --timeline-control-border: #434343;
+    --timeline-now: #{common.$darkTheme_light_blue};
+    --timeline-segment: #{common.$darkTheme_night_grey};
+    --timeline-marker: #{common.$darkTheme_grey_5};
+    --timeline-focus: white;
+    --timeline-accent: #{common.$darkTheme_light_blue};
+  }
+
+  ::ng-deep .segment {
+    border: 1px solid transparent;
+    color: common.$polar_grey_1;
+
+    :host-context(.night) & {
+      color: common.$darkTheme_grey_6;
+    }
+
+    // Waiting in the queue: hatched, because no time is being spent on the job itself.
+    &[data-kind='queued'] {
+      background-color: common.$cds_color_light_grey;
+      border-color: common.$polar_grey_3;
+      background-image: repeating-linear-gradient(-45deg,
+          transparent 0 3px,
+          rgba(0, 0, 0, .06) 3px 6px);
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_grey;
+        border-color: common.$darkTheme_grey_4;
+        background-image: repeating-linear-gradient(-45deg,
+            transparent 0 3px,
+            rgba(255, 255, 255, .07) 3px 6px);
+      }
+    }
+
+    // Held by a gate or a concurrency rule: the wait that can last days.
+    &[data-kind='blocked'] {
+      background-color: #ffe0d2;
+      border-color: common.$cds_color_orange;
+      background-image: repeating-linear-gradient(-45deg,
+          transparent 0 3px,
+          rgba(0, 0, 0, .08) 3px 6px);
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_orange;
+        border-color: common.$darkTheme_orange;
+      }
+    }
+
+    // A hatchery starting a worker.
+    &[data-kind='scheduling'] {
+      background-color: common.$cds_color_light_teal;
+      border-color: common.$cds_color_teal;
+      opacity: .75;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_blue;
+        border-color: common.$darkTheme_blue;
+      }
+    }
+
+    &[data-kind^='running'],
+    &[data-kind^='step'] {
+      background-color: common.$cds_color_light_teal;
+      border-color: common.$cds_color_teal;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_blue;
+        border-color: common.$darkTheme_blue;
+      }
+    }
+
+    &[data-kind='running-success'],
+    &[data-kind='step-success'] {
+      background-color: common.$cds_color_light_green;
+      border-color: common.$cds_color_green;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_green;
+        border-color: common.$darkTheme_green;
+      }
+    }
+
+    &[data-kind='running-fail'],
+    &[data-kind='running-stopped'],
+    &[data-kind='step-fail'],
+    &[data-kind='step-failure'] {
+      background-color: common.$cds_color_light_red;
+      border-color: common.$cds_color_red;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_red;
+        border-color: common.$darkTheme_red;
+      }
+    }
+
+    &[data-kind='running-cancelled'],
+    &[data-kind='running-skipped'],
+    &[data-kind='step-skipped'] {
+      background-color: common.$cds_color_light_grey;
+      border-color: common.$polar_grey_3;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_night_grey;
+        border-color: common.$darkTheme_grey_4;
+      }
+    }
+  }
+
+  // What the run logged as an error. The one mark on the timeline worth stopping at, so it is the one
+  // that takes the colour of a failure.
+  ::ng-deep .marker[data-kind='error'] {
+    border-color: common.$cds_color_red;
+    color: common.$cds_color_red;
+
+    :host-context(.night) & {
+      border-color: common.$darkTheme_red;
+      color: common.$darkTheme_red;
+    }
+
+    &::after {
+      background-color: common.$cds_color_red;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_red;
+      }
+    }
+  }
+
+  /**
+   * The lane of the run is not one of its jobs, and a name set like theirs read as one. It is set like
+   * the heading of a section instead, which is what it is: the run, above the jobs it ran. Only this lane
+   * is ever given these two statuses.
+   */
+  ::ng-deep .lane[data-status='run'] .lane-label .name,
+  ::ng-deep .lane[data-status='error'] .lane-label .name {
+    font-size: .8em;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+
+  ::ng-deep .lane[data-status='run'] .lane-label .name {
+    color: var(--timeline-muted);
+  }
+
+  // Red once the run has logged an error, which is the one thing about a run worth interrupting a read for.
+  ::ng-deep .lane[data-status='error'] .lane-label .name {
+    color: common.$cds_color_red;
+
+    :host-context(.night) & {
+      color: common.$darkTheme_red;
+    }
+  }
+
+  // What set the run off. It is about the run and not about anything it produced, so it takes the
+  // colour the view uses for itself rather than one of the statuses.
+  ::ng-deep .marker[data-kind='trigger'] {
+    border-color: common.$cds_color_teal;
+    color: common.$cds_color_teal;
+
+    :host-context(.night) & {
+      border-color: common.$darkTheme_light_blue;
+      color: common.$darkTheme_light_blue;
+    }
+
+    &::after {
+      background-color: common.$cds_color_teal;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_light_blue;
+      }
+    }
+  }
+
+  // A gate is not a thing the job produced but the thing that let it start, so it is set apart from
+  // the results sharing its lane.
+  ::ng-deep .marker[data-kind='gate'] {
+    border-color: common.$cds_color_orange;
+    color: common.$cds_color_orange;
+
+    :host-context(.night) & {
+      border-color: common.$darkTheme_orange;
+      color: common.$darkTheme_orange;
+    }
+
+    &::after {
+      background-color: common.$cds_color_orange;
+
+      :host-context(.night) & {
+        background-color: common.$darkTheme_orange;
+      }
+    }
+  }
+
+  // Every result carries an icon saying what kind of thing it is, so what tells two of them apart is
+  // the shape rather than the colour. They only need to stay legible over whatever bar they sit on,
+  // which is what `--timeline-marker` and `--timeline-surface` above are for.
+
+  ::ng-deep .lane[data-status='result'] .lane-label .name {
+    font-style: italic;
+  }
+}

--- a/ui/src/app/views/projectv2/run/run-timeline.spec.ts
+++ b/ui/src/app/views/projectv2/run/run-timeline.spec.ts
@@ -1,0 +1,683 @@
+import { axisEnds, AXIS_BAND_PX, formatDuration, MARKER_ROOM_PX, shouldFollow, timelineIcon, TimelineLane, TimelineScale, TimelineSection } from "../../../../../libs/timeline/src/public-api";
+import { V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunJobStatus, WorkflowRunInfo, WorkflowRunResult } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
+import { buildRunTimeline, computeCriticalPath } from "./run-timeline.builder";
+
+const MINUTE = 60000;
+const HOUR = 3600000;
+
+/** Two minutes of work two hours apart, which is the shape a gate leaves behind. */
+const BUSY_ACROSS_A_GATE = [
+    { start: 0, end: MINUTE },
+    { start: 2 * HOUR + MINUTE, end: 2 * HOUR + 2 * MINUTE }
+];
+const SPAN_ACROSS_A_GATE = 2 * HOUR + 2 * MINUTE;
+
+describe('TimelineScale', () => {
+    it('leaves time proportional when it is asked not to fold', () => {
+        const scale = TimelineScale.build(0, SPAN_ACROSS_A_GATE, BUSY_ACROSS_A_GATE, { foldGapsLongerThanMs: 0, foldedGapShare: 0.03 });
+
+        expect(scale.folds.length).toBe(0);
+        // The whole of the first job holds less than one percent of the axis.
+        expect(scale.ratio(MINUTE)).toBeCloseTo(MINUTE / SPAN_ACROSS_A_GATE, 5);
+    });
+
+    it('folds an idle stretch so that what ran keeps the axis', () => {
+        const scale = TimelineScale.build(0, SPAN_ACROSS_A_GATE, BUSY_ACROSS_A_GATE, { foldGapsLongerThanMs: MINUTE, foldedGapShare: 0.03 });
+
+        expect(scale.folds.length).toBe(1);
+        expect(TimelineScale.foldLabel(scale.folds[0])).toBe('2h');
+
+        // Two minutes of work and a two hour wait: the work now holds almost all of the axis, and the
+        // fold the little that is left.
+        expect(scale.ratio(MINUTE)).toBeGreaterThan(0.45);
+        expect(scale.ratio(2 * HOUR + MINUTE)).toBeLessThan(0.55);
+        expect(scale.ratio(2 * HOUR + MINUTE) - scale.ratio(MINUTE)).toBeCloseTo(0.03 / 1.03, 3);
+    });
+
+    it('keeps an instant inside an idle stretch out of the fold', () => {
+        const scale = TimelineScale.build(0, SPAN_ACROSS_A_GATE,
+            BUSY_ACROSS_A_GATE.concat([{ start: HOUR, end: HOUR }]),
+            { foldGapsLongerThanMs: MINUTE, foldedGapShare: 0.03 });
+
+        // The wait is now two folds with the instant between them, instead of one fold hiding it.
+        expect(scale.folds.length).toBe(2);
+        expect(scale.ratio(HOUR)).toBeGreaterThan(scale.ratio(MINUTE));
+        expect(scale.ratio(HOUR)).toBeLessThan(scale.ratio(2 * HOUR + MINUTE));
+    });
+
+    it('reads a position back as the date it stands for', () => {
+        const scale = TimelineScale.build(0, SPAN_ACROSS_A_GATE, BUSY_ACROSS_A_GATE, { foldGapsLongerThanMs: MINUTE, foldedGapShare: 0.03 });
+
+        [0, 30000, MINUTE, HOUR, 2 * HOUR + 90000, SPAN_ACROSS_A_GATE].forEach(at => {
+            expect(scale.time(scale.ratio(at))).toBeCloseTo(at, -1);
+        });
+    });
+
+    it('graduates only what is drawn to scale', () => {
+        const scale = TimelineScale.build(0, SPAN_ACROSS_A_GATE, BUSY_ACROSS_A_GATE, { foldGapsLongerThanMs: MINUTE, foldedGapShare: 0.03 });
+
+        const fold = scale.folds[0];
+        scale.ticks(0, 1, 10).forEach(tick => {
+            expect(tick.at >= fold.start && tick.at <= fold.end && tick.at !== fold.start && tick.at !== fold.end)
+                .withContext(`tick at ${tick.at} fell inside the fold`).toBeFalse();
+        });
+    });
+
+    it('places everything at the start when there is no length to speak of', () => {
+        const scale = TimelineScale.build(1000, 1000, [{ start: 1000, end: 1000 }]);
+
+        expect(scale.ratio(1000)).toBe(0);
+        expect(scale.ratio(2000)).toBe(1);
+    });
+});
+
+/**
+ * Room for the ends of an axis is taken out of the *track*, in pixels, and never out of the stretch of
+ * time it covers. Time taken has to be either drawn to scale — where a few pixels of room on a two day
+ * axis is an hour of invented time that then takes the whole view — or folded away, which is the room
+ * being taken straight back.
+ */
+describe('axisEnds', () => {
+    const ends = { trackWidth: 800, lasting: true, markAtStart: false, markAtEnd: false };
+
+    it('keeps the two bands clear and nothing more', () => {
+        expect(axisEnds(ends)).toEqual({ start: AXIS_BAND_PX, end: AXIS_BAND_PX });
+    });
+
+    it('makes room on the side a marker sits on the bound of', () => {
+        // A bar reaching the edge of the axis still reads as a bar; a glyph centred on that edge is half
+        // drawn outside it. So that side keeps more clear, and only that side.
+        expect(axisEnds({ ...ends, markAtStart: true }))
+            .toEqual({ start: AXIS_BAND_PX + MARKER_ROOM_PX, end: AXIS_BAND_PX });
+    });
+
+    it('gives content that never lasted the middle third', () => {
+        // A run that failed before queueing a job is two instants and not one bar: its bounds *are* the
+        // instants, so drawn across the whole track they sit against its two edges with nothing between.
+        const middle = axisEnds({ ...ends, lasting: false });
+
+        expect(middle.start).toBe(middle.end);
+        // A third of what the bands leave, which is the axis being drawn in the middle of what is left.
+        expect(800 - middle.start - middle.end).toBeCloseTo((800 - 2 * AXIS_BAND_PX) / 3, 6);
+    });
+
+    it('leaves the plot a fifth of the track however narrow it gets', () => {
+        const tight = axisEnds({ ...ends, trackWidth: 50, lasting: false, markAtStart: true, markAtEnd: true });
+
+        expect(tight.start + tight.end).toBeCloseTo(40, 6);
+    });
+
+});
+
+describe('timelineIcon', () => {
+    it('draws only the icons the view carries', () => {
+        expect(timelineIcon('experiment')).toBe('experiment');
+    });
+
+    it('draws no icon at all rather than one it was told to go and find', () => {
+        // An unregistered name is not a missing icon: the icon component fetches `assets/<theme>/<name>.svg`
+        // and puts what comes back on the page. A name reaching the view from data — a result type, a file
+        // name — would be a way of choosing a URL to load and render.
+        ['nonsense', '../../../etc/passwd', 'https://elsewhere.example/x', '', null].forEach(name => {
+            expect(timelineIcon(name)).toBeNull();
+        });
+    });
+
+    it('never lets one of the run through the adapter either', () => {
+        const run = <V2WorkflowRun>{ started: '2026-01-01T10:00:00Z', workflow_data: { workflow: <any>{ jobs: {} } } };
+        const nasty = <WorkflowRunResult>{
+            id: 'r1', issued_at: '2026-01-01T10:00:01Z',
+            type: <any>'../../../evil', identifier: 'x', label: 'x'
+        };
+        const lane = buildRunTimeline(run, [], [nasty]).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.markers[0].icon).toBe('file');
+    });
+});
+
+describe('formatDuration', () => {
+    it('keeps the largest unit and the one below it', () => {
+        expect(formatDuration(0)).toBe('<1s');
+        expect(formatDuration(999)).toBe('<1s');
+        expect(formatDuration(30000)).toBe('30s');
+        expect(formatDuration(61000)).toBe('1m 1s');
+        expect(formatDuration(90000)).toBe('1m 30s');
+        expect(formatDuration(2 * HOUR)).toBe('2h');
+        expect(formatDuration(HOUR + MINUTE + 1000)).toBe('1h 1m');
+        expect(formatDuration(86400000)).toBe('1d');
+        expect(formatDuration(2 * 86400000 + 3 * HOUR)).toBe('2d 3h');
+    });
+
+    it('drops what says nothing at the scale it is read at', () => {
+        // Two days and two seconds is two days; the seconds are noise next to the days.
+        expect(formatDuration(2 * 86400000 + 2000)).toBe('2d');
+    });
+});
+
+/**
+ * The run holds a section of its own above the jobs — what set it off, and anything it logged as an
+ * error — so the lanes of the jobs are those of every other section.
+ */
+const jobLanes = (section: TimelineSection): Array<TimelineLane> => section.id === 'run' ? [] : section.lanes;
+const jobSections = (built: ReturnType<typeof buildRunTimeline>): Array<TimelineSection> =>
+    built.data.sections.filter(section => section.id !== 'run');
+const runLane = (built: ReturnType<typeof buildRunTimeline>): TimelineLane =>
+    built.data.sections.find(section => section.id === 'run')?.lanes[0];
+
+function job(overrides: Partial<V2WorkflowRunJob>): V2WorkflowRunJob {
+    return <V2WorkflowRunJob>{
+        status: V2WorkflowRunJobStatus.Success,
+        steps_status: {},
+        ...overrides
+    };
+}
+
+describe('computeCriticalPath', () => {
+    const run = <V2WorkflowRun>{
+        workflow_data: {
+            workflow: <any>{
+                jobs: {
+                    a: {},
+                    b: { needs: ['a'] },
+                    c: { needs: ['a'] },
+                    d: { needs: ['b', 'c'] }
+                }
+            }
+        }
+    };
+
+    it('follows the jobs that set the total duration of the run', () => {
+        const jobs = [
+            job({ id: 'ja', job_id: 'a', ended: '2026-01-01T10:00:10Z' }),
+            job({ id: 'jb', job_id: 'b', ended: '2026-01-01T10:00:50Z' }),
+            job({ id: 'jc', job_id: 'c', ended: '2026-01-01T10:00:30Z' }),
+            job({ id: 'jd', job_id: 'd', ended: '2026-01-01T10:01:00Z' })
+        ];
+
+        // c ended before b, so shortening c would not have made the run any shorter.
+        expect(computeCriticalPath(run, jobs)).toEqual(['jd', 'jb', 'ja']);
+    });
+
+    it('has nothing to follow while no job has ended', () => {
+        expect(computeCriticalPath(run, [job({ id: 'ja', job_id: 'a' })])).toEqual([]);
+    });
+
+    it('says how many jobs it drew, so a chain of all of them can be told apart', () => {
+        // The highlight works by holding back what is not on the chain, so a chain holding every job of
+        // the run — which is what one job after another comes to — has nothing to bring out.
+        const chained = <V2WorkflowRun>{
+            workflow_data: { workflow: <any>{ jobs: { a: {}, b: { needs: ['a'] }, c: { needs: ['b'] } } } }
+        };
+        const at = (s: string) => ({ queued: s, started: s, ended: s });
+        const jobs = [
+            job({ id: 'ja', job_id: 'a', ...at('2026-01-01T10:00:10Z') }),
+            job({ id: 'jb', job_id: 'b', ...at('2026-01-01T10:00:20Z') }),
+            job({ id: 'jc', job_id: 'c', ...at('2026-01-01T10:00:30Z') })
+        ];
+        const built = buildRunTimeline(chained, jobs, []);
+
+        expect(built.criticalPath.length).toBe(3);
+        expect(built.jobCount).toBe(3);
+    });
+});
+
+describe('buildRunTimeline', () => {
+    const run = <V2WorkflowRun>{
+        started: '2026-01-01T10:00:00Z',
+        workflow_data: { workflow: <any>{ jobs: { build: {} } } }
+    };
+
+    const runJob = job({
+        id: 'j1',
+        job_id: 'build',
+        queued: '2026-01-01T10:00:01Z',
+        scheduled: '2026-01-01T10:00:05Z',
+        started: '2026-01-01T10:00:20Z',
+        ended: '2026-01-01T10:01:00Z',
+        steps_status: {
+            checkout: <any>{ conclusion: 'Success', started: '2026-01-01T10:00:21Z', ended: '2026-01-01T10:00:30Z' }
+        }
+    });
+
+    const result = <WorkflowRunResult>{
+        id: 'r1',
+        workflow_run_job_id: 'j1',
+        issued_at: '2026-01-01T10:00:55Z',
+        type: 'generic',
+        label: 'binary.tar.gz'
+    };
+
+    it('splits a job into the phases it went through', () => {
+        const built = buildRunTimeline(run, [runJob], []);
+        const lane = built.data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.segments.map(s => s.kind)).toEqual(['queued', 'scheduling', 'running-success']);
+        expect(lane.segments[0].end - lane.segments[0].start).toBe(4000);
+        expect(lane.segments[1].end - lane.segments[1].start).toBe(15000);
+        expect(lane.segments[2].end - lane.segments[2].start).toBe(40000);
+        // Nothing under the name: a bare duration there said neither what it measured nor of what.
+        expect(lane.sublabel).toBeUndefined();
+        // The axis starts with the run, not with its first job.
+        expect(built.data.start).toBe(Date.parse(run.started));
+    });
+
+    it('makes the phases of a job one group', () => {
+        const lane = buildRunTimeline(run, [runJob], []).data.sections.flatMap(jobLanes)[0];
+
+        // One group, so the bars are drawn as one element: the pointer cannot fall between two phases,
+        // and no fold can open between them.
+        expect([...new Set(lane.segments.map(s => s.group))]).toEqual([lane.id]);
+    });
+
+    it('leaves no gap between the phases of a job', () => {
+        const lane = buildRunTimeline(run, [runJob], []).data.sections.flatMap(jobLanes)[0];
+
+        // Why holding a group together costs nothing here: a job leaving one status takes the next in
+        // the same instant, so there is never a gap inside the group to hold open.
+        const ordered = lane.segments.slice().sort((a, b) => a.start - b.start);
+        ordered.slice(1).forEach((segment, i) => expect(segment.start).toBe(ordered[i].end));
+    });
+
+    it('names the wait of a job held by a gate', () => {
+        const blocked = job({ id: 'j2', job_id: 'build', status: V2WorkflowRunJobStatus.Blocked, queued: '2026-01-01T10:00:01Z' });
+        const lane = buildRunTimeline(run, [blocked], []).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.segments.length).toBe(1);
+        expect(lane.segments[0].kind).toBe('blocked');
+        // Still waiting: the segment is left open so that it grows on screen.
+        expect(lane.segments[0].end).toBeNull();
+    });
+
+    it('marks waiting as idle, so a wait of days can be folded', () => {
+        const built = buildRunTimeline(run, [runJob], []);
+        const lane = built.data.sections.flatMap(jobLanes)[0];
+
+        // Queueing and being blocked are waiting; scheduling a worker and running are not.
+        expect(lane.segments.filter(s => s.idle).map(s => s.kind)).toEqual(['queued']);
+        expect(lane.segments.filter(s => !s.idle).map(s => s.kind)).toEqual(['scheduling', 'running-success']);
+
+        const blocked = job({ id: 'j2', job_id: 'build', status: V2WorkflowRunJobStatus.Blocked, queued: '2026-01-01T10:00:01Z' });
+        expect(buildRunTimeline(run, [blocked], []).data.sections.flatMap(jobLanes)[0].segments[0].idle).toBeTrue();
+    });
+
+    it('folds through a blocked job, whose phases are a group of one', () => {
+        // The rule holding a group together claims what sits *between* its segments, never what is inside
+        // one of them. A job held by a gate is a single segment spanning the whole wait, and folding
+        // through it is the point of the whole thing.
+        const gated = job({ id: 'j2', job_id: 'build', status: V2WorkflowRunJobStatus.Blocked, queued: '2026-01-01T10:00:00Z' });
+        const lane = buildRunTimeline(run, [gated], []).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.segments.length).toBe(1);
+        const wait = 2 * 24 * HOUR;
+        const scale = TimelineScale.build(lane.segments[0].start, lane.segments[0].start + wait, []);
+        expect(scale.folds.length).toBe(1);
+    });
+
+    it('folds the wait of a gate without folding the jobs around it', () => {
+        // One job before the gate, one after it two days later, and the gated job waiting in between.
+        const before = job({
+            id: 'j1', job_id: 'build',
+            queued: '2026-01-01T10:00:00Z', scheduled: '2026-01-01T10:00:05Z',
+            started: '2026-01-01T10:00:10Z', ended: '2026-01-01T10:01:00Z'
+        });
+        const gated = job({
+            id: 'j2', job_id: 'deploy', status: V2WorkflowRunJobStatus.Blocked,
+            queued: '2026-01-01T10:01:00Z'
+        });
+        const after = job({
+            id: 'j3', job_id: 'notify',
+            queued: '2026-01-03T10:01:00Z', scheduled: '2026-01-03T10:01:02Z',
+            started: '2026-01-03T10:01:05Z', ended: '2026-01-03T10:02:00Z'
+        });
+
+        const built = buildRunTimeline(run, [before, gated, after], []);
+        const busy = built.data.sections
+            .reduce((all, section) => all.concat(section.lanes), [])
+            .reduce((all, lane) => all.concat(lane.segments.filter(s => !s.idle)), [])
+            .map(s => ({ start: s.start, end: s.end }));
+
+        const from = Date.parse('2026-01-01T10:00:00Z');
+        const to = Date.parse('2026-01-03T10:02:00Z');
+        const scale = TimelineScale.build(from, to, busy);
+
+        // Two days of waiting, two minutes of work: the work must still own most of the axis.
+        expect(scale.folds.length).toBe(1);
+        expect(TimelineScale.foldLabel(scale.folds[0])).toBe('2d');
+        expect(scale.ratio(Date.parse('2026-01-01T10:01:00Z'))).toBeGreaterThan(0.4);
+    });
+
+    it('gives each kind of result the icon that says what it is', () => {
+        const of = (type: string) => <WorkflowRunResult>{
+            id: `r-${type}`, workflow_run_job_id: 'j1', issued_at: '2026-01-01T10:00:55Z', type, label: type
+        };
+        const kinds = ['generic', 'tests', 'coverage', 'docker', 'npm', 'somethingNobodyHasSeenYet'];
+        const lane = buildRunTimeline(run, [runJob], kinds.map(of)).data.sections.flatMap(jobLanes)[0];
+
+        // The shape tells two results apart, so the colour no longer has to.
+        expect(lane.markers.map(m => m.icon)).toEqual(['file', 'experiment', 'pie-chart', 'container', 'inbox', 'file']);
+    });
+
+    it('calls a result by its key rather than by a sentence about it', () => {
+        const sized = <WorkflowRunResult>{
+            ...result,
+            identifier: 'generic:binary.tar.gz',
+            label: 'Filename: binary.tar.gz - Size: 2.0 kB',
+            detail: <any>{ data: { name: 'binary.tar.gz', size: 2048 } }
+        };
+        const lane = buildRunTimeline(run, [runJob], [sized]).data.sections.flatMap(jobLanes)[0];
+
+        // The key is what the Results tab lists it under and what someone would search a log for.
+        expect(lane.markers[0].label).toBe('generic:binary.tar.gz');
+        // No type row: the key begins with it.
+        expect(lane.markers[0].details.map(d => d.label)).toEqual(['Created:', 'File:', 'Size:']);
+        expect(lane.markers[0].details[2].value).toBe('2.0 kB');
+    });
+
+    it('pins a result on the step that was running when it was made', () => {
+        // A result says which job made it, never which step — but both timestamps come off the same
+        // worker, so the step covering the moment it was created is the step that created it.
+        const job3 = job({
+            ...runJob,
+            steps_status: {
+                checkout: <any>{ conclusion: 'Success', started: '2026-01-01T10:00:21Z', ended: '2026-01-01T10:00:30Z' },
+                upload: <any>{ conclusion: 'Success', started: '2026-01-01T10:00:45Z', ended: '2026-01-01T10:00:58Z' }
+            }
+        });
+        const built = buildRunTimeline(run, [job3], [result]);
+        const lane = built.data.sections.flatMap(jobLanes)[0];
+
+        // issued_at is 10:00:55, inside `upload`.
+        expect(lane.lanes.map(l => l.label)).toEqual(['checkout', 'upload']);
+        expect(lane.lanes[0].markers ?? []).toEqual([]);
+        expect(lane.lanes[1].markers.length).toBe(1);
+        expect(built.targets[lane.lanes[1].markers[0].id]).toEqual({ type: 'result', id: 'r1' });
+    });
+
+
+    it('pins a result on its job, and keeps a lane for one no step accounts for', () => {
+        const built = buildRunTimeline(run, [runJob], [result]);
+        const lane = built.data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.markers.length).toBe(1);
+        expect(lane.markers[0].at).toBe(Date.parse(result.issued_at));
+        expect(built.targets[lane.markers[0].id]).toEqual({ type: 'result', id: 'r1' });
+
+        // The only step of this job ran 10:00:21 → 10:00:30 and the result was made at 10:00:55, so no
+        // step accounts for it and it falls back to a lane of its own rather than being dropped.
+        expect(lane.lanes.map(l => l.label)).toEqual(['checkout', 'binary.tar.gz']);
+        expect(built.targets[lane.lanes[1].id]).toEqual({ type: 'result', id: 'r1' });
+        expect(built.targets[lane.id]).toEqual({ type: 'job', id: 'j1' });
+    });
+
+    it('carries the dates the graph no longer shows, and nothing the view already says', () => {
+        const retried = job({ ...runJob, retry: 2, worker_name: 'w-1', region: 'default' });
+        const lane = buildRunTimeline(run, [retried], []).data.sections.flatMap(jobLanes)[0];
+
+        // No status, no wall clock, no worker, no region: the first two are already in the colours and
+        // the breakdown, and the last two are on the job panel.
+        expect(lane.details.map(d => d.label)).toEqual(['Queued:', 'Scheduled:', 'Started:', 'Ended:', 'Retry:']);
+        expect(lane.details.find(d => d.label === 'Retry:').value).toBe('2');
+    });
+
+    it('leaves the dates it was not given out of the detail', () => {
+        const blocked = job({ id: 'j2', job_id: 'build', status: V2WorkflowRunJobStatus.Blocked, queued: '2026-01-01T10:00:01Z' });
+        const lane = buildRunTimeline(run, [blocked], []).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.details.map(d => d.label)).toEqual(['Queued:']);
+    });
+
+    it('starts the axis with the run on a first attempt', () => {
+        expect(buildRunTimeline(run, [runJob], [], [], 1).data.start).toBe(Date.parse(run.started));
+    });
+
+    it('starts the axis with the jobs on a later attempt', () => {
+        // A restart does not move the start of the run, so keeping it would open the timeline on a fold
+        // spanning everything since the first attempt.
+        expect(buildRunTimeline(run, [runJob], [], [], 2).data.start).toBeUndefined();
+    });
+
+    it('leaves out a job that never reached the queue', () => {
+        const built = buildRunTimeline(run, [job({ id: 'j3', job_id: 'build', status: V2WorkflowRunJobStatus.Skipped })], []);
+
+        // Nothing but the section of the run, which is there as soon as the run started.
+        expect(built.data.sections.flatMap(jobLanes).length).toBe(0);
+        expect(built.jobCount).toBe(0);
+    });
+
+    it('groups the jobs under their stage, in the order they were reached', () => {
+        const first = job({ id: 'j1', job_id: 'build', queued: '2026-01-01T10:00:01Z', job: <any>{ stage: 'build' } });
+        const second = job({ id: 'j2', job_id: 'deploy', queued: '2026-01-01T10:05:00Z', job: <any>{ stage: 'deploy' } });
+        const built = buildRunTimeline(run, [second, first], []);
+
+        // The run keeps a section of its own before them: it belongs to no stage, and putting its lane in
+        // the first one said that it was part of it.
+        expect(built.data.sections.map(s => s.id)[0]).toBe('run');
+        expect(jobSections(built).map(s => s.label)).toEqual(['build', 'deploy']);
+    });
+});
+
+describe('gates', () => {
+    const run = <V2WorkflowRun>{
+        started: '2026-01-01T10:00:00Z',
+        workflow_data: {
+            workflow: <any>{
+                jobs: { deploy: { gate: 'manual' } },
+                gates: { manual: { if: '${{ gate.manual }}', inputs: { version: { type: 'string' } } } }
+            }
+        }
+    };
+
+    it('marks the gate at the head of the job it held, with what was answered', () => {
+        const triggered = job({
+            id: 'j1', job_id: 'deploy', job: <any>{ gate: 'manual' },
+            gate_inputs: { version: '1.4.2', force: true },
+            queued: '2026-01-01T10:00:01Z', started: '2026-01-01T10:00:10Z', ended: '2026-01-01T10:00:40Z'
+        });
+        const lane = buildRunTimeline(run, [triggered], []).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.markers.map(m => m.kind)).toEqual(['gate']);
+        expect(lane.markers[0].at).toBe(Date.parse(triggered.queued));
+        expect(lane.markers[0].label).toBe('Gate manual');
+        // The values used are on the run job, the condition on the workflow.
+        expect(lane.markers[0].details.map(d => `${d.label} ${d.value}`))
+            .toEqual(['force: true', 'version: 1.4.2', 'Condition: ${{ gate.manual }}']);
+    });
+
+    it('says so when the gate has not been answered yet', () => {
+        const waiting = job({
+            id: 'j2', job_id: 'deploy', status: V2WorkflowRunJobStatus.Blocked,
+            job: <any>{ gate: 'manual' }, queued: '2026-01-01T10:00:01Z'
+        });
+        const lane = buildRunTimeline(run, [waiting], []).data.sections.flatMap(jobLanes)[0];
+
+        expect(lane.markers[0].details[0].label).toBe('Waiting to be triggered');
+    });
+});
+
+describe('the chain of work', () => {
+    // A skipped job is terminated and carries an end date like any other, but it did no work — so it has
+    // no business being presented as having set the duration of anything.
+    const chained = <V2WorkflowRun>{
+        workflow_data: { workflow: <any>{ jobs: { a: {}, b: { needs: ['a'] }, c: { needs: ['b'] } } } }
+    };
+
+    it('steps over a skipped job to reach what did the work behind it', () => {
+        const jobs = [
+            job({ id: 'ja', job_id: 'a', ended: '2026-01-01T10:00:10Z' }),
+            job({ id: 'jb', job_id: 'b', status: V2WorkflowRunJobStatus.Skipped, ended: '2026-01-01T10:00:11Z' }),
+            job({ id: 'jc', job_id: 'c', ended: '2026-01-01T10:00:30Z' })
+        ];
+
+        expect(computeCriticalPath(chained, jobs)).toEqual(['jc', 'ja']);
+    });
+
+    it('never lets a skipped job head the chain, even when it ends last', () => {
+        const jobs = [
+            job({ id: 'ja', job_id: 'a', ended: '2026-01-01T10:00:10Z' }),
+            job({ id: 'jb', job_id: 'b', status: V2WorkflowRunJobStatus.Skipped, ended: '2026-01-01T10:05:00Z' })
+        ];
+
+        expect(computeCriticalPath(chained, jobs)).toEqual(['ja']);
+    });
+});
+
+describe('run errors on the timeline', () => {
+    const run = <V2WorkflowRun>{
+        started: '2026-01-01T10:00:00Z',
+        workflow_name: 'build-and-deploy',
+        workflow_data: { workflow: <any>{ jobs: { build: {} } } }
+    };
+    const runJob = job({
+        id: 'j1', job_id: 'build', status: V2WorkflowRunJobStatus.Fail,
+        queued: '2026-01-01T10:00:05Z', started: '2026-01-01T10:00:10Z', ended: '2026-01-01T10:00:40Z'
+    });
+    const infos = <Array<WorkflowRunInfo>>[
+        { id: 'i1', issued_at: '2026-01-01T10:00:02Z', level: 'info', message: 'Workflow crafted' },
+        { id: 'i2', issued_at: '2026-01-01T10:00:41Z', level: 'error', message: 'job build failed: exit status 1' },
+        { id: 'i3', issued_at: '2026-01-01T10:00:42Z', level: 'warning', message: 'deprecated syntax' }
+    ];
+
+    it('marks what the run logged as an error, on a lane of the run itself', () => {
+        const built = buildRunTimeline(run, [runJob], [], infos);
+
+        // A run info belongs to the run and names no job, so it cannot go on a job's lane. The lane it
+        // goes on is named for what it is rather than after the workflow, which read as a job name.
+        expect(built.data.sections.map(s => s.lanes.map(l => l.label))).toEqual([['Run'], ['build']]);
+        expect(runLane(built).sublabel).toBe('1 error');
+        const error = runLane(built).markers.filter(m => m.kind === 'error');
+        expect(error.map(m => m.label)).toEqual(['job build failed: exit status 1']);
+        expect(error[0].at).toBe(Date.parse(infos[1].issued_at));
+        // The Info tab holds the full text, so that is where activating it goes.
+        expect(built.targets[error[0].id]).toEqual({ type: 'info', id: 'i2' });
+        // The lane of the run is not one of its jobs.
+        expect(built.jobCount).toBe(1);
+    });
+
+    it('leaves the ordinary chatter of a run out of it', () => {
+        // Warnings and infos are the everyday noise; a mark for each would bury the one worth stopping at.
+        const built = buildRunTimeline(run, [runJob], [], [infos[0], infos[2]]);
+
+        // The lane of the run is still there, holding what set it off and nothing else.
+        expect(runLane(built).markers.map(m => m.kind)).toEqual(['trigger']);
+        expect(runLane(built).sublabel).toBeNull();
+    });
+
+    it('still shows the error of a run that queued no job at all', () => {
+        // The run that failed while being crafted has nothing else to show, and is the one this matters for.
+        const built = buildRunTimeline(run, [], [], [infos[1]]);
+
+        expect(built.data.sections.length).toBe(1);
+        expect(built.data.sections[0].id).toBe('run');
+        // Two instants and not one bar, which is all such a run ever has: what started it and what
+        // stopped it.
+        expect(runLane(built).markers.map(m => m.kind)).toEqual(['trigger', 'error']);
+        expect(built.jobCount).toBe(0);
+    });
+
+    it('gives errors their own word for when several are drawn as one', () => {
+        const many = Array.from({ length: 3 }, (_, i) => <WorkflowRunInfo>{
+            id: `e${i}`, issued_at: '2026-01-01T10:00:41Z', level: 'error', message: `failure ${i}`
+        });
+        const lane = runLane(buildRunTimeline(run, [runJob], [], many));
+
+        // Without this a cluster of them would read "3 results", the word this timeline uses in general.
+        expect([...new Set(lane.markers.filter(m => m.kind === 'error').map(m => m.plural))]).toEqual(['errors']);
+        expect(lane.sublabel).toBe('3 errors');
+    });
+});
+
+describe('what set the run off', () => {
+    const pushed = <V2WorkflowRun>{
+        started: '2026-01-01T10:00:00Z',
+        workflow_name: 'build-and-deploy',
+        username: 'someone',
+        event: <any>{
+            event_name: 'push', hook_type: 'RepositoryWebHook',
+            ref: 'refs/heads/main', sha: '0123456789abcdef'
+        },
+        workflow_data: { workflow: <any>{ jobs: { build: {} } } }
+    };
+
+    it('marks the hook that fired, at the moment the run started', () => {
+        const built = buildRunTimeline(pushed, [], []);
+        const marker = runLane(built).markers[0];
+
+        expect(marker.at).toBe(Date.parse(pushed.started));
+        expect(marker.kind).toBe('trigger');
+        expect(marker.label).toBe('Started by a push');
+        // A branch reads as a branch, and eight characters of a sha are enough to recognise it.
+        expect(marker.details.map(d => `${d.label} ${d.value}`.trim()).slice(0, 4))
+            .toEqual(['Hook: Repository web hook', 'By: someone', 'Ref: main', 'Commit: 01234567']);
+        // Activating it opens the hook panel, which is where the whole event is written out.
+        expect(built.targets[marker.id]).toEqual({ type: 'hook', id: 'push' });
+    });
+
+    it('tells the kinds of trigger apart by their icon', () => {
+        const iconOf = (event_name: string) => {
+            const built = buildRunTimeline(<V2WorkflowRun>{ ...pushed, event: <any>{ event_name } }, [], []);
+            return runLane(built).markers[0].icon;
+        };
+
+        expect(['manual', 'push', 'scheduler', 'webhook', 'workflow-run', 'model-update', ''].map(iconOf))
+            .toEqual(['user', 'branches', 'clock-circle', 'global', 'appstore', 'sync', 'thunderbolt']);
+    });
+
+    it('has nothing to mark on a run with no start date', () => {
+        const built = buildRunTimeline(<V2WorkflowRun>{ ...pushed, started: null }, [], []);
+
+        expect(built.data.sections.length).toBe(0);
+    });
+
+    it('marks the restart instead on a later attempt, at the head of what it restarted', () => {
+        // A restart two days after the run: the run was set off long before anything being shown, so
+        // marking *it* there would drag the axis back to a moment that has nothing to do with this
+        // attempt — the very thing starting the axis with the jobs of the attempt is there to avoid.
+        const restarted = job({
+            id: 'j1', job_id: 'build',
+            queued: '2026-01-03T10:00:00Z', started: '2026-01-03T10:00:05Z', ended: '2026-01-03T10:01:00Z'
+        });
+        const again = <V2WorkflowRun>{
+            ...pushed,
+            run_attempt: 2,
+            job_events: <any>[{ username: 'someone', job_id: 'build', run_attempt: 2, inputs: {} }]
+        };
+
+        const built = buildRunTimeline(again, [restarted], [], [], 2);
+        const marker = runLane(built).markers[0];
+
+        expect(marker.label).toBe('Restarted by someone');
+        expect(marker.at).toBe(Date.parse(restarted.queued));
+        expect(marker.details.map(d => d.label)).toEqual(['Job:', 'Attempt:', 'Started:']);
+        // There is no panel for a restart, so like a gate it is a mark to hover and nothing more.
+        expect(built.targets[marker.id]).toBeUndefined();
+
+        // The same run read as its first attempt still marks the hook.
+        expect(runLane(buildRunTimeline(again, [restarted], [], [], 1)).markers[0].label).toBe('Started by a push');
+    });
+});
+
+describe('shouldFollow', () => {
+    it('keeps up with a live run while nothing has been asked of the view', () => {
+        expect(shouldFollow(true, false, false, 0)).toBeTrue();
+        // Content shorter than the view leaves negative room, which is still the foot of it.
+        expect(shouldFollow(true, false, false, -50)).toBeTrue();
+    });
+
+    it('leaves the view alone the moment anything is asked of it', () => {
+        // Scrolled up to read something further back.
+        expect(shouldFollow(true, false, false, 200)).toBeFalse();
+        // Zoomed in on something.
+        expect(shouldFollow(true, true, false, 0)).toBeFalse();
+        // Pointing at something.
+        expect(shouldFollow(true, false, true, 0)).toBeFalse();
+    });
+
+    it('has nothing to keep up with once the run has finished', () => {
+        expect(shouldFollow(false, false, false, 0)).toBeFalse();
+    });
+
+    it('picks it up again on the way back down, having remembered nothing', () => {
+        expect(shouldFollow(true, false, false, 300)).toBeFalse();
+        expect(shouldFollow(true, false, false, 4)).toBeTrue();
+    });
+});

--- a/ui/src/app/views/projectv2/run/run.component.ts
+++ b/ui/src/app/views/projectv2/run/run.component.ts
@@ -5,7 +5,7 @@ import { RUN_SUMMARY_HEADERS, V2WorkflowRunService } from "app/service/workflowv
 import { PreferencesState } from "app/store/preferences.state";
 import { Store } from "@ngxs/store";
 import * as actionPreferences from "app/store/preferences.action";
-import { Tab } from "app/shared/tabs/tabs.component";
+import { Tab, TabsComponent } from "app/shared/tabs/tabs.component";
 import { Tests } from "../../../model/pipeline.model";
 import { concatMap, map, switchMap } from "rxjs/operators";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -66,6 +66,7 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     @ViewChild('tabResultsTemplate') tabResultsTemplate: TemplateRef<any>;
     @ViewChild('tabTestsTemplate') tabTestsTemplate: TemplateRef<any>;
     @ViewChild('shareLink') shareLink: any;
+    @ViewChild('bottomTabs') bottomTabs: TabsComponent;
 
     runs: Array<V2WorkflowRun>;
     workflowRun: V2WorkflowRun;
@@ -108,6 +109,8 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
     gateDrawerOpen: boolean = false;
     /** Selected run job IDs for restart. Both simple jobs and matrix variants are tracked uniformly by their run job UUID. */
     selectedRunJobIds: Array<string> = [];
+    /** The run job the pointer is over in the graph, echoed on its lane in the timeline. */
+    hoveredJobRunID: string;
 
     // Subs
     paramsSub: Subscription;
@@ -213,9 +216,12 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
     ngAfterViewInit(): void {
         this.tabs = [<Tab>{
-            title: 'Info',
-            key: 'info',
+            title: 'Timeline',
+            key: 'timeline',
             default: true
+        }, <Tab>{
+            title: 'Info',
+            key: 'info'
         }, <Tab>{
             title: 'Results',
             key: 'results',
@@ -823,6 +829,17 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         this.selectedTab = tab;
     }
 
+    /**
+     * An error marked on the timeline was clicked. The full text of what the run logged lives in the Info
+     * tab rather than in a panel of its own, so that is where this goes.
+     */
+    showRunInfos(): void {
+        const info = this.tabs?.find(t => t.key === 'info');
+        if (info) {
+            this.bottomTabs?.select(info);
+        }
+    }
+
     panelStartResize(): void {
         this._store.dispatch(new actionPreferences.SetPanelResize({ resizing: true }));
     }
@@ -1099,6 +1116,24 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
         // No gates needed, restart jobs directly
         await this.triggerRestartJobs();
+    }
+
+    /**
+     * A job opened from the timeline is the same job the graph draws: the graph follows the selection
+     * so that the two views never disagree about what is being looked at.
+     */
+    selectJobRunFromTimeline(runJobID: string): void {
+        this.graph?.selectRunJob(runJobID);
+        this.openPanel('job', runJobID);
+    }
+
+    /** Pointing at a job in the graph points at its lane in the timeline. */
+    onHoverJobRun(runJobID: string): void {
+        if (this.hoveredJobRunID === runJobID) {
+            return;
+        }
+        this.hoveredJobRunID = runJobID;
+        this._cd.markForCheck();
     }
 
     /** Receive the latest selection from the graph component. */

--- a/ui/src/app/views/projectv2/run/run.html
+++ b/ui/src/app/views/projectv2/run/run.html
@@ -299,25 +299,29 @@ nzContent="{{workflowRun.contexts.cds.version}}" [nzCopyTooltips]="null"></span>
   (onSelectJobRun)="openPanel('job', $event)" (onSelectHook)="openPanel('hook', $event)"
   (onSelectJobRunRestart)="restartJob($event)" (onSelectJobRunStop)="stopJob($event)"
   (onSelectionChange)="onSelectionChange($event)" (onSelectionValidate)="clickValidateRestartJobs()"
-(onSelectionModeChange)="onSelectionModeChange($event)" #graph></app-graph>
+  (onSelectionModeChange)="onSelectionModeChange($event)" (onHoverJobRun)="onHoverJobRun($event)"
+#graph></app-graph>
 </div>
 </div>
 <!--  BOTTOM PANELS -->
 <app-resizable-panel [direction]="'vertical'" [minSize]="200" [initialSize]="infoPanelSize"
   (onGrabbingStart)="panelStartResize()" (onGrabbingEnd)="infoPanelEndResize($event)">
   <div class="bottom-panel">
-    <app-tabs [tabs]="tabs" (onSelect)="selectTab($event)" [disableNavigation]="true"></app-tabs>
-    @if (selectedTab && selectedTab.key === 'info') {
-      <app-run-info [info]="workflowRunInfo"></app-run-info>
-    }
-    @if (selectedTab && selectedTab.key === 'results') {
-      <app-run-results [results]="results"
-      (onSelectResult)="openPanel('result', $event)"></app-run-results>
-    }
-    @if (selectedTab && selectedTab.key === 'tests') {
-      <app-run-tests [tests]="tests"
-      (onSelectTest)="openPanel('test', $event)"></app-run-tests>
-    }
+    <app-tabs [tabs]="tabs" (onSelect)="selectTab($event)" [disableNavigation]="true" #bottomTabs></app-tabs>
+    <!-- Hidden rather than destroyed: a tab that is torn down on the way out comes back with its zoom,
+         its unfolded lanes and its filters reset, which is a poor trade for the little it saves. -->
+    <app-run-info [hidden]="selectedTab?.key !== 'info'" [info]="workflowRunInfo"></app-run-info>
+    <app-run-timeline [hidden]="selectedTab?.key !== 'timeline'" [workflowRun]="workflowRun" [jobs]="jobs"
+      [results]="results" [infos]="workflowRunInfo" [runAttempt]="selectedRunAttempt"
+      [hoveredJobRunID]="hoveredJobRunID"
+      [selectedJobRunID]="selectedItemType === 'job' ? selectedJobRun?.id : null"
+      (onSelectJobRun)="selectJobRunFromTimeline($event)" (onSelectInfo)="showRunInfos()"
+      (onSelectHook)="openPanel('hook', $event)"
+    (onSelectResult)="openPanel('result', $event)"></app-run-timeline>
+    <app-run-results [hidden]="selectedTab?.key !== 'results'" [results]="results"
+    (onSelectResult)="openPanel('result', $event)"></app-run-results>
+    <app-run-tests [hidden]="selectedTab?.key !== 'tests'" [tests]="tests"
+    (onSelectTest)="openPanel('test', $event)"></app-run-tests>
   </div>
 </app-resizable-panel>
 </div>

--- a/ui/src/app/views/projectv2/run/run.scss
+++ b/ui/src/app/views/projectv2/run/run.scss
@@ -395,6 +395,13 @@
         overflow: hidden;
         display: flex;
         flex-direction: column;
+
+        // The tabs of the panel are kept alive and hidden rather than destroyed, so that leaving one and
+        // coming back does not reset its zoom, its unfolded lanes or its filters. Said here because each
+        // of them sets its own display, which would otherwise win against the one `hidden` asks for.
+        > [hidden] {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
 The run page shows a workflow one way only: the graph, which says *what* happened
  but not *where the time went*. This adds a second view of the same run, as time —
  the default tab of the bottom panel, beside Info, Results and Tests.

  Supersedes #7529, an old attempt at the same feature, rebuilt on the run v2
  websocket.

  Each job gets a lane showing how long it waited before anything happened to it and
  how long it actually ran, so the question the graph cannot answer — which job held
  the run back, and how much of its wall clock was spent queueing rather than working
  — is answered by looking. Pinned on the lanes: the results a job produced, the gate
  that let it start, and, on a lane for the run itself, what set the run off and
  anything the run logged as an error. Clicking through opens the same panels the
  graph does, and the two views always agree on what is being looked at.

  A run can sit doing nothing for days waiting on a gate, so stretches where nothing
  is being worked on are compressed: still drawn, still in order, still labelled with
  how long they really were, but no longer costing the axis their length. Without that,
  everything that happened on such a run is a few pixels at the edge of an empty view.

  The view itself is a generic Angular library that knows nothing about CDS — it draws
  lanes and markers against a time axis — with a thin adapter turning a run into what
  it draws. It comes with zoom and pan, a critical-path highlight, keeping up with a
  live run, and full keyboard navigation.

  Two things changed outside it: the graph now reports and accepts hover and selection
  so the views stay in step, and its per-node duration tooltip is gone since the
  timeline shows the same numbers for every job at once. Reasoning for all of it is in
  `ui/specs/workflow-run-timeline.md`.