### PR TITLE
perf(cache): speed up the cache restore and stop it failing builds

### DIFF
--- a/contrib/grpcplugins/grpcplugins_cache.go
+++ b/contrib/grpcplugins/grpcplugins_cache.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"time"
 
+	"github.com/klauspost/pgzip"
 	"github.com/ovh/cds/engine/worker/pkg/workerruntime"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/grpcplugin/actionplugin"
@@ -76,20 +78,7 @@ func performFromArtifactory(ctx context.Context, c *actionplugin.Common, jobCtx 
 		return false, sdk.Errorf("unable to download cache (HTTP %d)", resp.StatusCode)
 	}
 
-	if err := os.MkdirAll(absPath, os.FileMode(0744)); err != nil {
-		return false, fmt.Errorf("unable to create destination directory: %v", err)
-	}
-
-	// Stream directly: HTTP body → gzip → tar → filesystem (no intermediate file)
-	countReader := &countingReader{r: resp.Body}
-	t0 := time.Now()
-	if err := sdk.UntarGz(afero.NewOsFs(), absPath, countReader); err != nil {
-		return false, fmt.Errorf("unable to extract cache: %v", err)
-	}
-	elapsed := time.Since(t0)
-
-	Successf(c, "Cache restored to %s (%d bytes downloaded and extracted in %.3f seconds).", absPath, countReader.n, elapsed.Seconds())
-	return true, nil
+	return extractCache(c, resp.Body, absPath)
 }
 
 func performFromCDN(ctx context.Context, c *actionplugin.Common, cacheKey string, workDirs *sdk.WorkerDirectories, absPath string) (bool, error) {
@@ -126,30 +115,87 @@ func performFromCDN(ctx context.Context, c *actionplugin.Common, cacheKey string
 		return false, sdk.Errorf("unable to download cache (HTTP %d)", resp.StatusCode)
 	}
 
+	return extractCache(c, resp.Body, absPath)
+}
+
+const (
+	// Read ahead of the decompression. The pgzip default is 4MB, too small to
+	// keep the download busy while the current blocks are being written to disk.
+	cacheGzipBlockSize = 1 << 20
+	cacheGzipBlocks    = 16
+)
+
+// extractCache streams a cache archive into absPath, without an intermediate
+// file, and reports how long the download held the extraction up. It returns
+// whether the cache could be used: an archive that cannot be read is reported
+// as a miss rather than as an error.
+func extractCache(c *actionplugin.Common, body io.Reader, absPath string) (bool, error) {
 	if err := os.MkdirAll(absPath, os.FileMode(0744)); err != nil {
 		return false, fmt.Errorf("unable to create destination directory: %v", err)
 	}
 
-	// Stream directly: HTTP body → gzip → tar → filesystem (no intermediate file)
-	countReader := &countingReader{r: resp.Body}
+	// HTTP body → gzip → tar → filesystem
+	countReader := &countingReader{r: body}
+	gzr, err := pgzip.NewReaderN(countReader, cacheGzipBlockSize, cacheGzipBlocks)
+	if err != nil {
+		warnCacheUnusable(c, absPath, err)
+		return false, nil
+	}
+	defer gzr.Close()
+
 	t0 := time.Now()
-	if err := sdk.UntarGz(afero.NewOsFs(), absPath, countReader); err != nil {
-		return false, fmt.Errorf("unable to extract cache: %v", err)
+	if err := sdk.Untar(afero.NewOsFs(), absPath, gzr); err != nil {
+		warnCacheUnusable(c, absPath, err)
+		return false, nil
 	}
 	elapsed := time.Since(t0)
 
-	Successf(c, "Cache restored to %s (%d bytes downloaded and extracted in %.3f seconds).", absPath, countReader.n, elapsed.Seconds())
+	// The decompression reads ahead in its own goroutine, so downloading and
+	// extracting overlap and the two cannot be told apart in wall clock time.
+	// Reporting how long the reads blocked is enough to know which of the two
+	// the restore is waiting on: close to the total means the network, much
+	// lower means the filesystem.
+	read := countReader.bytes()
+	blocked := countReader.blocked()
+	var throughput float64
+	if elapsed > 0 {
+		throughput = float64(read) / (1024 * 1024) / elapsed.Seconds()
+	}
+	Successf(c, "Cache restored to %s (%d bytes in %.3fs, %.3fs of which blocked on the download, %.1f MB/s).",
+		absPath, read, elapsed.Seconds(), blocked.Seconds(), throughput)
 	return true, nil
 }
 
-// countingReader wraps an io.Reader and counts bytes read.
+// warnCacheUnusable reports a cache that could not be read as a miss. A cache is
+// optimisation and must never take a build down: whatever the reason, from an
+// archive left truncated by an interrupted or concurrent upload to a full disk,
+// the job can still do the work itself. A job that saves its cache on a miss
+// then replaces the unusable copy, so the key repairs itself on the next run.
+//
+// The reason is not guessed: a truncated gzip stream, a bad checksum and a
+// failure to write a file all surface the same way here, so the error is
+// reported as is and the caller carries on without a cache.
+func warnCacheUnusable(c *actionplugin.Common, absPath string, err error) {
+	Warnf(c, "ignoring the cache, it could not be extracted to %s: %v", absPath, err)
+	Warnf(c, "%s may hold part of it, continuing as if there was no cache", absPath)
+}
+
+// countingReader counts the bytes read and the time spent waiting for them. It
+// is read from the decompression goroutine and reported from another one, hence
+// the atomics.
 type countingReader struct {
-	r io.Reader
-	n int64
+	r       io.Reader
+	n       atomic.Int64
+	waitedN atomic.Int64
 }
 
 func (cr *countingReader) Read(p []byte) (int, error) {
+	t0 := time.Now()
 	n, err := cr.r.Read(p)
-	cr.n += int64(n)
+	cr.waitedN.Add(int64(time.Since(t0)))
+	cr.n.Add(int64(n))
 	return n, err
 }
+
+func (cr *countingReader) bytes() int64           { return cr.n.Load() }
+func (cr *countingReader) blocked() time.Duration { return time.Duration(cr.waitedN.Load()) }

--- a/contrib/grpcplugins/grpcplugins_cache_test.go
+++ b/contrib/grpcplugins/grpcplugins_cache_test.go
@@ -1,0 +1,68 @@
+package grpcplugins
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/pgzip"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk/grpcplugin/actionplugin"
+)
+
+func cacheArchive(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := pgzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	// The directory comes first, as filepath.Walk emits it when the archive is
+	// built: Untar does not create the parent of a file on its own.
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "mod", Typeflag: tar.TypeDir, Mode: 0755,
+	}))
+	body := []byte("cached")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "mod/f.txt", Typeflag: tar.TypeReg, Mode: 0644, Size: int64(len(body)),
+	}))
+	_, err := tw.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	return buf.Bytes()
+}
+
+func TestExtractCache(t *testing.T) {
+	dst := t.TempDir()
+	found, err := extractCache(&actionplugin.Common{}, bytes.NewReader(cacheArchive(t)), dst)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	got, err := os.ReadFile(filepath.Join(dst, "mod/f.txt"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("cached"), got)
+}
+
+// An archive left truncated, by an interrupted or a concurrent upload, must be
+// reported as a miss so that the job carries on and rebuilds what it needs.
+func TestExtractCacheTruncated(t *testing.T) {
+	archive := cacheArchive(t)
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"cut in the middle", archive[:len(archive)/2]},
+		{"header only", archive[:5]},
+		{"empty", nil},
+		{"not a gzip stream", []byte("this is not an archive")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			found, err := extractCache(&actionplugin.Common{}, bytes.NewReader(tc.body), t.TempDir())
+			require.NoError(t, err, "an unusable cache must not fail the job")
+			require.False(t, found, "an unusable cache must be reported as a miss")
+		})
+	}
+}

--- a/sdk/file.go
+++ b/sdk/file.go
@@ -42,6 +42,11 @@ func UntarGz(fs afero.Fs, dst string, r io.Reader) error {
 func Untar(fs afero.Fs, dst string, r io.Reader) error {
 	tr := tar.NewReader(r)
 
+	// Reused for every entry. io.Copy allocates a 32kB buffer per call, which an
+	// archive holding a lot of small files, a go module cache for instance, pays
+	// once per file.
+	buf := make([]byte, 256*1024)
+
 	for {
 		header, err := tr.Next()
 
@@ -59,10 +64,10 @@ func Untar(fs afero.Fs, dst string, r io.Reader) error {
 		// check the file type
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if _, err := fs.Stat(target); err != nil {
-				if err := fs.MkdirAll(target, 0755); err != nil {
-					return err
-				}
+			// MkdirAll already returns nil on an existing directory, stating it
+			// first only adds a syscall per entry.
+			if err := fs.MkdirAll(target, 0755); err != nil {
+				return err
 			}
 
 		case tar.TypeReg:
@@ -71,7 +76,7 @@ func Untar(fs afero.Fs, dst string, r io.Reader) error {
 				return err
 			}
 
-			if _, err := io.Copy(f, tr); err != nil {
+			if _, err := io.CopyBuffer(f, tr, buf); err != nil {
 				return err
 			}
 			if err := f.Close(); err != nil {

--- a/sdk/file_test.go
+++ b/sdk/file_test.go
@@ -1,0 +1,118 @@
+package sdk
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/pgzip"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTarGz writes the given entries the way the cache plugin does, so the test
+// exercises the archives Untar actually receives.
+func buildTarGz(t *testing.T, entries []tar.Header, contents map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := pgzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for i := range entries {
+		h := entries[i]
+		if body, ok := contents[h.Name]; ok {
+			h.Size = int64(len(body))
+		}
+		require.NoError(t, tw.WriteHeader(&h))
+		if body, ok := contents[h.Name]; ok {
+			_, err := tw.Write(body)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	return buf.Bytes()
+}
+
+func TestUntarGz(t *testing.T) {
+	// One file smaller than the copy buffer, one empty, and one larger so that
+	// the reused buffer is filled more than once.
+	small := []byte("hello cache")
+	big := bytes.Repeat([]byte("0123456789abcdef"), 64*1024) // 1MB, > the 256kB buffer
+
+	entries := []tar.Header{
+		{Name: "mod", Typeflag: tar.TypeDir, Mode: 0755},
+		{Name: "mod/nested", Typeflag: tar.TypeDir, Mode: 0755},
+		{Name: "mod/nested/small.txt", Typeflag: tar.TypeReg, Mode: 0644},
+		{Name: "mod/nested/empty.txt", Typeflag: tar.TypeReg, Mode: 0600},
+		{Name: "mod/big.bin", Typeflag: tar.TypeReg, Mode: 0444},
+		{Name: "mod/link.txt", Typeflag: tar.TypeSymlink, Linkname: "nested/small.txt", Mode: 0777},
+	}
+	contents := map[string][]byte{
+		"mod/nested/small.txt": small,
+		"mod/nested/empty.txt": {},
+		"mod/big.bin":          big,
+	}
+	archive := buildTarGz(t, entries, contents)
+
+	dst := t.TempDir()
+	fs := afero.NewOsFs()
+	require.NoError(t, UntarGz(fs, dst, bytes.NewReader(archive)))
+
+	// Directories
+	for _, d := range []string{"mod", "mod/nested"} {
+		fi, err := fs.Stat(filepath.Join(dst, d))
+		require.NoError(t, err, d)
+		require.True(t, fi.IsDir(), d)
+	}
+
+	// Contents, including the file larger than the copy buffer
+	for name, want := range contents {
+		got, err := afero.ReadFile(fs, filepath.Join(dst, name))
+		require.NoError(t, err, name)
+		require.Equal(t, want, got, name)
+	}
+
+	// Modes
+	fi, err := fs.Stat(filepath.Join(dst, "mod/nested/small.txt"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0644), fi.Mode().Perm())
+	fi, err = fs.Stat(filepath.Join(dst, "mod/big.bin"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0444), fi.Mode().Perm())
+
+	// Symlink
+	target, err := os.Readlink(filepath.Join(dst, "mod/link.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "nested/small.txt", target)
+}
+
+// Restoring twice in a row must succeed: a cache is often extracted over a
+// directory that already holds part of it.
+func TestUntarGzOverExistingContent(t *testing.T) {
+	entries := []tar.Header{
+		{Name: "mod", Typeflag: tar.TypeDir, Mode: 0755},
+		{Name: "mod/f.txt", Typeflag: tar.TypeReg, Mode: 0644},
+	}
+	contents := map[string][]byte{"mod/f.txt": []byte("second")}
+	archive := buildTarGz(t, entries, contents)
+
+	dst := t.TempDir()
+	fs := afero.NewOsFs()
+	require.NoError(t, fs.MkdirAll(filepath.Join(dst, "mod"), 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dst, "mod/f.txt"), []byte("first"), 0644))
+
+	require.NoError(t, UntarGz(fs, dst, bytes.NewReader(archive)))
+
+	got, err := afero.ReadFile(fs, filepath.Join(dst, "mod/f.txt"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("second"), got, "an existing file must be truncated, not appended to")
+}
+
+func TestUntarGzInvalidArchive(t *testing.T) {
+	err := UntarGz(afero.NewOsFs(), t.TempDir(), io.LimitReader(bytes.NewReader([]byte("not a gzip")), 10))
+	require.Error(t, err)
+}


### PR DESCRIPTION
A cache archive can hold a very large number of small files, an extracted go module tree for instance, and restoring it is then bound by the number of entries rather than by their size.

Untar reused nothing between entries: io.Copy allocates a 32kB buffer per call, once per file. It now copies through a single 256kB buffer. Every directory entry was also stat'ed before being created although MkdirAll already returns nil on an existing directory, one syscall per directory for nothing.

The cache restore reads ahead 16MB instead of the 4MB default of pgzip, so that downloading the next blocks overlaps with writing the current ones. The two code paths, artifactory and cdn, were duplicating the extraction and now share it.

The restore reported downloading and extracting as a single duration, which said nothing about where the time went. Since the decompression reads ahead in its own goroutine the two genuinely overlap and cannot be separated in wall clock time, so it now also reports how long the reads blocked, and the throughput. Blocked close to the total means the network is the limit, much lower means the filesystem is.

A cache that could not be extracted used to fail the step, and with it the job, so an archive left truncated by an interrupted or a concurrent upload took down every build that restored it until its key changed. It is now reported as a miss: the job does the work itself, and one that saves its cache on a miss replaces the unusable copy, so the key repairs itself instead of staying poisoned. The reason is not guessed, a truncated stream, a bad checksum and a failure to write a file all surface the same way there and none of them is worth failing a build over an optimisation.

Untar had no test at all although the engine and the worker both rely on it to unpack archives. It now has a round trip covering nested directories, an empty file, a file larger than the copy buffer, the file modes, a symlink and extracting over existing content, and the restore has one for the happy path and four ways of being unusable.

@ovh/cds
