### PR TITLE
feat(sdk): blur more encoded forms of a secret in the logs

### DIFF
--- a/sdk/blur.go
+++ b/sdk/blur.go
@@ -2,8 +2,10 @@ package sdk
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/url"
 	"reflect"
 	"sort"
@@ -12,44 +14,106 @@ import (
 )
 
 func NewBlur(secrets []string) (*Blur, error) {
-	alternativeFuncs := func(v string) ([]string, error) {
-		jsonAlternative, err := json.Marshal(v)
-		if err != nil {
-			return nil, WithStack(err)
-		}
-		jsonAlt := buildJsonAlternative(string(v))
-		return []string{
-			v,
-			strings.Replace(v, "'", `'"'"'`, -1), // Useful to match secrets from 'env' in script steps
-			strings.Trim(string(jsonAlternative), "\""),
-			url.QueryEscape(v),
-			base64.StdEncoding.EncodeToString([]byte(v)),
-
-			// Useful to match secreet json variable, that are print through toJson function + an env variable
-			jsonAlt,
-			strings.TrimSuffix(strings.TrimPrefix(jsonAlt, "{ "), "}"),
-		}, nil
-	}
 	var alternatives []string
 	for i := range secrets {
-		as, err := alternativeFuncs(secrets[i])
+		as, err := secretAlternatives(secrets[i])
 		if err != nil {
 			return nil, err
 		}
 		alternatives = append(alternatives, as...)
 	}
+
+	// Longest alternatives first: strings.Replacer gives the priority to the pattern given first,
+	// so a longer alternative always wins over a shorter one matching at the same position. Without
+	// this a partial match could blur only the beginning of an encoded secret.
 	sort.Slice(alternatives, func(i, j int) bool { return len(alternatives[i]) > len(alternatives[j]) })
 
 	oldNew := make([]string, 0, 2*len(alternatives))
+	known := make(map[string]struct{}, len(alternatives))
 	for i := range alternatives {
-		if len(alternatives[i]) >= SecretMinLength {
-			oldNew = append(oldNew, alternatives[i], PasswordPlaceholder)
+		// The minimum applies to each form, so a short one — a line of a multi-line secret, the
+		// last wrapped line of a base64 — is not blurred on its own.
+		if len(alternatives[i]) < SecretMinLength {
+			continue
 		}
+		if _, ok := known[alternatives[i]]; ok {
+			continue
+		}
+		known[alternatives[i]] = struct{}{}
+		oldNew = append(oldNew, alternatives[i], PasswordPlaceholder)
 	}
 
 	return &Blur{
 		replacer: strings.NewReplacer(oldNew...),
 	}, nil
+}
+
+// secretAlternatives returns the forms of a secret that could be found in logs. Forms shorter than
+// SecretMinLength are dropped by NewBlur, so a short one cannot blur unrelated text.
+func secretAlternatives(v string) ([]string, error) {
+	// A secret stored with surrounding blank chars is often used without them
+	values := []string{v}
+	if trimmed := strings.TrimSpace(v); trimmed != v {
+		values = append(values, trimmed)
+	}
+
+	var res []string
+	for _, value := range values {
+		as, err := encodingAlternatives(value)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, as...)
+	}
+
+	// Logs are blurred line by line, so every line of a multi line secret, like a private key, has
+	// to be an alternative on its own: the whole secret never appears in a single log line.
+	if strings.ContainsAny(v, "\r\n") {
+		for _, line := range strings.FieldsFunc(v, func(r rune) bool { return r == '\n' || r == '\r' }) {
+			res = append(res, line, strings.TrimSpace(line))
+		}
+	}
+
+	return res, nil
+}
+
+// encodingAlternatives returns the escapes and the encodings of a value that jobs commonly print.
+func encodingAlternatives(v string) ([]string, error) {
+	jsonAlternative, err := json.Marshal(v)
+	if err != nil {
+		return nil, WithStack(err)
+	}
+	jsonAlt := buildJsonAlternative(v)
+	res := []string{
+		v,
+		strings.Replace(v, "'", `'"'"'`, -1), // Useful to match secrets from 'env' in script steps
+
+		// The worker exports every environment variable through OneLineValue, so a multi-line
+		// secret reaches a step as a single line holding the two chars `\n`. The JSON escape below
+		// covers it only as long as the secret holds nothing else JSON escapes.
+		OneLineValue(v),
+		strings.Trim(string(jsonAlternative), "\""),
+		url.QueryEscape(v), // Blank chars encoded as '+', as in a query string
+		url.PathEscape(v),  // Blank chars encoded as '%20', as in an URL path or a basic auth
+
+		// Markup escaping comes in flavours: the quotes are not always escaped, and not always
+		// as a numeric reference. All of them give back the value itself when it holds no markup
+		// char, and are then dropped as duplicates.
+		html.EscapeString(v),
+		markupEscape(v, ""),
+		markupEscape(v, "xml"),
+
+		// Hex encoding does not need any end of line alternative as it encodes each byte on its
+		// own: the encoding of the secret is always a prefix of the encoding of the secret + '\n'
+		hex.EncodeToString([]byte(v)),
+		strings.ToUpper(hex.EncodeToString([]byte(v))),
+
+		// Useful to match a JSON secret printed through the toJson function, which spaces out its
+		// punctuation, and the same value without its outer braces
+		jsonAlt,
+		strings.TrimSuffix(strings.TrimPrefix(jsonAlt, "{ "), "}"),
+	}
+	return append(res, base64Alternatives(v)...), nil
 }
 
 type Blur struct {
@@ -90,6 +154,90 @@ func (b *Blur) Interface(i interface{}) error {
 	}
 
 	return nil
+}
+
+// markupEscape escapes the markup chars of a value the way most HTML and XML escapers do:
+// only the three structural chars, and with the named quote references of XML when asked.
+func markupEscape(v string, flavour string) string {
+	replacements := []string{"&", "&amp;", "<", "&lt;", ">", "&gt;"}
+	if flavour == "xml" {
+		replacements = append(replacements, `"`, "&quot;", "'", "&apos;")
+	}
+	return strings.NewReplacer(replacements...).Replace(v)
+}
+
+// base64WrapWidth is the line width used by the base64 command line tool when -w is not given.
+const base64WrapWidth = 76
+
+// base64Alternatives returns the base64 encodings of a secret that can be found in logs. All the
+// standard alphabets are covered, padded and unpadded, because the encoding used by the job is
+// unknown. Trailing end of lines are added to the secret before encoding as shell snippets usually
+// rely on `echo "$secret" | base64` and echo appends an end of line to its argument: that extra
+// byte changes the tail of the encoded value so the encoding of the raw secret does not match it.
+func base64Alternatives(v string) []string {
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	}
+	var res []string
+	for _, input := range []string{v, v + "\n", v + "\r\n"} {
+		for _, enc := range encodings {
+			res = append(res, enc.EncodeToString([]byte(input)))
+		}
+		// The base64 command line tool wraps its output every base64WrapWidth chars unless -w0 is
+		// given. As logs are blurred line by line, every wrapped line must be an alternative.
+		res = append(res, splitLength(base64.StdEncoding.EncodeToString([]byte(input)), base64WrapWidth)...)
+	}
+	return append(res, base64EmbeddedAlternatives(v)...)
+}
+
+// base64EmbeddedAlternatives returns what stays stable of the base64 of a secret when it is encoded
+// as a part of something larger, as in a registry credential file, where `base64("user:$password")`
+// never holds the encoding of the password on its own.
+//
+// Base64 reads three bytes at a time, so what a prefix changes is only the alignment: dropping the
+// first one or two bytes of the secret gives back the alignment of a prefix of any length. What
+// follows the secret only changes the last chars of the encoding, which are dropped for the same
+// reason.
+//
+// What is left out stays readable in the logs, a few chars around the blurred value: at most the
+// two first bytes of the secret, and nothing of what follows it, as the bits of the bytes it
+// shares with its suffix are split between a blurred char and a readable one. The padding is
+// dropped with them, its length telling the length of the secret modulo three.
+func base64EmbeddedAlternatives(v string) []string {
+	encodings := []*base64.Encoding{base64.RawStdEncoding, base64.RawURLEncoding}
+	res := make([]string, 0, 3*len(encodings))
+	for shift := 0; shift < 3 && shift < len(v); shift++ {
+		aligned := v[shift:]
+		for _, enc := range encodings {
+			encoded := enc.EncodeToString([]byte(aligned))
+			// A secret whose length is not a multiple of three ends on an incomplete group of
+			// three bytes, encoded together with whatever follows it in the stream
+			if len(aligned)%3 != 0 {
+				encoded = encoded[:len(encoded)-1]
+			}
+			res = append(res, encoded)
+		}
+	}
+	return res
+}
+
+// splitLength cuts s in chunks of at most width chars, it returns nothing if s is not longer.
+func splitLength(s string, width int) []string {
+	if len(s) <= width {
+		return nil
+	}
+	var res []string
+	for len(s) > width {
+		res = append(res, s[:width])
+		s = s[width:]
+	}
+	if len(s) > 0 {
+		res = append(res, s)
+	}
+	return res
 }
 
 func buildJsonAlternative(v string) string {

--- a/sdk/blur_test.go
+++ b/sdk/blur_test.go
@@ -2,7 +2,9 @@ package sdk_test
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"html"
 	"net/url"
 	"strings"
 	"testing"
@@ -85,4 +87,118 @@ func TestBlur(t *testing.T) {
 	require.Equal(t, sdk.PasswordPlaceholder, tests.TestSuites[0].TestCases[0].Systemout.Value)
 	require.Equal(t, 0, tests.TestSuites[0].Total)
 	require.Equal(t, 5, tests.TestSuites[0].Skipped)
+}
+
+func TestBlurBase64(t *testing.T) {
+	// One secret for each length modulo 3 as the base64 padding depends on the input length
+	secrets := []string{"the-api-key-aa", "the-api-key-abc", "the-api-key-ab"}
+
+	for _, secret := range secrets {
+		b, err := sdk.NewBlur([]string{secret})
+		require.NoError(t, err)
+
+		for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+			// Raw secret, as done by `printf '%s' "$secret" | base64 -w0`
+			require.Equal(t, sdk.PasswordPlaceholder, b.String(enc.EncodeToString([]byte(secret))))
+			// Secret with a trailing end of line, as done by `echo "$secret" | base64 -w0`
+			require.Equal(t, sdk.PasswordPlaceholder, b.String(enc.EncodeToString([]byte(secret+"\n"))))
+			require.Equal(t, sdk.PasswordPlaceholder, b.String(enc.EncodeToString([]byte(secret+"\r\n"))))
+		}
+
+		// Encoded secret in the middle of a log line
+		require.Equal(t, "API KEY: "+sdk.PasswordPlaceholder+", but... "+sdk.PasswordPlaceholder,
+			b.String("API KEY: "+secret+", but... "+base64.StdEncoding.EncodeToString([]byte(secret+"\n"))))
+	}
+
+	// A long secret encoded without -w0 is wrapped every 76 chars by the base64 tool, logs are
+	// blurred line by line so every wrapped line must be blurred on its own
+	longSecret := strings.Repeat("abcdefghij", 20)
+	b, err := sdk.NewBlur([]string{longSecret})
+	require.NoError(t, err)
+	encoded := base64.StdEncoding.EncodeToString([]byte(longSecret + "\n"))
+	for i := 0; i < len(encoded); i += 76 {
+		require.Equal(t, sdk.PasswordPlaceholder, b.String(encoded[i:min(i+76, len(encoded))]))
+	}
+}
+
+func TestBlurSecretEncodedInsideAnotherValue(t *testing.T) {
+	// `base64("user:$password")`, the shape of a registry credential: the encoding of the password
+	// alone is nowhere in that string, only a part of it survives.
+	secret := "th3-r3g1stry-p4ssw0rd"
+	b, err := sdk.NewBlur([]string{secret})
+	require.NoError(t, err)
+
+	// Every prefix length, so the secret starts on each of the three byte alignments, and a
+	// suffix, which changes the last chars of the encoding
+	for _, user := range []string{"", "a", "ab", "abc", "user", "user:", "a-longer-user:"} {
+		for _, suffix := range []string{"", "\n", ":extra"} {
+			blob := base64.StdEncoding.EncodeToString([]byte(user + secret + suffix))
+			blurred := b.String(blob)
+			require.Contains(t, blurred, sdk.PasswordPlaceholder,
+				"secret encoded with prefix %q and suffix %q not blurred: %s", user, suffix, blurred)
+			// What stays readable are the chars of the groups of three bytes the secret shares
+			// with the prefix and the suffix, so at most two of its bytes on each side. The rest
+			// of the blob, everything the secret encodes on its own, has to be gone.
+			replaced := len(blob) - len(strings.Replace(blurred, sdk.PasswordPlaceholder, "", 1))
+			require.GreaterOrEqual(t, replaced, len(secret),
+				"too little blurred for prefix %q and suffix %q: %s", user, suffix, blurred)
+		}
+	}
+}
+
+func TestBlurEncodings(t *testing.T) {
+	secret := "the api key &é'(§è!çà"
+	b, err := sdk.NewBlur([]string{secret})
+	require.NoError(t, err)
+
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(url.QueryEscape(secret)))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(url.PathEscape(secret)))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(html.EscapeString(secret)))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(hex.EncodeToString([]byte(secret))))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(strings.ToUpper(hex.EncodeToString([]byte(secret)))))
+	// `echo "$secret" | xxd -p` encodes the end of line added by echo, only that byte remains
+	require.Equal(t, sdk.PasswordPlaceholder+"0a", b.String(hex.EncodeToString([]byte(secret+"\n"))))
+}
+
+func TestBlurMarkupEscapes(t *testing.T) {
+	secret := `p@ss w0rd&<sh3ll>'quoted'`
+	b, err := sdk.NewBlur([]string{secret})
+	require.NoError(t, err)
+
+	// Go escapes the quotes as numeric references, a `sed` in a step script usually escapes only
+	// the three structural chars, and an XML escaper uses the named references
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(html.EscapeString(secret)))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(
+		strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(secret)))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(
+		strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;").Replace(secret)))
+}
+
+func TestBlurSecretWithSurroundingBlankChars(t *testing.T) {
+	b, err := sdk.NewBlur([]string{"  the-api-key\n"})
+	require.NoError(t, err)
+
+	require.Equal(t, sdk.PasswordPlaceholder, b.String("the-api-key"))
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(base64.StdEncoding.EncodeToString([]byte("the-api-key"))))
+}
+
+func TestBlurMultiLineSecret(t *testing.T) {
+	// The shape of a key or of a credential file, without the header of one: a value looking like
+	// a private key in the source of a test is what secret scanners are there to shout about
+	secret := "AAAAAmultilinesecretAAAAA\nBBBBBmultilinesecretBBBBB\nCCCCCmultilinesecretCCCCC\n"
+	b, err := sdk.NewBlur([]string{secret})
+	require.NoError(t, err)
+
+	// The worker blurs the logs line by line, the whole secret is never in a single log line
+	for _, line := range strings.Split(strings.TrimSpace(secret), "\n") {
+		require.Equal(t, sdk.PasswordPlaceholder, b.String(line))
+	}
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(secret))
+
+	// A multi-line secret given to a step through `env` reaches it as a single line, whatever else
+	// it holds: the worker exports it through OneLineValue
+	quoted := "line one \"quoted\"\nline two 'quoted'\nline three\n"
+	b, err = sdk.NewBlur([]string{quoted})
+	require.NoError(t, err)
+	require.Equal(t, sdk.PasswordPlaceholder, b.String(sdk.OneLineValue(quoted)))
 }

--- a/tests/04_sc_workflow_run_worker_cmd.yml
+++ b/tests/04_sc_workflow_run_worker_cmd.yml
@@ -49,7 +49,8 @@ testcases:
     - script: {{.cdsctl}} -f {{.cdsctl.config}} workflow logs download 04SCWORKFLOWRUNWORKERCMD 04SCWorkflowRunWorkerCmd-WORKFLOW 1 --pattern TMPL; grep "this a a line in the file, with a CDS variable 1" *.log
       retry: 100
       delay: 1
-    - script: {{.cdsctl}} -f {{.cdsctl.config}} workflow logs download 04SCWORKFLOWRUNWORKERCMD 04SCWorkflowRunWorkerCmd-WORKFLOW 1 --pattern KEY; grep "BEGIN RSA PRIVATE KEY" *.log
+    # The job checks the installed files itself: a key printed in the logs is blurred, as it should be
+    - script: {{.cdsctl}} -f {{.cdsctl.config}} workflow logs download 04SCWORKFLOWRUNWORKERCMD 04SCWorkflowRunWorkerCmd-WORKFLOW 1 --pattern KEY; grep "KEY INSTALLED IN WORKSPACE" *.log && grep "KEY INSTALLED IN TMP" *.log
       retry: 100
       delay: 1
     - script: {{.cdsctl}} -f {{.cdsctl.config}} workflow logs download 04SCWORKFLOWRUNWORKERCMD 04SCWorkflowRunWorkerCmd-WORKFLOW 1 --pattern ARTIFACTLIST; grep "\"name\":\"myFileUploaded\"" *.log

--- a/tests/fixtures/04SCWorkflowRunWorkerCmd/pipeline.yml
+++ b/tests/fixtures/04SCWorkflowRunWorkerCmd/pipeline.yml
@@ -93,10 +93,10 @@ jobs:
       - if [[ -z "$GIT_SSH" ]]; then exit 1; fi;
       - ""
       - worker key install --file id_rsa proj-ssh-04scworkflowrunworkercmd
-      - cat id_rsa
+      - if [ -s id_rsa ] && head -n 1 id_rsa | grep -q BEGIN; then echo "KEY INSTALLED IN WORKSPACE"; else exit 1; fi
       - ""
       - worker key install --file /tmp/ssh/id_rsa proj-ssh-04scworkflowrunworkercmd
-      - cat /tmp/ssh/id_rsa
+      - if [ -s /tmp/ssh/id_rsa ] && head -n 1 /tmp/ssh/id_rsa | grep -q BEGIN; then echo "KEY INSTALLED IN TMP"; else exit 1; fi
     - script:
         - sleep 5
   requirements:


### PR DESCRIPTION
Widen the alternatives the blur looks for, so a secret that a step transformed before printing it is still recognized:

- base64 in the four alphabets, padded and unpadded, for the secret with and without a trailing end of line, plus the 76 char lines of `base64` used without `-w0`, as the logs are blurred line by line
- base64 of a secret encoded as a part of something larger, as in a registry credential file, where `base64("user:$password")` holds the encoding of no secret on its own. Base64 reads three bytes at a time, so dropping the first one or two bytes of the secret gives back the alignment of a prefix of any length, and the last chars, shared with what follows, are dropped. What the secret encodes together with its neighbours stays readable: at most its first two bytes, when a prefix pushed it out of alignment, and nothing of what follows it, those bits being split between a blurred char and a readable one
- hexadecimal in both cases, byte aligned so no end of line variant is needed
- `url.PathEscape` next to the existing query escape, and the three usual markup escapes, which differ on the quotes
- the secret trimmed of its surrounding blank chars, and every line of a multi-line secret on its own
- OneLineValue, the form every environment variable is exported with

The alternatives are now deduplicated, which keeps the replacer smaller than the number of generated forms suggests: a plain secret costs 9 patterns, as most encodings collapse into duplicates when the secret has nothing to escape.

@ovh/cds
