### PR TITLE
fix(tests): report the failures of the suites running in parallel

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-trap 'kill $(jobs -p)' EXIT
+# Kill the test suites still running when the script exits early. jobs -p is
+# empty once everything has been waited for, and can still list a suite that
+# just terminated, so neither case is worth reporting as an error.
+cleanup() {
+    local pids
+    pids=$(jobs -p)
+    if [ -n "${pids}" ]; then
+        kill ${pids} 2>/dev/null
+    fi
+    return 0
+}
+trap cleanup EXIT
 
 # script usage definition
 usage() {
@@ -97,6 +108,28 @@ check_failure() {
 mv_results() {
     tsuite_file=$1
     mv ./results/venom.log ./results/${tsuite_file}-venom.log
+}
+
+# Suites running in parallel report their failure through a marker file: their
+# exit status is lost by the `wait` that collects them, and a suite dying before
+# writing its xml report would otherwise go unnoticed. Every suite is still run,
+# the whole list of failures is reported once they are all done.
+FAILED_DIR=./results/.failed
+
+mark_failure() {
+    mkdir -p ${FAILED_DIR}
+    touch ${FAILED_DIR}/$1
+}
+
+report_failures() {
+    if [ ! -d ${FAILED_DIR} ] || [ -z "$(ls -A ${FAILED_DIR} 2>/dev/null)" ]; then
+        return 0
+    fi
+    echo -e "${LIGHTRED}Failed test suites:${NOCOLOR}"
+    for f in $(ls -1 ${FAILED_DIR}); do
+        echo -e "  ${RED}${f}${NOCOLOR}"
+    done
+    return 1
 }
 
 smoke_tests_api() {
@@ -198,16 +231,17 @@ run_workflow_tests() {
     echo -e "  ${YELLOW}${f} ${BLUE}STARTING ${DARKGRAY}cmd: ${CMD}${NOCOLOR}"
     START="$(date +%s)"
     ${CMD} > ./results/${f}/${f}.output 2>&1
-    exit_status=$?    
+    exit_status=$?
     if [ $exit_status -ne 0 ]; then
         out=`cat ./results/${f}/${f}.output`
         echo -e "  ${YELLOW}${f} ${LIGHTRED}FAILURE ${DARKGRAY}code: ${exit_status}\n${RED}${out}${NOCOLOR}"
         mv ./results/${f}/venom.log ./results/${f}/${f}-venom.log
+        mark_failure ${f}
     else
         echo -e "  ${YELLOW}${f} ${GREEN}SUCCESS ${DARKGRAY}duration: $[ $(date +%s) - ${START} ]${NOCOLOR}"
     fi
     mv ./results/${f}/* ./results
-    exit $exit_status
+    return $exit_status
 }
 
 workflow_with_integration_tests() {
@@ -297,16 +331,19 @@ run_cds_v2_tests() {
     echo -e "  ${YELLOW}${f} ${BLUE}STARTING ${DARKGRAY}cmd: ${CMD}${NOCOLOR}"
     START="$(date +%s)"
     ${CMD} > ./results/${f}/${f}.output 2>&1
-    exit_status=$?    
+    exit_status=$?
     if [ $exit_status -ne 0 ]; then
         out=`cat ./results/${f}/${f}.output`
         echo -e "  ${YELLOW}${f} ${LIGHTRED}FAILURE ${DARKGRAY}code: ${exit_status}\n${RED}${out}${NOCOLOR}"
         mv ./results/${f}/venom.log ./results/${f}/${f}-venom.log
+        mark_failure ${f}
     else
         echo -e "  ${YELLOW}${f} ${GREEN}SUCCESS ${DARKGRAY}duration: $[ $(date +%s) - ${START} ]${NOCOLOR}"
     fi
     mv ./results/${f}/* ./results
-    exit $exit_status
+    # Returning instead of exiting: the concurrency suites call this function in
+    # the foreground, an exit here would end the script after the first one.
+    return $exit_status
 }
 
 rm -rf ./results
@@ -345,3 +382,9 @@ for target in $@; do
             exit 1;;
     esac
 done
+
+# Every suite has run by now, so the whole list of failures can be reported at
+# once. This is also what makes the exit status meaningful for the targets
+# running their suites in parallel.
+report_failures
+exit $?


### PR DESCRIPTION
The suites run in background jobs collected by a bare `wait`, whose status is always 0, so their failure never reached the exit status of the script. It only surfaced through the junit step uploading the venom reports, which left two holes: a suite dying before writing its xml report was not counted as a failure at all, and the debug gate of the integration test jobs, which keys off the exit status to hold the host open, could never trigger on a test failure.

Suites now record their failure through a marker file, and the whole list is reported once every suite has run, so nothing fails early and the exit status becomes meaningful.

run_cds_v2_tests and run_workflow_tests return instead of exiting. The concurrency suites call them in the foreground, where the exit ended the whole script after the first suite, silently skipping the other seven.

The EXIT trap no longer complains about killing an already finished job.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
