### PR TITLE
chore(tests): drop the unreferenced engine args file

### DIFF
--- a/tests/args.file
+++ b/tests/args.file
@@ -1,9 +1,0 @@
---config
-/etc/cds-engine/cds-engine.toml
-start
-api
-cdn
-hooks
-hatchery:swarm
-vcs
-ui


### PR DESCRIPTION
tests/args.file held arguments for a cds-engine.test invocation: the path of the configuration file and the list of services to start. Nothing in this repository reads it. cdsctl_wrapper.sh does use an args file, but it writes its own per invocation, which is what the *.args.file entry of tests/.gitignore covers.

The engine takes its list of services from the CDS_SERVICE environment variable as well, so starting it does not require a file listing them.

1. Description
1. Related issues
1. About tests
1. Mentions

@ovh/cds
