### PR TITLE
perf(contrib,tests): linux only plugin archive and shardable v2 suites

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build package copy
+.PHONY: clean build package copy archive archive-linux-amd64
 
 TARGET_DIST := $(if ${TARGET_DIST},${TARGET_DIST},./dist)
 
@@ -53,6 +53,27 @@ $(ALL_ARCHIVES):
 	cd $(TARGET_DIST); tar czf $(ARCHIVE) $(PATTERN)
 
 archive: $(ALL_ARCHIVES)
+
+# Slim archive holding only the linux/amd64 binaries and their manifests. The
+# integration tests never import any other os/arch (see tests/01_init_plugins.yml),
+# so shipping the full cross-compiled set to them is pure transfer time.
+LINUX_AMD64_ARCHIVE = cds-plugins-linux-amd64.tar.gz
+
+archive-linux-amd64:
+	$(info Preparing archive $(LINUX_AMD64_ARCHIVE))
+	@cd $(TARGET_DIST); \
+	FILES=""; \
+	for BIN in `ls *-linux-amd64 2>/dev/null`; do \
+		NAME=`echo $$BIN | sed 's/-linux-amd64$$//'`; \
+		FILES="$$FILES $$BIN"; \
+		if [ -f "$$BIN.yml" ]; then FILES="$$FILES $$BIN.yml"; fi; \
+		if [ -f "$$NAME.yml" ]; then FILES="$$FILES $$NAME.yml"; fi; \
+	done; \
+	if [ -z "$$FILES" ]; then \
+		echo "no linux/amd64 plugin binary found in $(TARGET_DIST)" >&2; \
+		exit 1; \
+	fi; \
+	tar czf $(LINUX_AMD64_ARCHIVE) $$FILES
 
 clean_archive:
 	rm -rf $(TARGET_DIST)/*.tar.gz

--- a/tests/08_v2_workflow_concurrency_cancel_with_job.yml
+++ b/tests/08_v2_workflow_concurrency_cancel_with_job.yml
@@ -107,7 +107,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
     
     - name: Run the second workflow
@@ -118,7 +118,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Check that the 1st workflow is cancelled
@@ -126,7 +126,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Cancelled"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Wait all success

--- a/tests/08_v2_workflow_concurrency_cancel_with_workflow.yml
+++ b/tests/08_v2_workflow_concurrency_cancel_with_workflow.yml
@@ -97,7 +97,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
       vars:
         workflowRunID:
@@ -112,7 +112,7 @@ testcases:
         - result.systemoutjson ShouldHaveLength 2
         - result.systemoutjson.systemoutjson1.status ShouldEqual "Cancelled"
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Wait all success

--- a/tests/08_v2_workflow_concurrency_with_jobs.yml
+++ b/tests/08_v2_workflow_concurrency_with_jobs.yml
@@ -110,7 +110,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
     
     - name: Run the 2nd workflow
@@ -121,7 +121,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Blocked"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Check the end of workflow 1
@@ -129,7 +129,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Success"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Check that workflow 2 is building
@@ -137,7 +137,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Wait all success

--- a/tests/08_v2_workflow_concurrency_with_workflow.yml
+++ b/tests/08_v2_workflow_concurrency_with_workflow.yml
@@ -98,7 +98,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
     
     - name: Run a 2nd time
@@ -110,7 +110,7 @@ testcases:
         - result.systemoutjson ShouldHaveLength 2
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Blocked"
         - result.systemoutjson.systemoutjson1.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Run 3
@@ -123,7 +123,7 @@ testcases:
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Blocked"
         - result.systemoutjson.systemoutjson1.status ShouldEqual "Blocked"
         - result.systemoutjson.systemoutjson2.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Wait for the first to end and the 3rd to start
@@ -133,7 +133,7 @@ testcases:
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
         - result.systemoutjson.systemoutjson1.status ShouldEqual "Blocked"
         - result.systemoutjson.systemoutjson2.status ShouldEqual "Success"
-      retry: 50
+      retry: 120
       delay: 1
 
     - name: Wait for the 3rd to end and the 2nd to start

--- a/tests/08_v2_workflow_job_concurrency_cancel_with_job.yml
+++ b/tests/08_v2_workflow_job_concurrency_cancel_with_job.yml
@@ -107,7 +107,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
       vars:
         workflowRunID:
@@ -121,7 +121,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
     
     - name: Wait for job in workflow 1
@@ -129,7 +129,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual 'Cancelled'
-      retry: 30
+      retry: 120
       delay: 1
 
     - name: Wait workflow 2 end

--- a/tests/08_v2_workflow_job_concurrency_cancel_with_workflow.yml
+++ b/tests/08_v2_workflow_job_concurrency_cancel_with_workflow.yml
@@ -107,7 +107,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
       vars:
         workflowRunID:
@@ -121,7 +121,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
     
     - name: Wait for job in workflow 1
@@ -129,7 +129,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual 'Cancelled'
-      retry: 30
+      retry: 120
       delay: 1
 
     - name: Wait workflow 2 end

--- a/tests/08_v2_workflow_job_concurrency_with_workflow.yml
+++ b/tests/08_v2_workflow_job_concurrency_with_workflow.yml
@@ -106,7 +106,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
       vars:
         workflowRunID:
@@ -120,7 +120,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual "Building"
-      retry: 20
+      retry: 120
       delay: 1
       vars:
         workflow2RunID:
@@ -131,7 +131,7 @@ testcases:
       assertions:
         - result.systemoutjson ShouldHaveLength 1
         - result.systemoutjson.systemoutjson0.status ShouldEqual 'Blocked'
-      retry: 20
+      retry: 120
       delay: 1
 
     - name: Check the end of workflow  1
@@ -150,7 +150,7 @@ testcases:
           - result.systemoutjson.systemoutjson0.status ShouldEqual 'Building'
           - result.systemoutjson.systemoutjson0.status ShouldEqual 'Waiting'
           - result.systemoutjson.systemoutjson0.status ShouldEqual 'Scheduling'
-      retry: 50
+      retry: 120
       delay: 1
 
     - name: Workflow 2 - wait workflow end

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -73,6 +73,11 @@ CDS_REGION_REQ="${CDS_REGION_REQ:-""}"
 HOSTNAME="${HOSTNAME:-localhost}"
 MAX_CHILDREN="${MAX_CHILDREN:-10}"
 
+# Split a test suite across several runners. SHARD_INDEX is 0-based and must be
+# lower than SHARD_TOTAL. Defaults run every test suite in a single shard.
+SHARD_TOTAL="${SHARD_TOTAL:-1}"
+SHARD_INDEX="${SHARD_INDEX:-0}"
+
 # The default values below fit to default minio installation.
 # Run "make minio_start" to start a minio docker container
 AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
@@ -130,6 +135,10 @@ report_failures() {
         echo -e "  ${RED}${f}${NOCOLOR}"
     done
     return 1
+}
+
+shard() {
+    awk -v total="${SHARD_TOTAL}" -v idx="${SHARD_INDEX}" 'NR % total == idx'
 }
 
 smoke_tests_api() {
@@ -302,8 +311,8 @@ admin_tests() {
 cds_v2_tests() {
     echo "Check if forgejo is running"
     curl --fail -I -X GET ${FORGEJO_HOST}/api/swagger
-    echo "Running CDS v2 tests (excluding concurrency):"
-    for f in $(ls -1 08_*.yml | grep -v concurrency); do
+    echo "Running CDS v2 tests (excluding concurrency), shard ${SHARD_INDEX}/${SHARD_TOTAL}:"
+    for f in $(ls -1 08_*.yml | grep -v concurrency | shard); do
         run_cds_v2_tests $f &
         local my_pid=$$
         local children=$(ps -eo ppid | grep -w $my_pid | wc -w)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,7 +16,8 @@ trap cleanup EXIT
 # script usage definition
 usage() {
     echo "Usage: ./test.sh <target...>"
-    echo "   Available targets: smoke_api, smoke_services, initialization, cli, workflow, workflow_with_integration, workflow_with_third_parties, admin"
+    echo "   Available targets: smoke_api, initialization, smoke_services, cli, workflow, workflow_with_integration, workflow_with_third_parties, admin, v2, v2_concurrency"
+    echo "   The v2 target can be split across runners with SHARD_TOTAL and SHARD_INDEX."
 }
 
 # Arguments are mandatory


### PR DESCRIPTION
  Three independent changes making the integration test suites cheaper and
  steadier to run, without changing what they assert.

  ### A linux/amd64 only plugin archive

  `make archive-linux-amd64` builds `cds-plugins-linux-amd64.tar.gz`, holding
  only the linux/amd64 plugin binaries and their manifests, next to the existing
  `<plugin>-all.tar.gz` archives.

  `tests/01_init_plugins.yml` only ever imports the linux/amd64 binary of each
  plugin, so anything that just runs the integration tests can pull this archive
  instead of the full cross compiled set. The existing archives are untouched,
  for the callers that do need every arch.

  ### Shardable v2 suites

  `test.sh` accepts `SHARD_TOTAL` and `SHARD_INDEX` to split the `08_*` suites of
  the `v2` target across several runners, each with its own CDS. Defaults are
  `1` and `0`, so a plain `./test.sh smoke_services v2` still runs every suite,
  exactly as before.

  The concurrency suites are not concerned: they keep their own `v2_concurrency`
  target and still run sequentially.

  ### Realistic budgets for the concurrency assertions

  The concurrency suites held 23 status assertions with a 20 to 50 second budget,
  where the 43 other v2 suites use 60 to 150 nearly everywhere. Some were not
  reachable even on an idle host: "check the end of workflow 1" waits for
  `Success` within 20 seconds while the job of that workflow is a `sleep 20`, so
  it only passed because the preceding steps had already consumed part of the
  sleep.

  They all wait for a status to be reached, so a longer window only gives the run
  more time. It cannot make a broken concurrency rule look correct either:
  `Blocked` is only ever set by the concurrency engine, a run waiting for a free
  worker stays `Building`.

  Also lists every target in `./test.sh` usage output, `v2` and `v2_concurrency`
  were missing.

@ovh/cds
