### PR TITLE
perf(api,sdk): lighten the recurring database and event load

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -925,6 +925,10 @@ func (a *API) Serve(ctx context.Context) error {
 		event_v2.Dequeue(ctx, a.mustDB(), a.Cache, a.GoRoutines, a.Config.URL.UI)
 	})
 
+	a.GoRoutines.RunWithRestart(ctx, "event_v2.flushRunJobStepUpdates", func(ctx context.Context) {
+		event_v2.FlushRunJobStepUpdates(ctx, a.Cache)
+	})
+
 	log.Info(ctx, "Initializing internal routines...")
 	a.GoRoutines.RunWithRestart(ctx, "maintenance.Subscribe", func(ctx context.Context) {
 		if err := a.listenMaintenance(ctx); err != nil {

--- a/engine/api/event_v2/event_run.go
+++ b/engine/api/event_v2/event_run.go
@@ -69,26 +69,31 @@ func PublishRunJobManualEvent(ctx context.Context, store cache.Store, eventType 
 }
 
 func PublishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, wr sdk.V2WorkflowRun, rj sdk.V2WorkflowRunJob) {
-	publishRunJobEvent(ctx, store, eventType, rj)
+	publishRunJobEvent(ctx, store, eventType, rj, time.Now())
 
 	ev := NewEventJobSummaryV2(wr, rj)
 	event.PublishEventJobSummary(ctx, ev, nil)
 }
 
 // PublishRunJobStepUpdate reports the progress of the steps of a job. It carries no job summary: the
-// job status did not change, only its steps did.
+// job status did not change, only its steps did. Progress reported while the job already announced
+// some is held back, see stepUpdates.
 func PublishRunJobStepUpdate(ctx context.Context, store cache.Store, rj sdk.V2WorkflowRunJob) {
-	publishRunJobEvent(ctx, store, sdk.EventRunJobStepUpdated, rj)
+	at := time.Now()
+	if !runJobStepUpdates.take(rj, at) {
+		return
+	}
+	publishRunJobEvent(ctx, store, sdk.EventRunJobStepUpdated, rj, at)
 }
 
-func publishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, rj sdk.V2WorkflowRunJob) {
+func publishRunJobEvent(ctx context.Context, store cache.Store, eventType sdk.EventType, rj sdk.V2WorkflowRunJob, at time.Time) {
 	bts, _ := json.Marshal(rj)
 	e := sdk.WorkflowRunJobEvent{
 		GlobalEventV2: sdk.GlobalEventV2{
 			ID:        sdk.UUID(),
 			Type:      eventType,
 			Payload:   bts,
-			Timestamp: time.Now(),
+			Timestamp: at,
 		},
 		ProjectEventV2: sdk.ProjectEventV2{
 			ProjectKey: rj.ProjectKey,

--- a/engine/api/event_v2/event_run_job_step.go
+++ b/engine/api/event_v2/event_run_job_step.go
@@ -1,0 +1,87 @@
+package event_v2
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ovh/cds/engine/cache"
+	"github.com/ovh/cds/sdk"
+)
+
+// stepUpdateWindow bounds how often the progress of a single job is announced. A job made of quick
+// steps moves faster than a view can show, and every announcement costs a frame to each client
+// watching that run, so the announcements falling in the same window are collapsed into one.
+const stepUpdateWindow = time.Second
+
+var runJobStepUpdates = &stepUpdates{pending: make(map[string]*heldStepUpdate)}
+
+type heldStepUpdate struct {
+	runJob sdk.V2WorkflowRunJob
+	at     time.Time
+}
+
+// stepUpdates collapses the progress announcements of the jobs reporting to this API. An
+// announcement carries the whole run job rather than what changed in it, so the last one of a window
+// supersedes those it replaces and nothing is lost by holding the others back.
+type stepUpdates struct {
+	mutex sync.Mutex
+	// A job is present as soon as its window is open; its value is what is waiting for the end of
+	// that window, nil when nothing is.
+	pending map[string]*heldStepUpdate
+}
+
+// take reports whether the progress of a job is to be announced right away, which it is when its
+// window is closed. Otherwise it is held back until the window ends, taking the place of whatever
+// was already waiting.
+func (s *stepUpdates) take(rj sdk.V2WorkflowRunJob, at time.Time) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, windowIsOpen := s.pending[rj.ID]; windowIsOpen {
+		s.pending[rj.ID] = &heldStepUpdate{runJob: rj, at: at}
+		return false
+	}
+
+	s.pending[rj.ID] = nil
+	return true
+}
+
+// flush ends the current window and returns what was held back during it. A job that held nothing
+// back is forgotten, so that only the jobs that are moving are kept.
+func (s *stepUpdates) flush() []heldStepUpdate {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	held := make([]heldStepUpdate, 0, len(s.pending))
+	for id, update := range s.pending {
+		if update == nil {
+			delete(s.pending, id)
+			continue
+		}
+		held = append(held, *update)
+		s.pending[id] = nil
+	}
+	return held
+}
+
+// FlushRunJobStepUpdates announces the progress held back by the collapsing of the step updates. It
+// runs until the context is done.
+func FlushRunJobStepUpdates(ctx context.Context, store cache.Store) {
+	tick := time.NewTicker(stepUpdateWindow)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			for _, update := range runJobStepUpdates.flush() {
+				// Stamped with the moment the worker reported it, not the moment it is let through:
+				// a view drops an event older than the last one it applied to the same job, which is
+				// how an update held back past the end of its job is kept from overwriting it.
+				publishRunJobEvent(ctx, store, sdk.EventRunJobStepUpdated, update.runJob, update.at)
+			}
+		}
+	}
+}

--- a/engine/api/event_v2/event_run_job_step_test.go
+++ b/engine/api/event_v2/event_run_job_step_test.go
@@ -1,0 +1,69 @@
+package event_v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func stepUpdateOf(id string, steps ...string) sdk.V2WorkflowRunJob {
+	rj := sdk.V2WorkflowRunJob{ID: id, StepsStatus: sdk.JobStepsStatus{}}
+	for _, s := range steps {
+		rj.StepsStatus[s] = sdk.JobStepStatus{}
+	}
+	return rj
+}
+
+func TestStepUpdates_AnnouncesTheFirstOfAWindowAndTheLast(t *testing.T) {
+	s := &stepUpdates{pending: make(map[string]*heldStepUpdate)}
+	at := time.Now()
+
+	require.True(t, s.take(stepUpdateOf("job1", "one"), at), "the first update of a job opens its window and goes out")
+	require.False(t, s.take(stepUpdateOf("job1", "one", "two"), at.Add(time.Millisecond)), "an update of an open window is held back")
+	require.False(t, s.take(stepUpdateOf("job1", "one", "two", "three"), at.Add(2*time.Millisecond)), "and so is the next one")
+
+	held := s.flush()
+	require.Len(t, held, 1, "one announcement is held back per job, whatever the number of updates")
+	require.Len(t, held[0].runJob.StepsStatus, 3, "the last update supersedes the ones it replaces")
+	require.Equal(t, at.Add(2*time.Millisecond), held[0].at, "held back with the moment it was reported, not the moment it goes out")
+}
+
+func TestStepUpdates_KeepsTheJobsApart(t *testing.T) {
+	s := &stepUpdates{pending: make(map[string]*heldStepUpdate)}
+	at := time.Now()
+
+	require.True(t, s.take(stepUpdateOf("job1", "one"), at))
+	require.True(t, s.take(stepUpdateOf("job2", "one"), at), "a window is open per job, not for all of them")
+	require.False(t, s.take(stepUpdateOf("job1", "one", "two"), at))
+
+	held := s.flush()
+	require.Len(t, held, 1)
+	require.Equal(t, "job1", held[0].runJob.ID)
+}
+
+func TestStepUpdates_ForgetsAJobThatWentQuiet(t *testing.T) {
+	s := &stepUpdates{pending: make(map[string]*heldStepUpdate)}
+	at := time.Now()
+
+	require.True(t, s.take(stepUpdateOf("job1", "one"), at))
+
+	require.Empty(t, s.flush(), "nothing was held back during the window")
+	require.Empty(t, s.pending, "a job that held nothing back is forgotten with its window")
+
+	require.True(t, s.take(stepUpdateOf("job1", "one", "two"), at), "and its next update goes out right away")
+}
+
+func TestStepUpdates_ReopensTheWindowAfterAFlush(t *testing.T) {
+	s := &stepUpdates{pending: make(map[string]*heldStepUpdate)}
+	at := time.Now()
+
+	require.True(t, s.take(stepUpdateOf("job1", "one"), at))
+	require.False(t, s.take(stepUpdateOf("job1", "one", "two"), at))
+	require.Len(t, s.flush(), 1)
+
+	require.False(t, s.take(stepUpdateOf("job1", "one", "two", "three"), at), "the flush left a window open behind it")
+	require.Len(t, s.flush(), 1)
+}

--- a/engine/api/status.go
+++ b/engine/api/status.go
@@ -23,6 +23,18 @@ import (
 	"github.com/ovh/cds/sdk/telemetry"
 )
 
+const (
+	// queueMetricsInterval paces the queue metrics, which drive scheduling dashboards and alerting
+	// and therefore have to stay close to real time.
+	queueMetricsInterval = 9 * time.Second
+	// inventoryMetricsInterval paces the counts of what CDS holds. They move slowly and each of them
+	// is a full table scan, so they are refreshed at a rate that does not weigh on the database.
+	inventoryMetricsInterval = 5 * time.Minute
+	// inventoryMetricsQueryTimeout caps a single count. A count that cannot complete within it is
+	// worth losing rather than holding a connection for the next tick to pile onto.
+	inventoryMetricsQueryTimeout = 2 * time.Minute
+)
+
 // Status returns status, implements interface service.Service
 func (api *API) Status(ctx context.Context) *sdk.MonitoringStatus {
 	m := api.NewMonitoringStatus()
@@ -298,8 +310,15 @@ func (api *API) computeMetrics(ctx context.Context) {
 		log.Error(ctx, "api.computeMetrics> unable to tag observability context: %v", err)
 	}
 
-	api.GoRoutines.RunWithRestart(ctx, "api.computeMetrics", func(ctx context.Context) {
-		tick := time.NewTicker(9 * time.Second).C
+	api.computeQueueMetrics(ctx)
+	api.computeInventoryMetrics(ctx)
+}
+
+// computeQueueMetrics refreshes what a scheduling dashboard reads: the queues, which are small hot
+// tables filtered on an indexed status, and the state of the process itself.
+func (api *API) computeQueueMetrics(ctx context.Context) {
+	api.GoRoutines.RunWithRestart(ctx, "api.computeQueueMetrics", func(ctx context.Context) {
+		tick := time.NewTicker(queueMetricsInterval).C
 		for {
 			select {
 			case <-ctx.Done():
@@ -308,27 +327,7 @@ func (api *API) computeMetrics(ctx context.Context) {
 					return
 				}
 			case <-tick:
-				// Common metrics
-				api.countMetric(ctx, api.Metrics.nbUsers, "SELECT COUNT(1) FROM \"authentified_user\"")
-				api.countMetric(ctx, api.Metrics.nbProjects, "SELECT COUNT(1) FROM project")
-				api.countMetric(ctx, api.Metrics.nbGroups, "SELECT COUNT(1) FROM \"group\"")
 				telemetry.Record(ctx, api.Metrics.DatabaseConns, int64(api.DBConnectionFactory.DB().Stats().OpenConnections))
-
-				// V1 metrics
-				api.countMetric(ctx, api.Metrics.nbApplications, "SELECT COUNT(1) FROM application")
-				api.countMetric(ctx, api.Metrics.nbPipelines, "SELECT COUNT(1) FROM pipeline")
-				api.countMetric(ctx, api.Metrics.nbWorkflows, "SELECT COUNT(1) FROM workflow")
-				api.countMetric(ctx, api.Metrics.nbArtifacts, "SELECT COUNT(1) FROM workflow_node_run_artifacts")
-				api.countMetric(ctx, api.Metrics.nbWorkerModels, "SELECT COUNT(1) FROM worker_model")
-				api.countMetric(ctx, api.Metrics.nbWorkflowRuns, "SELECT COUNT(1) FROM workflow_run")
-				api.countMetric(ctx, api.Metrics.nbWorkflowNodeRuns, "SELECT COUNT(1) FROM workflow_node_run")
-				api.countMetric(ctx, api.Metrics.nbMaxWorkersBuilding, "SELECT COUNT(1) FROM worker where status = 'Building'")
-				api.countMetric(ctx, api.Metrics.RunResultSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NOT NULL")
-				api.countMetric(ctx, api.Metrics.RunResultToSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NULL")
-				api.countMetric(ctx, api.Metrics.RunResultSynchronizedError, "SELECT COUNT(1) FROM workflow_run_result where sync ? 'error'")
-
-				// V2 metrics
-				api.countMetric(ctx, api.Metrics.nbWorkflowsAsCodeV2, "select count(distinct(project_repository_id,name)) from entity where type = 'Workflow'")
 
 				// Queue common
 				now := time.Now()
@@ -380,10 +379,59 @@ func (api *API) computeMetrics(ctx context.Context) {
 	})
 }
 
+// computeInventoryMetrics counts what CDS holds. None of those counts can be answered from an index:
+// they are sequential scans of the largest tables of the instance, so they run on their own slow
+// ticker rather than with the queues. Refreshing them every few seconds kept a connection of every
+// API replica permanently busy scanning, and evicted from the shared buffers the pages every other
+// query needs.
+func (api *API) computeInventoryMetrics(ctx context.Context) {
+	api.GoRoutines.RunWithRestart(ctx, "api.computeInventoryMetrics", func(ctx context.Context) {
+		tick := time.NewTicker(inventoryMetricsInterval).C
+		for {
+			select {
+			case <-ctx.Done():
+				if ctx.Err() != nil {
+					log.Error(ctx, "Exiting metrics.Initialize: %v", ctx.Err())
+					return
+				}
+			case <-tick:
+				// Common metrics
+				api.countMetric(ctx, api.Metrics.nbUsers, "SELECT COUNT(1) FROM \"authentified_user\"")
+				api.countMetric(ctx, api.Metrics.nbProjects, "SELECT COUNT(1) FROM project")
+				api.countMetric(ctx, api.Metrics.nbGroups, "SELECT COUNT(1) FROM \"group\"")
+
+				// V1 metrics
+				api.countMetric(ctx, api.Metrics.nbApplications, "SELECT COUNT(1) FROM application")
+				api.countMetric(ctx, api.Metrics.nbPipelines, "SELECT COUNT(1) FROM pipeline")
+				api.countMetric(ctx, api.Metrics.nbWorkflows, "SELECT COUNT(1) FROM workflow")
+				api.countMetric(ctx, api.Metrics.nbArtifacts, "SELECT COUNT(1) FROM workflow_node_run_artifacts")
+				api.countMetric(ctx, api.Metrics.nbWorkerModels, "SELECT COUNT(1) FROM worker_model")
+				api.countMetric(ctx, api.Metrics.nbWorkflowRuns, "SELECT COUNT(1) FROM workflow_run")
+				api.countMetric(ctx, api.Metrics.nbWorkflowNodeRuns, "SELECT COUNT(1) FROM workflow_node_run")
+				api.countMetric(ctx, api.Metrics.nbMaxWorkersBuilding, "SELECT COUNT(1) FROM worker where status = 'Building'")
+				api.countMetric(ctx, api.Metrics.RunResultSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NOT NULL")
+				api.countMetric(ctx, api.Metrics.RunResultToSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NULL")
+				api.countMetric(ctx, api.Metrics.RunResultSynchronizedError, "SELECT COUNT(1) FROM workflow_run_result where sync ? 'error'")
+
+				// V2 metrics
+				api.countMetric(ctx, api.Metrics.nbWorkflowsAsCodeV2, "select count(distinct(project_repository_id,name)) from entity where type = 'Workflow'")
+			}
+		}
+	})
+}
+
 func (api *API) countMetric(ctx context.Context, v *stats.Int64Measure, query string) {
-	n, err := api.mustDB().SelectInt(query)
+	// Bounded so that a scan that outgrew the instance releases its connection instead of holding one
+	// of the few the pool has until it completes.
+	ctxQuery, cancel := context.WithTimeout(ctx, inventoryMetricsQueryTimeout)
+	defer cancel()
+
+	n, err := api.mustDBWithCtx(ctxQuery).SelectInt(query)
 	if err != nil {
+		// Reporting nothing leaves the last count in place. Reporting the zero of a count that did
+		// not happen reads as the disappearance of everything it counts.
 		log.Warn(ctx, "metrics>Errors while fetching count %s: %v", query, err)
+		return
 	}
 	telemetry.Record(ctx, v, n)
 }

--- a/engine/websocket/client.go
+++ b/engine/websocket/client.go
@@ -5,12 +5,26 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/rockbears/log"
 	"github.com/tevino/abool"
 
 	"github.com/ovh/cds/sdk"
+)
+
+const (
+	// writeTimeout bounds a single write to a client. Without it a client that stopped reading holds
+	// the goroutine writing to it for as long as it likes. A connection whose write deadline was
+	// exceeded is left in an undefined state, so such a client is dropped rather than written to
+	// again.
+	writeTimeout = 10 * time.Second
+	// maxPendingWrites bounds the writes waiting their turn on one client. Each of them holds a
+	// goroutine and the message it carries until the client reads, so a client falling behind what it
+	// subscribed to is dropped instead of being waited for.
+	maxPendingWrites = 64
 )
 
 func NewClient(conn *websocket.Conn) Client {
@@ -32,6 +46,7 @@ type Client interface {
 type CommonClient struct {
 	uuid      string
 	mutex     sync.Mutex
+	pending   atomic.Int64
 	conn      *websocket.Conn
 	isClosed  *abool.AtomicBool
 	onMessage func([]byte)
@@ -48,6 +63,12 @@ func (c *CommonClient) Send(m interface{}) (err error) {
 		}
 	}()
 
+	if pending := c.pending.Add(1); pending > maxPendingWrites {
+		c.pending.Add(-1)
+		return sdk.WithStack(fmt.Errorf("client %s is too far behind, %d writes pending", c.uuid, pending-1))
+	}
+	defer c.pending.Add(-1)
+
 	// Lock avoid parallel write on same conn
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -56,14 +77,20 @@ func (c *CommonClient) Send(m interface{}) (err error) {
 		return sdk.WithStack(fmt.Errorf("client deconnected"))
 	}
 
+	if err := c.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return sdk.WithStack(err)
+	}
+
 	if err := c.conn.WriteJSON(m); err != nil {
+		// A write that failed leaves the connection in an undefined state, so the error is returned
+		// whatever it is: the caller drops the client rather than writing to it again.
 		// ErrCloseSent is returned when the application writes a message to the connection after sending a close message.
-		if err == websocket.ErrCloseSent || strings.Contains(err.Error(), "use of closed network connection") {
-			return sdk.WithStack(err)
+		if err != websocket.ErrCloseSent && !strings.Contains(err.Error(), "use of closed network connection") {
+			err = sdk.WrapError(err, "can't send to client %s", c.uuid)
+			ctx := sdk.ContextWithStacktrace(context.Background(), err)
+			log.Error(ctx, "%v", err)
 		}
-		err = sdk.WrapError(err, "can't send to client %s", c.uuid)
-		ctx := sdk.ContextWithStacktrace(context.Background(), err)
-		log.Error(ctx, "%v", err)
+		return sdk.WithStack(err)
 	}
 
 	return nil

--- a/engine/websocket/client_test.go
+++ b/engine/websocket/client_test.go
@@ -1,0 +1,32 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tevino/abool"
+)
+
+func TestCommonClient_Send_RefusesToQueueBehindAClientThatFellBehind(t *testing.T) {
+	c := &CommonClient{uuid: "client", isClosed: abool.NewBool(false)}
+
+	// Stands in for a write in progress on a client that stopped reading: every Send below queues
+	// behind it, as they would behind a write waiting on the socket.
+	c.mutex.Lock()
+
+	for i := 0; i < maxPendingWrites; i++ {
+		go func() { _ = c.Send("message") }()
+	}
+	require.Eventually(t, func() bool { return c.pending.Load() == maxPendingWrites }, 5*time.Second, time.Millisecond,
+		"the writes of a client that does not read should be waiting their turn")
+
+	err := c.Send("one too many")
+	require.Error(t, err, "a write past the bound is refused rather than held")
+	require.Contains(t, err.Error(), "too far behind")
+	require.Equal(t, int64(maxPendingWrites), c.pending.Load(), "a refused write does not count as pending")
+
+	c.mutex.Unlock()
+	require.Eventually(t, func() bool { return c.pending.Load() == 0 }, 5*time.Second, time.Millisecond,
+		"the writes waiting are released once the client is written to again")
+}

--- a/sdk/goroutine.go
+++ b/sdk/goroutine.go
@@ -168,16 +168,23 @@ func (m *GoRoutines) GetStatus() []MonitoringStatusLine {
 	return lines
 }
 
-func (m *GoRoutines) exec(g *GoRoutine) {
+// goRoutineHostname is read once: it does not change while the process runs, and reading it is a
+// system call that Exec used to make on the caller, for every goroutine it started.
+var goRoutineHostname = sync.OnceValue(func() string {
 	hostname, _ := os.Hostname()
+	return hostname
+})
 
+func (m *GoRoutines) exec(g *GoRoutine) {
 	go func(ctx context.Context) {
 		ctx = context.WithValue(ctx, cdslog.Goroutine, g.Name)
 
+		// No goroutine id among the labels: deriving one means walking the stack of the goroutine
+		// that is starting, and a label unique to each of them gives a profile as many groups as
+		// there are goroutines, which is the opposite of what grouping is for.
 		labels := pprof.Labels(
 			"goroutine-name", g.Name,
-			"goroutine-hostname", hostname,
-			"goroutine-id", fmt.Sprintf("%d", GoroutineID()),
+			"goroutine-hostname", goRoutineHostname(),
 		)
 		goroutineCtx := pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(goroutineCtx)
@@ -187,7 +194,7 @@ func (m *GoRoutines) exec(g *GoRoutine) {
 				buf := make([]byte, 1<<16)
 				buf = buf[:runtime.Stack(buf, false)]
 				ctx = context.WithValue(ctx, cdslog.Stacktrace, string(buf))
-				log.Error(ctx, "[PANIC][%s] %s failed", hostname, g.Name)
+				log.Error(ctx, "[PANIC][%s] %s failed", goRoutineHostname(), g.Name)
 			}
 			g.mutex.Lock()
 			g.Active = false

--- a/ui/specs/workflow-run-graph.md
+++ b/ui/specs/workflow-run-graph.md
@@ -418,6 +418,11 @@ Events of an attempt other than the displayed one are ignored. When the run is r
 somewhere else, the view follows the new attempt, unless the user was deliberately looking at a
 previous one.
 
+**Steps moving faster than the eye.** The progress of a job is announced at most once per second. A
+job made of quick steps would otherwise send more frames than a view can show, to every client
+watching that run. Each announcement carries the whole job rather than what changed in it, so the one
+that is sent stands for those it replaces, and nothing is lost.
+
 **What events do not carry.** Run infos and job infos are not published as events: they are read again
 when the run or one of its jobs changes state, and at most once per interval for a job going through
 many steps.


### PR DESCRIPTION
Stacked on #7826 Three things the API repeated more often than it needed to.
  No behaviour change.

  - **Metrics** — the counts of what CDS holds are sequential scans of the largest tables,
    and they ran every 9 seconds on every replica, back to back once a pass outlasted the
    tick. They move to their own 5-minute ticker; the queue metrics keep the 9 seconds they
    need for scheduling. Each count is bounded by a timeout so it gives its connection back,
    and a count that failed now reports nothing rather than a zero that reads as the
    disappearance of what it counts.

  - **Step events** — the progress of a job is announced at most once per second. An
    announcement carries the whole run job rather than what changed in it, so the last one of
    a window stands for those it replaces and nothing is lost. It keeps the moment it was
    reported, not the moment it goes out, so one held back past the end of its job cannot
    overwrite it.

  - **Websocket fan-out** — starting a goroutine no longer makes a system call for the
    hostname nor walks its stack for an id, both only to build pprof labels, and both paid
    once per client per event. A write to a client now has a deadline, a bound on the writes
    waiting behind it, and returns its failures, so a client that stopped reading is dropped
    instead of holding goroutines.

@ovh/cds
