### PR TITLE
feat(ui): grey the run timeline, and follow what is being looked at

### DIFF
--- a/ui/libs/timeline/src/lib/timeline.component.ts
+++ b/ui/libs/timeline/src/lib/timeline.component.ts
@@ -12,6 +12,7 @@ import {
     OnChanges,
     OnDestroy,
     Output,
+    SimpleChanges,
     TemplateRef,
     ViewChild,
     ViewContainerRef
@@ -23,6 +24,7 @@ import {
     AXIS_BAND_PX,
     flattenLanes,
     formatDuration,
+    revealBy,
     TimelineActivation,
     TimelineData,
     TimelineDetail,
@@ -152,9 +154,10 @@ const CARD_DELAY = 450;
 const CAP_MARGIN_PX = 46;
 /**
  * How far apart two markers have to be to be drawn separately. Closer than this they overlap, so they are
- * drawn as one carrying a count — see `cluster()`.
+ * drawn as one carrying a count — see `cluster()`. A mark is `--timeline-mark-size` wide, and this is that
+ * plus enough for the two to be seen as two.
  */
-const MARKER_GAP_PX = 17;
+const MARKER_GAP_PX = 25;
 /** How many of them a card lists before it stops and says how many are left. */
 const CLUSTER_LISTED = 8;
 
@@ -269,6 +272,9 @@ export class TimelineComponent implements OnChanges, OnDestroy {
     private pointerInside: boolean = false;
     /** One scroll to the foot of the lanes pending, so a burst of updates does not queue a dozen. */
     private followQueued: boolean = false;
+    /** The lane to bring into view once the render lands, and whether one scroll is already pending. */
+    private revealID: string = null;
+    private revealQueued: boolean = false;
     /** Where the pointer is, in client coordinates: what the guide and the card are placed against. */
     private pointer = { x: 0, y: 0 };
     private unwatchPointer: () => void;
@@ -279,8 +285,13 @@ export class TimelineComponent implements OnChanges, OnDestroy {
     private _viewContainer = inject(ViewContainerRef);
     private _injector = inject(Injector);
 
-    ngOnChanges(): void {
+    ngOnChanges(changes: SimpleChanges): void {
         this.layout();
+        // Which lane the two views agree is being looked at outranks which one is merely being pointed at.
+        const asked = changes['selectedLaneID']?.currentValue ?? changes['hoveredLaneID']?.currentValue;
+        if (asked) {
+            this.revealLane(asked);
+        }
     }
 
     ngOnDestroy(): void {
@@ -1035,6 +1046,48 @@ export class TimelineComponent implements OnChanges, OnDestroy {
             if (view && !this.pointerInside) {
                 view.scrollTop = view.scrollHeight;
             }
+        }, { injector: this._injector });
+    }
+
+    /**
+     * Bring a lane into view. Pointing at a job in the graph, or opening one from anywhere, brings out its
+     * lane here — which says nothing at all if that lane is below the fold.
+     *
+     * Vertically only, and by the least that does it: the axis is where someone put it and moving it
+     * sideways would be answering a question nobody asked, and a lane already in view is not a reason to
+     * move anything. A lane that has gone with the data it stood for is simply not found, and nothing moves.
+     *
+     * This never fights the lanes being followed down (§8.1), and does not have to be made to: following
+     * only happens while the view is sitting at the foot of the list, which a view that has just been
+     * scrolled up to a lane is not.
+     */
+    private revealLane(id: string): void {
+        this.revealID = id;
+        if (this.revealQueued) {
+            return;
+        }
+        this.revealQueued = true;
+        // After the render, because the lane asked for may be one that is only arriving with this change.
+        afterNextRender(() => {
+            this.revealQueued = false;
+            const wanted = this.revealID;
+            this.revealID = null;
+            const view = this.viewport?.nativeElement;
+            if (!view?.offsetParent || !wanted) {
+                return;
+            }
+            const lane = Array.from(view.querySelectorAll<HTMLElement>('.lane'))
+                .find(element => element.dataset.laneId === wanted);
+            if (!lane) {
+                return;
+            }
+            const by = revealBy(view.getBoundingClientRect(), lane.getBoundingClientRect());
+            if (by === 0) {
+                return;
+            }
+            // Somebody who has asked for less motion is not asking for the view to slide there.
+            const still = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+            view.scrollBy({ top: by, behavior: still ? 'auto' : 'smooth' });
         }, { injector: this._injector });
     }
 

--- a/ui/libs/timeline/src/lib/timeline.html
+++ b/ui/libs/timeline/src/lib/timeline.html
@@ -106,7 +106,8 @@
               @for (lane of section.lanes; track lane.id) {
                 <li class="lane" [class.highlighted]="lane.highlighted" [class.child]="lane.depth > 0"
                   [class.hovered]="lane.id === hoveredLaneID" [class.selected]="lane.id === selectedLaneID"
-                  [class.marked]="lane.hasMarkers" [attr.data-status]="lane.status">
+                  [class.marked]="lane.hasMarkers" [attr.data-status]="lane.status"
+                  [attr.data-lane-id]="lane.id">
                   <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
                   <div class="lane-gutter" [class.expandable]="lane.expandable"
                     [style.padding-left.px]="6 + lane.depth * 16" (click)="clickRow(lane, $event)">

--- a/ui/libs/timeline/src/lib/timeline.model.ts
+++ b/ui/libs/timeline/src/lib/timeline.model.ts
@@ -159,10 +159,40 @@ export function shouldFollow(live: boolean, zoomed: boolean, hovering: boolean, 
     return roomBelowPx <= FOLLOW_SLACK_PX;
 }
 
+/** How much of the view is kept clear above and below a lane brought into it. */
+export const REVEAL_MARGIN_PX = 10;
+
+/** A stretch of the vertical, in whatever coordinates both sides of a comparison share. */
+export interface VerticalBounds {
+    top: number;
+    bottom: number;
+}
+
+/**
+ * How far to scroll to bring a lane into view, in pixels — negative upwards, and zero when it is already
+ * there. Pointing at a job in the graph brings out its lane here, which says nothing at all if that lane
+ * is below the fold.
+ *
+ * The least that does it, never more: the view is where someone put it, and a lane that is already in it
+ * is not a reason to move anything. A lane taller than the view — an unfolded job with many steps — is
+ * shown from its top rather than scrolled past to its foot, which is why the two ends are not symmetric.
+ */
+export function revealBy(view: VerticalBounds, lane: VerticalBounds, margin: number = REVEAL_MARGIN_PX): number {
+    const above = lane.top - margin - view.top;
+    const below = lane.bottom + margin - view.bottom;
+    if (above < 0) {
+        return above;
+    }
+    if (below > 0) {
+        return Math.min(below, above);
+    }
+    return 0;
+}
+
 /** Width of the band walling off either end of the axis. */
 export const AXIS_BAND_PX = 12;
-/** How much more is kept clear on a side where a marker sits on the bound. */
-export const MARKER_ROOM_PX = 14;
+/** How much more is kept clear on a side where a marker sits on the bound: the width of one, `--timeline-mark-size`. */
+export const MARKER_ROOM_PX = 21;
 
 /** What decides how much room the ends of an axis need. */
 export interface AxisRoom {

--- a/ui/libs/timeline/src/lib/timeline.scss
+++ b/ui/libs/timeline/src/lib/timeline.scss
@@ -21,6 +21,21 @@
   --timeline-marked-row-height: var(--timeline-row-height);
   --timeline-marked-child-row-height: var(--timeline-child-row-height);
 
+  /**
+   * How big a mark on a lane is drawn. Everything else about one — where it is centred, how far its stem
+   * reaches, how wide a crowd of them may grow — is worked out from these, so a mark is resized in one
+   * place and nowhere else.
+   *
+   * Two sizes, because a mark carrying an icon has to hold it and a bare lozenge has nothing to hold.
+   * Both are read by `MARKER_GAP_PX`, which decides when two of them would touch and have to be drawn as
+   * one, and by `MARKER_ROOM_PX`, which keeps the room a mark sitting on the end of the axis needs: change
+   * these and those two go with them.
+   */
+  --timeline-mark-size: 21px;
+  --timeline-dot-size: 15px;
+  // The gap a mark is held above its bar, which its stem then crosses.
+  --timeline-mark-stem: 3px;
+
   --timeline-text: rgba(0, 0, 0, .85);
   // Kept dark enough for small text to stay readable against the panel.
   --timeline-muted: rgba(0, 0, 0, .55);
@@ -522,12 +537,15 @@
     text-overflow: ellipsis;
   }
 
-  // The duration where the eye already is, instead of only on hover.
+  /**
+   * The duration where the eye already is, instead of only on hover. Set apart from the name by its size
+   * and by sitting at the far end of the bar, and not by being faded: a number small enough to need every
+   * bit of contrast it has is the wrong thing to spend contrast on.
+   */
   .segment-duration {
     font-size: .7em;
     padding-right: 5px;
     margin-left: auto;
-    opacity: .75;
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
   }
@@ -541,14 +559,15 @@
   // two is visible, and placed with `bottom` rather than a transform so hovering can scale it without
   // moving it.
   //
-  // Everything here has to fit in the room the row keeps above its bars, because the track clips what
-  // overflows it — and it must, to cut the bars off at its edges. So a mark that has more to say grows
-  // sideways, never upwards.
+  // A mark is taller than the room the row keeps above its bars, so it hangs into the row above — which
+  // is what that room being the same on every row buys, and what growing a mark spends. A mark that has
+  // more to say therefore grows sideways, never upwards: upwards it would reach the bars of a lane it has
+  // nothing to do with, and on the first row it would reach the edge of the view, which does clip.
   position: absolute;
-  bottom: calc(100% + 3px);
-  width: 10px;
-  height: 10px;
-  margin: 0 0 0 -5px;
+  bottom: calc(100% + var(--timeline-mark-stem));
+  width: var(--timeline-dot-size);
+  height: var(--timeline-dot-size);
+  margin: 0 0 0 calc(var(--timeline-dot-size) / -2);
   padding: 0;
   border: 1px solid var(--timeline-marker);
   background-color: var(--timeline-marker);
@@ -560,11 +579,11 @@
   }
 
   &.iconic {
-    width: 14px;
-    height: 14px;
-    margin-left: -7px;
+    width: var(--timeline-mark-size);
+    height: var(--timeline-mark-size);
+    margin-left: calc(var(--timeline-mark-size) / -2);
     box-sizing: border-box;
-    border-radius: 3px;
+    border-radius: 4px;
     transform: none;
     // The icon carries the colour; the box behind it only has to lift it off whatever is underneath.
     background-color: var(--timeline-surface);
@@ -573,8 +592,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 2px;
-    font-size: 9px;
+    gap: 3px;
+    font-size: 13px;
     line-height: 1;
 
     &:hover {
@@ -589,9 +608,9 @@
       position: absolute;
       top: 100%;
       left: 50%;
-      width: 2px;
-      height: 3px;
-      margin-left: -1px;
+      width: 3px;
+      height: var(--timeline-mark-stem);
+      margin-left: -1.5px;
       background-color: var(--timeline-marker);
     }
   }
@@ -602,17 +621,17 @@
   // so it came out clipped.
   &.crowd {
     width: auto;
-    min-width: 14px;
-    height: 14px;
-    padding: 0 3px;
+    min-width: var(--timeline-mark-size);
+    height: var(--timeline-mark-size);
+    padding: 0 5px;
     box-sizing: border-box;
     // Stated here rather than left to `.iconic`, so that a crowd is a legible pill even where the host
     // gave its markers no icon to draw.
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 2px;
-    border-radius: 3px;
+    gap: 3px;
+    border-radius: 4px;
     background-color: var(--timeline-surface);
     border-color: var(--timeline-marker);
     color: var(--timeline-marker);
@@ -626,9 +645,11 @@
       transform: translateX(-50%) scale(1.15);
     }
 
+    // Plain rather than bold: at this size the number is legible on its own, and a mark drawn heavier than
+    // its neighbours would be saying that several results are more worth looking at than one, which is the
+    // opposite of what the crowd means.
     .count {
-      font-size: 9px;
-      font-weight: bold;
+      font-size: 13px;
       line-height: 1;
       font-variant-numeric: tabular-nums;
       color: var(--timeline-marker);
@@ -640,10 +661,10 @@
   &.loose {
     bottom: auto;
     top: 50%;
-    margin-top: -5px;
+    margin-top: calc(var(--timeline-dot-size) / -2);
 
     &.iconic {
-      margin-top: -7px;
+      margin-top: calc(var(--timeline-mark-size) / -2);
     }
 
     &::after {

--- a/ui/specs/workflow-run-timeline.md
+++ b/ui/specs/workflow-run-timeline.md
@@ -98,12 +98,48 @@ doing any work.
 A job that never reached the queue has no place on a time axis and is left out.
 
 The lane label carries nothing but the job name and its matrix variant when it has one. There is no
-second line: the status is already in the colour of the bars, and a bare duration under a name says
-neither what it measured nor between which two points. Both are in the hover card, where there is room
-to name them.
+second line: what a job came to is the graph's answer to give and a bar says it again as soon as the lane
+is asked about, and a bare duration under a name says neither what it measured nor between which two
+points. What it measured, and between which points, are in the hover card, where there is room to name
+them.
 
 Durations are read off the bars themselves — a segment wide enough shows its own duration next to its
 name — so the common question is answered without hovering anything.
+
+**Which bars are painted.** The timeline shares the run page with the graph, and the graph is what the eye
+should land on first: a wall of status colour under it would take that, and it would be saying a second
+time what the graph is already there to say. So a bar that has nothing left to say is **grey**, and colour
+is kept for the four cases that do:
+
+| Coloured | Because |
+|---|---|
+| What is **still running** | It is what is happening now, and worth seeing without being asked for |
+| What **failed** — stopped with it | Where a run went wrong should be answerable from across the room |
+| The lane **pointed at or opened** — from the graph as well as from here | Colour follows what is being looked at |
+| The lanes on the **critical path**, once the highlight is on | See §4 |
+
+A live job is therefore coloured while it runs and greys out as it ends, which is the state changing rather
+than a rule about it: a bar is coloured for still going by having no end, and ending is what gives it one.
+
+Grey, not faded: the name and the duration written on a bar keep their contrast, which an opacity over the
+whole thing would have taken with them.
+
+**The greys are a ramp, not a wash.** Colour says what a job came to; the greys have to go on saying what a
+bar *is* once it is gone, or the view at rest is a row of identical blocks. So they run from nothing
+happened to working, each step darker than the last in the light theme and lighter in the dark one — which
+puts the most ink on the one phase worth measuring, and leaves a visible edge wherever a job passes from
+one phase to the next:
+
+| At rest | Reads as |
+|---|---|
+| An outline with nothing in it | Terminated without running — a place kept on the axis, not time spent |
+| The palest fill, hatched | Waiting: in the queue, or held by a gate |
+| A step darker | A hatchery starting a worker |
+| The darkest fill, and a darker outline with it | The job running — the one bar that is work |
+
+So a job read in grey still says where its time went, and two of the three things a colour was carrying —
+the wait, and whether it ran at all — survive without it. The third, what the job came to, is the graph's
+answer to give, and comes back here on hover.
 
 ### 2.1 The Row Asks, The Bars Answer
 
@@ -149,9 +185,11 @@ of the very thing it belonged to. A short stem crosses the gap and meets the top
 so the mark reads as belonging to that bar rather than floating above the row. The gap is what makes the
 stem worth having — run down inside the bar it was hidden by it.
 
-A lane carrying markers is taller than one that does not, by the room they take. It is grown **at both
-ends**, so its bars stay centred on the line and keep exactly the height they have on a lane carrying
-none — a lane with artifacts is a taller lane, not a lane whose bars have moved.
+A lane carrying markers is **no taller** than one that does not: a mark is taller than the room a row keeps
+above its bars, and hangs into the row above rather than every such row growing to hold it. A timeline is
+read by comparing rows, and rows of two heights are harder to compare than marks are to look past. The room
+can be given back — `--timeline-marked-row-height` and the insets under it are there for exactly that —
+and the price is that comparison.
 
 A marker with no bar under it — a lane that is only a point in time, which is what an unaccounted-for
 result falls back to — sits in the middle of its row instead, with nothing to be welded to.
@@ -226,17 +264,23 @@ for is the host's to name — and a kind of marker may name its own plural, so a
 
 - A cluster of one kind keeps that kind's icon; a mixed one gets a neutral mark, since the icon would
   otherwise claim they were all the same thing.
-- It carries the count **beside** the icon, growing sideways into a pill. Everything a marker draws has
-  to fit in the room the row keeps above its bars, because the track clips what overflows it — and it
-  must, to cut the bars off at its edges. A badge hung off the corner was the obvious thing to reach for
-  and the wrong one: it needed height the row does not have, so it came out clipped. Sideways is the one
-  direction a marker has room to grow in.
+- It carries the count **beside** the icon, growing sideways into a pill. A mark is taller than the room
+  the row keeps above its bars and hangs into the row above, which is what every row being the same height
+  buys; growing one upwards would spend that on reaching the bars of a lane it has nothing to do with, and
+  on the first row would reach the edge of the view, which does clip. A badge hung off the corner was the
+  obvious thing to reach for and the wrong one, for the same reason. Sideways is the one direction a marker
+  has room to grow in.
 - Hovering it lists the first few by name and time, then says how many are left.
 - **Clicking it zooms into what it covers**, which pulls it apart into the individual marks — the natural
   way out, given that the crowding was a matter of scale to begin with. It stands for no single thing, so
   there is nothing else for a click to open.
 - Results created at the very same instant cannot be pulled apart by any zoom. Those stay one mark, and
   the card is what tells them apart.
+
+**How big a mark is drawn** is one number, `--timeline-mark-size`, and two things follow from it rather
+than being decided beside it: how close two marks may come before they are drawn as one, and how much room
+the axis keeps at an end a mark sits on. Both are pixel counts in the view, and both are wrong the moment a
+mark is resized without them.
 
 A result is called by its **key** — `generic:binary.tar.gz`, `tests:unit.xml` — which is what the Results
 tab lists it under and what someone would search a log for. The sentence the API also offers, filename and
@@ -377,7 +421,8 @@ stage needs. For a matrixed job, the variant that ended last is the one on the c
 
 Highlighting it brings those lanes out by holding the others back: everything off the chain is dimmed —
 its bars, its markers, its name, and the dotted rule behind them, which left alone showed straight through
-the faded bars and drew more attention than they did.
+the faded bars and drew more attention than they did. The lanes on the chain are given their colour back
+while it is on, so the gap between kept and left out is opened from both ends.
 
 The control is a toggle that reads on or off the way the filters of the Results tab do.
 
@@ -511,6 +556,12 @@ The graph and the timeline show one run, and must never disagree about what is b
   what is being looked at rather than only what was last hovered.
 - Hovering a job in the graph **brings out its lane** in the timeline, marked more strongly than a plain
   hover since the pointer is elsewhere and cannot say where it is.
+- A lane brought out from the graph, or opened from anywhere, is **scrolled into view if it is not in
+  it** — the timeline holds one row per job and a run has more of them than fit. Vertically only, by the
+  least that shows it, and not at all when it is already there: the axis is where somebody put it, and a
+  view that has nothing to answer is a view that should not move. A lane taller than the view is shown
+  from its top. This never fights the lanes being followed down (§8.1), which only happens while the view
+  is sitting at the foot of the list — which a view just scrolled up to a lane is not.
 
 ---
 
@@ -586,7 +637,7 @@ and there is no longer any way to tell whether it was being watched.
 |---|---|
 | Generic timeline view (axis, folding, zoom, lanes, keyboard) | `libs/timeline/src/lib/timeline.component.ts`, `timeline.html`, `timeline.scss` |
 | Time axis and gap folding | `libs/timeline/src/lib/timeline.scale.ts` |
-| View model, and the rules pulled out of the view to be testable (`axisEnds`, `shouldFollow`) | `libs/timeline/src/lib/timeline.model.ts` |
+| View model, and the rules pulled out of the view to be testable (`axisEnds`, `shouldFollow`, `revealBy`) | `libs/timeline/src/lib/timeline.model.ts` |
 | The icons a marker may be drawn with, and why nothing else is | `libs/timeline/src/lib/timeline.icons.ts` |
 | CDS adapter (trigger, phases, stages, results, critical path) | `run-timeline.builder.ts` |
 | Host component (panels, critical path toggle, graph hover) | `run-timeline.component.ts`, `run-timeline.html` |

--- a/ui/src/app/views/projectv2/run/run-timeline.scss
+++ b/ui/src/app/views/projectv2/run/run-timeline.scss
@@ -61,10 +61,32 @@ app-timeline {
     --timeline-surface: #ffffff;
     --timeline-control-border: #d9d9d9;
     --timeline-now: #{common.$cds_color_teal};
-    --timeline-segment: #{common.$cds_color_light_grey};
     --timeline-marker: #{common.$polar_grey_0};
     --timeline-focus: #{common.$polar_grey_0};
     --timeline-accent: #{common.$cds_color_teal};
+
+    /**
+     * The greys a bar is drawn in at rest. Colour says what a job came to; these say what a bar *is*, and
+     * they have to go on saying it once the colour is gone — a run read in grey is still a run whose queue,
+     * whose worker and whose work can be told apart at a glance.
+     *
+     * So they are a ramp rather than a set: nothing happened, waited, starting up, working. Nothing happened
+     * is nothing at all rather than a grey close enough to the lane to be taken for one, and each step after
+     * it is darker than the last — which puts the most ink on the one phase worth measuring, and leaves an
+     * edge wherever a job goes from one phase to the next.
+     *
+     * Those three steps are off the palette, which offers #EEEEEE and #E1E2E5 — too close to read as two —
+     * and then #B5B7BD, a heavier bar than a row of them can carry. They are spaced evenly instead, and
+     * end well short of that weight.
+     */
+    --bar-inert: transparent;
+    --bar-wait: #F4F4F6;
+    --bar-start: #E7E8EB;
+    --bar-work: #D3D5DA;
+    --bar-edge: #{common.$polar_grey_3};
+    // The one phase that is work gets a darker outline with it, so the bar is read as solid.
+    --bar-work-edge: #{common.$polar_grey_2};
+    --bar-text: #{common.$polar_grey_0};
   }
 
   :host-context(.night) & ::ng-deep .timeline {
@@ -79,31 +101,61 @@ app-timeline {
     --timeline-surface: #{common.$darkTheme_grey_1};
     --timeline-control-border: #434343;
     --timeline-now: #{common.$darkTheme_light_blue};
-    --timeline-segment: #{common.$darkTheme_night_grey};
     --timeline-marker: #{common.$darkTheme_grey_5};
     --timeline-focus: white;
     --timeline-accent: #{common.$darkTheme_light_blue};
+
+    // The same ramp read the other way up: here a bar is lighter than the surface, so working is the
+    // lightest step rather than the darkest.
+    --bar-inert: transparent;
+    --bar-wait: #{common.$darkTheme_grey_0};
+    --bar-start: #{common.$darkTheme_grey_3};
+    --bar-work: #{common.$darkTheme_grey_inactive};
+    --bar-edge: #{common.$darkTheme_grey_4};
+    --bar-work-edge: #{common.$darkTheme_grey_5};
+    // Light enough to stay legible on the lightest step of the ramp, which `--timeline-text` is not.
+    --bar-text: white;
   }
 
+  /**
+   * A kind says which colour a bar *has*; whether that colour is painted is a second question, answered
+   * below. The timeline shares the run page with the graph, and the graph is what the eye should land on
+   * first — so a bar that has nothing left to say is grey, and colour is kept for the four cases that do:
+   * what is still running, what failed, the lane being pointed at or opened, and the critical path.
+   *
+   * Grey rather than faded: the name and the duration written on a bar keep their contrast, which an
+   * opacity over the whole thing would have taken with them. What tells a wait from work at rest is the
+   * hatching, which every kind keeps whatever colour it is drawn in.
+   */
   ::ng-deep .segment {
-    border: 1px solid transparent;
-    color: common.$polar_grey_1;
+    // What a kind is worth in colour, and what it is worth in grey. Both are stated for every kind: which
+    // of the two is painted is not the kind's business.
+    --segment-fill: var(--bar-work);
+    --segment-edge: var(--bar-work-edge);
+    --segment-rest-fill: var(--bar-work);
+    --segment-rest-edge: var(--bar-work-edge);
 
-    :host-context(.night) & {
-      color: common.$darkTheme_grey_6;
-    }
+    // What is actually painted. Only these two are ever overridden to say "this one is worth a colour".
+    --segment-paint-fill: var(--segment-rest-fill);
+    --segment-paint-edge: var(--segment-rest-edge);
+
+    background-color: var(--segment-paint-fill);
+    border: 1px solid var(--segment-paint-edge);
+    color: var(--bar-text);
 
     // Waiting in the queue: hatched, because no time is being spent on the job itself.
     &[data-kind='queued'] {
-      background-color: common.$cds_color_light_grey;
-      border-color: common.$polar_grey_3;
+      --segment-fill: #{common.$cds_color_light_grey};
+      --segment-edge: #{common.$polar_grey_3};
+      --segment-rest-fill: var(--bar-wait);
+      --segment-rest-edge: var(--bar-edge);
       background-image: repeating-linear-gradient(-45deg,
           transparent 0 3px,
           rgba(0, 0, 0, .06) 3px 6px);
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_grey;
-        border-color: common.$darkTheme_grey_4;
+        --segment-fill: #{common.$darkTheme_night_grey};
+        --segment-edge: #{common.$darkTheme_grey_4};
         background-image: repeating-linear-gradient(-45deg,
             transparent 0 3px,
             rgba(255, 255, 255, .07) 3px 6px);
@@ -112,49 +164,53 @@ app-timeline {
 
     // Held by a gate or a concurrency rule: the wait that can last days.
     &[data-kind='blocked'] {
-      background-color: #ffe0d2;
-      border-color: common.$cds_color_orange;
+      --segment-fill: #ffe0d2;
+      --segment-edge: #{common.$cds_color_orange};
+      --segment-rest-fill: var(--bar-wait);
+      --segment-rest-edge: var(--bar-edge);
       background-image: repeating-linear-gradient(-45deg,
           transparent 0 3px,
           rgba(0, 0, 0, .08) 3px 6px);
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_orange;
-        border-color: common.$darkTheme_orange;
+        --segment-fill: #{common.$darkTheme_night_orange};
+        --segment-edge: #{common.$darkTheme_orange};
       }
     }
 
-    // A hatchery starting a worker.
+    // A hatchery starting a worker: a step of the ramp of its own, since it is neither the wait before it
+    // nor the work after it — and the two bars it sits between are what say so once the colour is gone.
     &[data-kind='scheduling'] {
-      background-color: common.$cds_color_light_teal;
-      border-color: common.$cds_color_teal;
-      opacity: .75;
+      --segment-fill: #{common.$cds_color_light_teal};
+      --segment-edge: #{common.$cds_color_teal};
+      --segment-rest-fill: var(--bar-start);
+      --segment-rest-edge: var(--bar-edge);
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_blue;
-        border-color: common.$darkTheme_blue;
+        --segment-fill: #{common.$darkTheme_night_blue};
+        --segment-edge: #{common.$darkTheme_blue};
       }
     }
 
     &[data-kind^='running'],
     &[data-kind^='step'] {
-      background-color: common.$cds_color_light_teal;
-      border-color: common.$cds_color_teal;
+      --segment-fill: #{common.$cds_color_light_teal};
+      --segment-edge: #{common.$cds_color_teal};
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_blue;
-        border-color: common.$darkTheme_blue;
+        --segment-fill: #{common.$darkTheme_night_blue};
+        --segment-edge: #{common.$darkTheme_blue};
       }
     }
 
     &[data-kind='running-success'],
     &[data-kind='step-success'] {
-      background-color: common.$cds_color_light_green;
-      border-color: common.$cds_color_green;
+      --segment-fill: #{common.$cds_color_light_green};
+      --segment-edge: #{common.$cds_color_green};
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_green;
-        border-color: common.$darkTheme_green;
+        --segment-fill: #{common.$darkTheme_night_green};
+        --segment-edge: #{common.$darkTheme_green};
       }
     }
 
@@ -162,26 +218,56 @@ app-timeline {
     &[data-kind='running-stopped'],
     &[data-kind='step-fail'],
     &[data-kind='step-failure'] {
-      background-color: common.$cds_color_light_red;
-      border-color: common.$cds_color_red;
+      --segment-fill: #{common.$cds_color_light_red};
+      --segment-edge: #{common.$cds_color_red};
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_red;
-        border-color: common.$darkTheme_red;
+        --segment-fill: #{common.$darkTheme_night_red};
+        --segment-edge: #{common.$darkTheme_red};
       }
     }
 
+    // Terminated without running: the one bar with no work in it, so at rest it is an outline with
+    // nothing inside, and reads as a place kept on the axis rather than as time spent.
     &[data-kind='running-cancelled'],
     &[data-kind='running-skipped'],
     &[data-kind='step-skipped'] {
-      background-color: common.$cds_color_light_grey;
-      border-color: common.$polar_grey_3;
+      --segment-fill: #{common.$cds_color_light_grey};
+      --segment-edge: #{common.$polar_grey_3};
+      --segment-rest-fill: var(--bar-inert);
+      --segment-rest-edge: var(--bar-edge);
 
       :host-context(.night) & {
-        background-color: common.$darkTheme_night_grey;
-        border-color: common.$darkTheme_grey_4;
+        --segment-fill: #{common.$darkTheme_night_grey};
+        --segment-edge: #{common.$darkTheme_grey_4};
       }
     }
+  }
+
+  /**
+   * The four cases worth a colour. Every one of them is the same two declarations, so they are stated
+   * once: what changes between them is only which bars are being spoken about.
+   *
+   * - **Still going.** A segment with no end is what is happening now, and that is worth seeing without
+   *   being asked for. It greys out on its own the moment the job ends, since the segment closes.
+   * - **Failed.** Red stays whatever else is grey, so where a run went wrong is answered from across the
+   *   room rather than by reading. Stopped counts: it is how a run ends badly, not how it ends.
+   * - **Pointed at or opened.** The lane under the pointer — from the graph as well as from here — and
+   *   the lane whose panel is open. Colour follows what is being looked at.
+   * - **On the critical path**, once the highlight is on. A lane carries `highlighted` whether or not it
+   *   is: it is which lanes the chain holds, not the answer to a question nobody asked.
+   */
+  ::ng-deep .segment.open,
+  ::ng-deep .segment[data-kind='running-fail'],
+  ::ng-deep .segment[data-kind='running-stopped'],
+  ::ng-deep .segment[data-kind='step-fail'],
+  ::ng-deep .segment[data-kind='step-failure'],
+  ::ng-deep .lane:hover > .lane-track .segment,
+  ::ng-deep .lane.hovered > .lane-track .segment,
+  ::ng-deep .lane.selected > .lane-track .segment,
+  ::ng-deep .timeline.highlighting .lane.highlighted > .lane-track .segment {
+    --segment-paint-fill: var(--segment-fill);
+    --segment-paint-edge: var(--segment-edge);
   }
 
   // What the run logged as an error. The one mark on the timeline worth stopping at, so it is the one

--- a/ui/src/app/views/projectv2/run/run-timeline.spec.ts
+++ b/ui/src/app/views/projectv2/run/run-timeline.spec.ts
@@ -1,4 +1,4 @@
-import { axisEnds, AXIS_BAND_PX, formatDuration, MARKER_ROOM_PX, shouldFollow, timelineIcon, TimelineLane, TimelineScale, TimelineSection } from "../../../../../libs/timeline/src/public-api";
+import { axisEnds, AXIS_BAND_PX, formatDuration, MARKER_ROOM_PX, revealBy, shouldFollow, timelineIcon, TimelineLane, TimelineScale, TimelineSection } from "../../../../../libs/timeline/src/public-api";
 import { V2WorkflowRun, V2WorkflowRunJob, V2WorkflowRunJobStatus, WorkflowRunInfo, WorkflowRunResult } from "../../../../../libs/workflow-graph/src/lib/v2.workflow.run.model";
 import { buildRunTimeline, computeCriticalPath } from "./run-timeline.builder";
 
@@ -679,5 +679,31 @@ describe('shouldFollow', () => {
     it('picks it up again on the way back down, having remembered nothing', () => {
         expect(shouldFollow(true, false, false, 300)).toBeFalse();
         expect(shouldFollow(true, false, false, 4)).toBeTrue();
+    });
+});
+
+describe('revealBy', () => {
+    const view = { top: 100, bottom: 400 };
+
+    it('leaves a lane already in view where it is', () => {
+        expect(revealBy(view, { top: 200, bottom: 220 }, 10)).toBe(0);
+        // Right up against either edge, margin included.
+        expect(revealBy(view, { top: 110, bottom: 390 }, 10)).toBe(0);
+    });
+
+    it('scrolls up by the least that shows a lane above the view', () => {
+        expect(revealBy(view, { top: 60, bottom: 80 }, 10)).toBe(-50);
+        // In view but for its top edge: only the missing part, and the margin, is scrolled.
+        expect(revealBy(view, { top: 95, bottom: 200 }, 10)).toBe(-15);
+    });
+
+    it('scrolls down by the least that shows a lane below the view', () => {
+        expect(revealBy(view, { top: 500, bottom: 520 }, 10)).toBe(130);
+        expect(revealBy(view, { top: 300, bottom: 405 }, 10)).toBe(15);
+    });
+
+    it('shows a lane taller than the view from its top rather than its foot', () => {
+        // Scrolling to its foot would have carried its name off the top of the view.
+        expect(revealBy(view, { top: 500, bottom: 900 }, 10)).toBe(390);
     });
 });


### PR DESCRIPTION
The timeline was drawn in full status colour beside a graph saying the same thing, so a bar with nothing left to say is now grey. Colour is kept for what is still running, what failed, the lane being pointed at or opened, and the critical path once it is on — a live job is coloured while it runs and greys out as it ends, by having no end and then getting one.

The greys are a ramp rather than a wash — nothing happened, waited, starting up, working — so a run read in grey still says where its time went. Greyed rather than faded, so what is written on a bar keeps its contrast; the duration is no longer faded either.

Pointing at a job in the graph brings out its lane, which says nothing if that lane is below the fold: it is now scrolled to, vertically only, by the least that shows it, and not at all when it is already there. The arithmetic is a pure function tested on its own.

Marks are half again as big, from one number the rest is worked out from — the two pixel counts that decide when two of them merge, and the room the axis keeps at an end one sits on, are read off it and moved with it. The count on a crowd is no longer bold.

@ovh/cds
