### PR TITLE
fix(api): delete auth consumers on user deletion

### DIFF
--- a/engine/api/authentication/dao_user_consumer.go
+++ b/engine/api/authentication/dao_user_consumer.go
@@ -102,6 +102,13 @@ func LoadUserConsumersByGroupID(ctx context.Context, db gorp.SqlExecutor, groupI
 	return consumers, nil
 }
 
+// DeleteConsumersByUserID removes all the auth consumers of a given user from database.
+// Sessions and child consumers are removed by cascade.
+func DeleteConsumersByUserID(db gorp.SqlExecutor, userID string) error {
+	_, err := db.Exec(`DELETE FROM auth_consumer WHERE id IN (SELECT auth_consumer_id FROM auth_consumer_user WHERE user_id = $1)`, userID)
+	return sdk.WrapError(err, "unable to delete auth consumers of user %s", userID)
+}
+
 // LoadUserConsumerByID returns an auth consumer from database.
 func LoadUserConsumerByID(ctx context.Context, db gorp.SqlExecutor, id string, opts ...LoadUserConsumerOptionFunc) (*sdk.AuthUserConsumer, error) {
 	query := gorpmapping.NewQuery("SELECT * FROM auth_consumer WHERE id = $1").Args(id)

--- a/engine/api/authentication/dao_user_consumer_data.go
+++ b/engine/api/authentication/dao_user_consumer_data.go
@@ -19,7 +19,8 @@ func loadConsumerUserDataByConsumerID(ctx context.Context, db gorp.SqlExecutor, 
 		return sdk.WrapError(err, "cannot get auth consumer user")
 	}
 	if !found {
-		return nil
+		// The consumer's user data are removed by cascade when the user is deleted, the consumer is then orphan and can't be used anymore
+		return sdk.NewErrorFrom(sdk.ErrNotFound, "no user data found for auth consumer %s", ac.ID)
 	}
 
 	isValid, err := gorpmapping.CheckSignature(dbAuthConsumerUserData, dbAuthConsumerUserData.Signature)

--- a/engine/api/authentication/dao_user_consumer_test.go
+++ b/engine/api/authentication/dao_user_consumer_test.go
@@ -177,3 +177,35 @@ func TestDeleteConsumer(t *testing.T) {
 	_, err = authentication.LoadUserConsumerByID(context.TODO(), db, c.ID)
 	assert.Error(t, err)
 }
+
+// A consumer whose user has been deleted is orphan: its auth_consumer_user row is removed by cascade.
+// Loading it must fail instead of returning a consumer with no user, else every caller dereferencing
+// AuthConsumerUser.AuthentifiedUser panics (ex: signin with a token of a deleted user).
+func TestLoadConsumerOfDeletedUser(t *testing.T) {
+	db, _ := test.SetupPG(t, bootstrap.InitiliazeDB)
+
+	u := sdk.AuthentifiedUser{
+		Username: sdk.RandomString(10),
+	}
+	require.NoError(t, user.Insert(context.TODO(), db, &u))
+
+	c := sdk.AuthUserConsumer{
+		AuthConsumer: sdk.AuthConsumer{
+			Name:            sdk.RandomString(10),
+			Type:            sdk.ConsumerBuiltin,
+			ValidityPeriods: sdk.NewAuthConsumerValidityPeriod(time.Now(), 0),
+		},
+		AuthConsumerUser: sdk.AuthUserConsumerData{
+			ScopeDetails:       sdk.NewAuthConsumerScopeDetails(sdk.AuthConsumerScopeAdmin),
+			AuthentifiedUserID: u.ID,
+		},
+	}
+	require.NoError(t, authentication.InsertUserConsumer(context.TODO(), db, &c))
+
+	require.NoError(t, user.DeleteByID(db, u.ID))
+
+	_, err := authentication.LoadUserConsumerByID(context.TODO(), db, c.ID,
+		authentication.LoadUserConsumerOptions.WithAuthentifiedUser)
+	require.Error(t, err)
+	require.True(t, sdk.ErrorIs(err, sdk.ErrNotFound), "got %v", err)
+}

--- a/engine/api/authentication/loader_user_consumer.go
+++ b/engine/api/authentication/loader_user_consumer.go
@@ -88,9 +88,11 @@ func loadAuthentifiedUser(ctx context.Context, db gorp.SqlExecutor, cs ...*sdk.A
 	}
 
 	for i := range cs {
-		if user, ok := mUsers[cs[i].AuthConsumerUser.AuthentifiedUserID]; ok {
-			cs[i].AuthConsumerUser.AuthentifiedUser = &user
+		u, ok := mUsers[cs[i].AuthConsumerUser.AuthentifiedUserID]
+		if !ok {
+			return sdk.NewErrorFrom(sdk.ErrNotFound, "unable to find user %s for auth consumer %s", cs[i].AuthConsumerUser.AuthentifiedUserID, cs[i].ID)
 		}
+		cs[i].AuthConsumerUser.AuthentifiedUser = &u
 	}
 
 	return nil

--- a/engine/api/user.go
+++ b/engine/api/user.go
@@ -517,6 +517,12 @@ func (api *API) deleteUserHandler() service.Handler {
 			}
 		}
 
+		// Consumers are not removed by cascade when deleting a user, only their user data are.
+		// Delete them explicitly so the user's tokens and sessions can't be used anymore.
+		if err := authentication.DeleteConsumersByUserID(tx, u.ID); err != nil {
+			return err
+		}
+
 		if err := user.DeleteByID(tx, u.ID); err != nil {
 			return sdk.WrapError(err, "cannot delete user")
 		}

--- a/engine/api/user_test.go
+++ b/engine/api/user_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ovh/cds/engine/api/authentication"
 	"github.com/ovh/cds/engine/api/organization"
 	"github.com/ovh/cds/engine/api/test/assets"
 	"github.com/ovh/cds/engine/api/user"
@@ -507,5 +508,36 @@ func Test_deleteUserHandler(t *testing.T) {
 				assert.Contains(t, rec.Body.String(), c.ExpectedBodyContains)
 			}
 		})
+	}
+}
+
+// Deleting a user must also delete its consumers: an orphan consumer keeps its token accepted at
+// signin while its user data are gone by cascade, which used to panic on a nil AuthentifiedUser.
+func Test_deleteUserHandlerRemovesConsumers(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+
+	assets.DeleteAdmins(t, db)
+
+	_, jwtAdminRaw := assets.InsertAdminUser(t, db)
+	u, _ := assets.InsertLambdaUser(t, db)
+
+	consumers, err := authentication.LoadUserConsumersByUserID(context.TODO(), db, u.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, consumers)
+
+	uri := api.Router.GetRoute(http.MethodDelete, api.deleteUserHandler, map[string]string{
+		"permUsernamePublic": u.Username,
+	})
+	require.NotEmpty(t, uri)
+
+	req := assets.NewJWTAuthentifiedRequest(t, jwtAdminRaw, http.MethodDelete, uri, nil)
+	rec := httptest.NewRecorder()
+	api.Router.Mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The auth_consumer rows must be gone, not only the auth_consumer_user rows removed by cascade
+	for _, c := range consumers {
+		_, err := authentication.LoadConsumerByID(context.TODO(), db, c.ID)
+		require.True(t, sdk.ErrorIs(err, sdk.ErrNotFound), "consumer %s should have been deleted, got %v", c.ID, err)
 	}
 }

--- a/engine/sql/api/322_delete_orphan_auth_consumer.sql
+++ b/engine/sql/api/322_delete_orphan_auth_consumer.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+
+-- Deleting a user only removes its auth_consumer_user rows by cascade, the auth_consumer rows are left orphan.
+-- Such consumers can't be used anymore, delete them (their sessions and child consumers go by cascade).
+DELETE FROM auth_consumer c
+WHERE NOT EXISTS (SELECT 1 FROM auth_consumer_user cu WHERE cu.auth_consumer_id = c.id)
+  AND NOT EXISTS (SELECT 1 FROM auth_consumer_hatchery ch WHERE ch.auth_consumer_id = c.id);
+
+-- +migrate Down
+SELECT 1;


### PR DESCRIPTION
Deleting a user only removed its auth_consumer_user row by cascade, leaving the auth_consumer orphan: the token was still accepted at signin and panicked on a nil AuthentifiedUser. Consumer loads now fail, the handler deletes the consumers and a migration cleans up the existing orphans.

