### PR TITLE
perf(api,ui): stop reading the database for every event of every client

### DIFF
--- a/engine/api/v2_websocket.go
+++ b/engine/api/v2_websocket.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ovh/cds/engine/api/rbac"
 	"github.com/ovh/cds/engine/api/region"
-	"github.com/ovh/cds/engine/api/workflow_v2"
 	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/engine/websocket"
@@ -89,6 +88,62 @@ type websocketV2ClientData struct {
 	AuthConsumer sdk.AuthUserConsumer
 	mutex        sync.Mutex
 	filters      webSocketV2Filters
+	accessMutex  sync.Mutex
+	access       *runJobAccess
+}
+
+// runJobAccessTTL bounds how long the permissions of a client are held before being read again. A
+// right taken away reaches an open connection within that delay; registering a filter checks the
+// permissions of the moment anyway.
+const runJobAccessTTL = 30 * time.Second
+
+// runJobAccess is what a client may see of the job events: the projects it can read and the regions
+// it can execute on. It follows the consumer, not the event, so it is read once for a while rather
+// than for each of the job events of the instance, of which a single job produces eight.
+type runJobAccess struct {
+	projectKeys sdk.StringSlice
+	regionNames sdk.StringSlice
+	readAt      time.Time
+}
+
+func (c *websocketV2ClientData) runJobEventAccess(ctx context.Context, db gorp.SqlExecutor) (*runJobAccess, error) {
+	// Held for the read so that a burst of events on a client that has nothing cached asks the
+	// database once instead of once per event.
+	c.accessMutex.Lock()
+	defer c.accessMutex.Unlock()
+
+	if c.access != nil && time.Since(c.access.readAt) < runJobAccessTTL {
+		return c.access, nil
+	}
+
+	userID := c.AuthConsumer.AuthConsumerUser.AuthentifiedUserID
+
+	projectKeys, err := rbac.LoadAllProjectKeysAllowed(ctx, db, sdk.ProjectRoleRead, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	rbacRegions, err := rbac.LoadRegionIDsByRoleAndUserID(ctx, db, sdk.RegionRoleExecute, userID)
+	if err != nil {
+		return nil, err
+	}
+	regionIDs := sdk.StringSlice{}
+	for _, r := range rbacRegions {
+		regionIDs = append(regionIDs, r.RegionID)
+	}
+	regionIDs.Unique()
+
+	allowedRegions, err := region.LoadRegionByIDs(ctx, db, regionIDs)
+	if err != nil {
+		return nil, err
+	}
+	regionNames := sdk.StringSlice{}
+	for _, r := range allowedRegions {
+		regionNames = append(regionNames, r.Name)
+	}
+
+	c.access = &runJobAccess{projectKeys: projectKeys, regionNames: regionNames, readAt: time.Now()}
+	return c.access, nil
 }
 
 func (c *websocketV2ClientData) updateEventFilters(ctx context.Context, db gorp.SqlExecutor, cache cache.Store, msg []byte) error {
@@ -139,7 +194,10 @@ func (c *websocketV2ClientData) updateEventFilters(ctx context.Context, db gorp.
 }
 
 // For some event we need to check if it should be sent or not depending permissions or filters
-func (c *websocketV2ClientData) eventPostCheck(ctx context.Context, db gorp.SqlExecutor, cache cache.Store, event sdk.FullEventV2) (result bool, err error) {
+//
+// run is the run the event carries, read once for every client the event is offered to, and nil
+// when the event carries none or it could not be read.
+func (c *websocketV2ClientData) eventPostCheck(ctx context.Context, db gorp.SqlExecutor, cache cache.Store, event sdk.FullEventV2, run *sdk.EventWorkflowRunPayload) (result bool, err error) {
 	log.Debug(ctx, "websocketV2ClientData.eventPostCheck> running eventPostCheck for event.Type: %q", string(event.Type))
 	defer log.Debug(ctx, "websocketV2ClientData.eventPostCheck> result eventPostCheck for event.Type: %q is %t", string(event.Type), result)
 
@@ -150,41 +208,17 @@ func (c *websocketV2ClientData) eventPostCheck(ctx context.Context, db gorp.SqlE
 			return true, nil
 		}
 
-		pKeys, err := rbac.LoadAllProjectKeysAllowed(ctx, db, sdk.ProjectRoleRead, c.AuthConsumer.AuthConsumerUser.AuthentifiedUserID)
+		access, err := c.runJobEventAccess(ctx, db)
 		if err != nil {
 			return false, err
 		}
-		if len(pKeys) == 0 || !pKeys.Contains(event.ProjectKey) {
-			return false, nil
-		}
-
-		rbacRegions, err := rbac.LoadRegionIDsByRoleAndUserID(ctx, db, sdk.RegionRoleExecute, c.AuthConsumer.AuthConsumerUser.AuthentifiedUserID)
-		if err != nil {
-			return false, err
-		}
-		regionIDs := sdk.StringSlice{}
-		for _, r := range rbacRegions {
-			regionIDs = append(regionIDs, r.RegionID)
-		}
-		regionIDs.Unique()
-
-		allowedRegions, err := region.LoadRegionByIDs(ctx, db, regionIDs)
-		if err != nil {
-			return false, err
-		}
-		for _, r := range allowedRegions {
-			if r.Name == event.Region {
-				return true, nil
-			}
-		}
-
-		return false, nil
+		return access.projectKeys.Contains(event.ProjectKey) && access.regionNames.Contains(event.Region), nil
 	}
 
 	// Post check to return only runs according query filters
 	if event.Type == sdk.EventRunCrafted || event.Type == sdk.EventRunBuilding || event.Type == sdk.EventRunEnded || event.Type == sdk.EventRunRestart {
 		filter := c.filters.GetFirstByType(sdk.WebsocketV2FilterTypeProjectRuns)
-		if filter == nil {
+		if filter == nil || run == nil {
 			return false, nil
 		}
 
@@ -192,18 +226,20 @@ func (c *websocketV2ClientData) eventPostCheck(ctx context.Context, db gorp.SqlE
 		if err != nil {
 			return false, sdk.WrapError(err, "cannot parse project_runs_params filter")
 		}
-		filters, offset, limit, sort := parseWorkflowRunsSearchV2Query(query)
+		filters, offset, _, _ := parseWorkflowRunsSearchV2Query(query)
 
-		runs, err := workflow_v2.SearchRuns(ctx, db, filter.ProjectKey, filters, offset, limit, sort)
-		if err != nil {
-			return false, sdk.WrapError(err, "unable to search runs")
+		// The filters are matched against the run the event carries. Nothing is read: what is asked
+		// here is whether the run is one the client asked to see, and whether the client may read
+		// the project at all was settled when it registered this filter.
+		//
+		// The page is not part of the answer, where replaying the search made it one. A client
+		// reading further down the list is pushed nothing, since the only place a run list has for a
+		// run arriving is its top; on the first page every run the search matches is pushed, and
+		// where it belongs among those displayed is for the list to decide.
+		if offset > 0 {
+			return false, nil
 		}
-		for i := range runs {
-			if runs[i].ID == event.WorkflowRunID {
-				return true, nil
-			}
-		}
-		return false, nil
+		return run.ProjectKey == filter.ProjectKey && filters.MatchesRun(*run), nil
 	}
 
 	return false, nil
@@ -291,6 +327,19 @@ func (a *API) websocketV2OnMessage(e sdk.FullEventV2) {
 		return
 	}
 
+	// The run an event carries is read once here rather than by each of the clients it is offered
+	// to: it is what the filters of a run list are matched against.
+	var run *sdk.EventWorkflowRunPayload
+	if e.Type == sdk.EventRunCrafted || e.Type == sdk.EventRunBuilding || e.Type == sdk.EventRunEnded || e.Type == sdk.EventRunRestart {
+		var payload sdk.EventWorkflowRunPayload
+		if err := sdk.JSONUnmarshal(e.Payload, &payload); err != nil {
+			ctx := sdk.ContextWithStacktrace(context.TODO(), err)
+			log.Warn(ctx, "api.websocketV2OnMessage> cannot read the run of a %s event: %v", e.Type, err)
+		} else {
+			run = &payload
+		}
+	}
+
 	clientIDs := a.WSV2Server.server.ClientIDs()
 	// Randomize the order of client to prevent the old client to always received new events in priority
 	rand.Shuffle(len(clientIDs), func(i, j int) { clientIDs[i], clientIDs[j] = clientIDs[j], clientIDs[i] })
@@ -317,7 +366,7 @@ func (a *API) websocketV2OnMessage(e sdk.FullEventV2) {
 			}
 
 			if needPostCheck {
-				allowed, err := c.eventPostCheck(ctx, a.mustDBWithCtx(ctx), a.Cache, e)
+				allowed, err := c.eventPostCheck(ctx, a.mustDBWithCtx(ctx), a.Cache, e, run)
 				if err != nil {
 					err = sdk.WrapError(err, "unable to validate event post check for client %s with consumer id: %s", clientID, c.AuthConsumer.ID)
 					ctx = sdk.ContextWithStacktrace(ctx, err)

--- a/engine/api/v2_websocket_access_test.go
+++ b/engine/api/v2_websocket_access_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func clientWithAccess(readAt time.Time) *websocketV2ClientData {
+	return &websocketV2ClientData{
+		AuthConsumer: sdk.AuthUserConsumer{
+			AuthConsumerUser: sdk.AuthUserConsumerData{
+				AuthentifiedUser:   &sdk.AuthentifiedUser{Ring: sdk.UserRingUser},
+				AuthentifiedUserID: "user-1",
+			},
+		},
+		access: &runJobAccess{
+			projectKeys: sdk.StringSlice{"KEY"},
+			regionNames: sdk.StringSlice{"default"},
+			readAt:      readAt,
+		},
+	}
+}
+
+// The database given to the check is nil: reading the permissions again would panic on it, so these
+// answers can only come from what the client already holds.
+func TestEventPostCheck_JobEventAnsweredFromTheHeldAccess(t *testing.T) {
+	c := clientWithAccess(time.Now())
+
+	for _, tc := range []struct {
+		name    string
+		event   sdk.FullEventV2
+		allowed bool
+	}{
+		{"a project it reads, on a region it runs on", sdk.FullEventV2{Type: sdk.EventRunJobBuilding, ProjectKey: "KEY", Region: "default"}, true},
+		{"another project", sdk.FullEventV2{Type: sdk.EventRunJobBuilding, ProjectKey: "OTHER", Region: "default"}, false},
+		{"another region", sdk.FullEventV2{Type: sdk.EventRunJobBuilding, ProjectKey: "KEY", Region: "gpu"}, false},
+		{"no region on the event", sdk.FullEventV2{Type: sdk.EventRunJobEnded, ProjectKey: "KEY"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			allowed, err := c.eventPostCheck(context.TODO(), nil, nil, tc.event, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.allowed, allowed)
+		})
+	}
+}
+
+// Past the delay the permissions are read again rather than trusted. The nil database makes that
+// read fail, which is what tells the two apart: an event that the held access would have allowed is
+// refused instead of being answered from it.
+func TestEventPostCheck_JobEventReadsTheAccessAgainOnceItAged(t *testing.T) {
+	c := clientWithAccess(time.Now().Add(-runJobAccessTTL - time.Second))
+
+	allowed, err := c.eventPostCheck(context.TODO(), nil, nil,
+		sdk.FullEventV2{Type: sdk.EventRunJobBuilding, ProjectKey: "KEY", Region: "default"}, nil)
+	require.Error(t, err)
+	require.False(t, allowed)
+}
+
+// A maintainer sees every job event, and is not worth a lookup.
+func TestEventPostCheck_JobEventOfAMaintainerNeedsNothing(t *testing.T) {
+	c := clientWithAccess(time.Now().Add(-runJobAccessTTL - time.Second))
+	c.AuthConsumer.AuthConsumerUser.AuthentifiedUser.Ring = sdk.UserRingMaintainer
+
+	allowed, err := c.eventPostCheck(context.TODO(), nil, nil,
+		sdk.FullEventV2{Type: sdk.EventRunJobBuilding, ProjectKey: "OTHER", Region: "gpu"}, nil)
+	require.NoError(t, err)
+	require.True(t, allowed)
+}

--- a/engine/api/v2_workflow_run_match_test.go
+++ b/engine/api/v2_workflow_run_match_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/engine/api/test/assets"
+	"github.com/ovh/cds/engine/api/workflow_v2"
+	"github.com/ovh/cds/sdk"
+)
+
+// MatchesRun answers, without reading anything, the question a websocket client asks of every run
+// event: is this run one of those it asked to see. It stands for a search, so it has to agree with
+// it, and this is what holds the two together — every filter is run through both.
+func TestMatchesRun_AgreesWithTheSearch(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+
+	admin, _ := assets.InsertAdminUser(t, db)
+	proj := assets.InsertTestProject(t, db, api.Cache, sdk.RandomString(10), sdk.RandomString(10))
+	vcsServer := assets.InsertTestVCSProject(t, db, proj.ID, "github", "github")
+	repo := assets.InsertTestProjectRepository(t, db, proj.Key, vcsServer.ID, sdk.RandomString(10))
+	otherRepo := assets.InsertTestProjectRepository(t, db, proj.Key, vcsServer.ID, sdk.RandomString(10))
+
+	newRun := func(workflowName string, mutate func(*sdk.V2WorkflowRun)) sdk.V2WorkflowRun {
+		wr := sdk.V2WorkflowRun{
+			ProjectKey:   proj.Key,
+			VCSServerID:  vcsServer.ID,
+			VCSServer:    vcsServer.Name,
+			RepositoryID: repo.ID,
+			Repository:   repo.Name,
+			WorkflowName: workflowName,
+			WorkflowSha:  "123",
+			WorkflowRef:  "refs/heads/master",
+			RunNumber:    1,
+			Started:      time.Now(),
+			LastModified: time.Now(),
+			Status:       sdk.V2WorkflowRunStatusSuccess,
+			Initiator:    &sdk.V2Initiator{UserID: admin.ID, User: admin.Initiator()},
+			RunEvent:     sdk.V2WorkflowRunEvent{},
+			Contexts: sdk.WorkflowRunContext{
+				Git: sdk.GitContext{
+					Server:        "github",
+					Repository:    "ovh/cds",
+					Ref:           "refs/heads/main",
+					Sha:           "abcdef123456",
+					Author:        "jdoe",
+					CommitMessage: "a commit that says something",
+				},
+				CDS: sdk.CDSContext{Version: "1.2.3+cds.1"},
+			},
+			WorkflowData: sdk.V2WorkflowRunData{Workflow: sdk.V2Workflow{}},
+		}
+		if mutate != nil {
+			mutate(&wr)
+		}
+		require.NoError(t, workflow_v2.InsertRun(context.Background(), db, &wr))
+		return wr
+	}
+
+	runs := []sdk.V2WorkflowRun{
+		newRun("wf-plain", nil),
+		newRun("wf-failed", func(r *sdk.V2WorkflowRun) { r.Status = sdk.V2WorkflowRunStatusFail }),
+		newRun("wf-dev", func(r *sdk.V2WorkflowRun) {
+			r.Contexts.Git.Ref = "refs/heads/dev"
+			r.Contexts.Git.Sha = "999999999999"
+			r.Contexts.Git.Author = "asmith"
+			r.Contexts.Git.CommitMessage = "another message entirely"
+		}),
+		newRun("wf-other-repo", func(r *sdk.V2WorkflowRun) {
+			r.RepositoryID = otherRepo.ID
+			r.Repository = otherRepo.Name
+			r.Contexts.Git.Repository = "ovh/other"
+		}),
+		newRun("wf-workflow-ref", func(r *sdk.V2WorkflowRun) { r.WorkflowRef = "refs/heads/dev" }),
+		newRun("wf-templated", func(r *sdk.V2WorkflowRun) {
+			r.Contexts.CDS.WorkflowTemplateVCSServer = "github"
+			r.Contexts.CDS.WorkflowTemplateRepository = "ovh/templates"
+			r.Contexts.CDS.WorkflowTemplate = "my-template"
+		}),
+		newRun("wf-annotated", func(r *sdk.V2WorkflowRun) {
+			r.Annotations = sdk.WorkflowRunAnnotations{"release": "1.2.3"}
+		}),
+		newRun("wf-from-vcs", func(r *sdk.V2WorkflowRun) {
+			r.Initiator = &sdk.V2Initiator{VCS: "github", VCSUsername: "mybot"}
+		}),
+	}
+
+	for _, tc := range []struct {
+		name    string
+		filters workflow_v2.SearchRunsFilters
+	}{
+		{"no filter", workflow_v2.SearchRunsFilters{}},
+		{"workflow", workflow_v2.SearchRunsFilters{Workflows: []string{vcsServer.Name + "/" + repo.Name + "/wf-plain"}}},
+		{"several workflows", workflow_v2.SearchRunsFilters{Workflows: []string{
+			vcsServer.Name + "/" + repo.Name + "/wf-plain",
+			vcsServer.Name + "/" + repo.Name + "/wf-failed",
+		}}},
+		{"status", workflow_v2.SearchRunsFilters{Status: []string{string(sdk.V2WorkflowRunStatusFail)}}},
+		{"git ref", workflow_v2.SearchRunsFilters{Refs: []string{"refs/heads/dev"}}},
+		{"workflow ref", workflow_v2.SearchRunsFilters{WorkflowRefs: []string{"refs/heads/dev"}}},
+		{"run repository", workflow_v2.SearchRunsFilters{Repositories: []string{"github/ovh/cds"}}},
+		{"workflow repository", workflow_v2.SearchRunsFilters{WorkflowRepositories: []string{vcsServer.Name + "/" + otherRepo.Name}}},
+		{"commit author", workflow_v2.SearchRunsFilters{Authors: []string{"asmith"}}},
+		{"commit", workflow_v2.SearchRunsFilters{Commits: []string{"abcdef123456"}}},
+		{"unmatched commit", workflow_v2.SearchRunsFilters{Commits: []string{"000000000000"}}},
+		{"template", workflow_v2.SearchRunsFilters{Templates: []string{"github/ovh/templates/my-template"}}},
+		{"annotation", workflow_v2.SearchRunsFilters{Annotations: []string{"release:1.2.3"}}},
+		{"unmatched annotation", workflow_v2.SearchRunsFilters{Annotations: []string{"release:9.9.9"}}},
+		{"actor", workflow_v2.SearchRunsFilters{Actors: []string{admin.Username}}},
+		{"actor of a run started from a vcs", workflow_v2.SearchRunsFilters{Actors: []string{"mybot"}}},
+		{"two filters", workflow_v2.SearchRunsFilters{
+			Status: []string{string(sdk.V2WorkflowRunStatusSuccess)},
+			Refs:   []string{"refs/heads/main"},
+		}},
+
+		// Free text, which the database matches over a concatenation of the run it builds itself.
+		{"free text on the workflow name", workflow_v2.SearchRunsFilters{Query: "wf-dev"}},
+		{"free text on a commit message", workflow_v2.SearchRunsFilters{Query: "entirely"}},
+		{"free text on the version", workflow_v2.SearchRunsFilters{Query: "1.2.3+cds.1"}},
+		{"free text on an annotation", workflow_v2.SearchRunsFilters{Query: "release:1.2.3"}},
+		{"free text on the run number", workflow_v2.SearchRunsFilters{Query: "wf-plain#1"}},
+		{"free text of several words", workflow_v2.SearchRunsFilters{Query: "wf- message"}},
+		{"free text matching nothing", workflow_v2.SearchRunsFilters{Query: "nowhere"}},
+		{"free text next to a filter", workflow_v2.SearchRunsFilters{
+			Status: []string{string(sdk.V2WorkflowRunStatusSuccess)},
+			Query:  "wf-",
+		}},
+		{"free text wildcards are matched literally", workflow_v2.SearchRunsFilters{Query: "%"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Every run of the project fits in the page: what is compared is the filters, not the
+			// paging, which the match leaves to the list.
+			found, err := workflow_v2.SearchRuns(context.Background(), db, proj.Key, tc.filters, 0, 100, "")
+			require.NoError(t, err)
+
+			selected := make(map[string]bool, len(found))
+			for i := range found {
+				selected[found[i].ID] = true
+			}
+
+			for i := range runs {
+				payload, err := sdk.NewEventWorkflowRunPayload(runs[i], nil, nil)
+				require.NoError(t, err)
+				require.Equal(t, selected[runs[i].ID], tc.filters.MatchesRun(*payload),
+					"run %s", runs[i].WorkflowName)
+			}
+		})
+	}
+}

--- a/engine/api/workflow_v2/run_search_match.go
+++ b/engine/api/workflow_v2/run_search_match.go
@@ -1,0 +1,138 @@
+package workflow_v2
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/ovh/cds/sdk"
+)
+
+// MatchesRun reports whether the given run is one the filters select. It is the in-memory twin of
+// runQueryFilters and runQueryAnnotationFilters, written in the same order so that the two can be
+// read side by side, and held to them by TestMatchesRun_AgreesWithTheSearch.
+//
+// An event carries the whole run, so answering whether that run belongs to the list a websocket
+// client is watching asks nothing of the database. Which is all that is being asked there: whether
+// the client may read the project at all was settled when it registered its filter.
+func (s SearchRunsFilters) MatchesRun(run sdk.EventWorkflowRunPayload) bool {
+	if len(s.Workflows) > 0 && !matches(s.Workflows, strings.Join([]string{run.VCSServer, run.Repository, run.WorkflowName}, "/")) {
+		return false
+	}
+	if len(s.Actors) > 0 && !matchesContext(s.Actors, actorOf(run)) {
+		return false
+	}
+	if len(s.Status) > 0 && !matches(s.Status, string(run.Status)) {
+		return false
+	}
+	if len(s.Refs) > 0 && !matchesContext(s.Refs, run.Contexts.Git.Ref) {
+		return false
+	}
+	if len(s.WorkflowRefs) > 0 && !matches(s.WorkflowRefs, run.WorkflowRef) {
+		return false
+	}
+	if len(s.Repositories) > 0 && !matchesContext(s.Repositories, contextPath(run.Contexts.Git.Server, run.Contexts.Git.Repository)) {
+		return false
+	}
+	if len(s.WorkflowRepositories) > 0 && !matches(s.WorkflowRepositories, strings.Join([]string{run.VCSServer, run.Repository}, "/")) {
+		return false
+	}
+	if len(s.Authors) > 0 && !matchesContext(s.Authors, run.Contexts.Git.Author) {
+		return false
+	}
+	if len(s.Commits) > 0 && !matchesContext(s.Commits, run.Contexts.Git.Sha) {
+		return false
+	}
+	if len(s.Templates) > 0 && !matchesContext(s.Templates, contextPath(run.Contexts.CDS.WorkflowTemplateVCSServer, run.Contexts.CDS.WorkflowTemplateRepository, run.Contexts.CDS.WorkflowTemplate)) {
+		return false
+	}
+	// Every annotation asked for has to be carried by the run, which is what the array containment
+	// of the query means. The pairs are compared whole, as they are there, so a value holding a
+	// colon is no different from any other.
+	for _, annotation := range s.Annotations {
+		var found bool
+		for k, v := range run.Annotations {
+			if k+":"+v == annotation {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	// Every word of a free text search has to be found, in any order, anywhere in the text the
+	// search reads of a run.
+	if words := sdk.SearchQueryWords(s.Query); len(words) > 0 {
+		text := strings.ToLower(runSearchableText(run))
+		for _, w := range words {
+			if !strings.Contains(text, w) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// runSearchableText is the text a free text search reads of a run, the twin of
+// runQuerySearchableText. The parts are joined the same way and in the same order; a part the run
+// does not carry is empty here where the query leaves it out, which changes nothing to the words
+// found in the result.
+func runSearchableText(run sdk.EventWorkflowRunPayload) string {
+	return strings.Join([]string{
+		run.ProjectKey,
+		run.VCSServer + "/" + run.Repository + "/" + run.WorkflowName,
+		run.WorkflowName + "#" + strconv.FormatInt(run.RunNumber, 10),
+		run.WorkflowRef,
+		string(run.Status),
+		run.Contexts.Git.Server + "/" + run.Contexts.Git.Repository,
+		run.Contexts.Git.Ref,
+		run.Contexts.Git.Sha,
+		run.Contexts.Git.Author,
+		run.Contexts.Git.CommitMessage,
+		run.Contexts.CDS.Version,
+		run.Username,
+		run.VCSUsername,
+		annotationsText(run.Annotations),
+	}, " ")
+}
+
+func annotationsText(annotations sdk.WorkflowRunAnnotations) string {
+	pairs := make([]string, 0, len(annotations))
+	for k, v := range annotations {
+		pairs = append(pairs, k+":"+v)
+	}
+	return strings.Join(pairs, " ")
+}
+
+// actorOf is the initiator of a run in the form the actor filter is written in. The query reads the
+// user name and the VCS name of the initiator as two values and matches either; a run carries only
+// one of them, so there is only ever one to compare.
+func actorOf(run sdk.EventWorkflowRunPayload) string {
+	if run.UserID != "" {
+		return run.Username
+	}
+	return run.VCSUsername
+}
+
+// matches mirrors "column = ANY(:values)" over a column the table declares NOT NULL.
+func matches(values []string, value string) bool {
+	return sdk.StringSlice(values).Contains(value)
+}
+
+// matchesContext mirrors the same comparison over a value read from the jsonb of a run, where a
+// field that is not set is absent rather than empty. NULL matches no value, so neither does an
+// empty one here.
+func matchesContext(values []string, value string) bool {
+	return value != "" && sdk.StringSlice(values).Contains(value)
+}
+
+// contextPath joins the parts of a path read from the jsonb of a run. Concatenating an absent field
+// gives NULL in SQL whatever the other parts, so one part missing leaves nothing to match.
+func contextPath(parts ...string) string {
+	for _, p := range parts {
+		if p == "" {
+			return ""
+		}
+	}
+	return strings.Join(parts, "/")
+}

--- a/engine/api/workflow_v2/run_search_match_test.go
+++ b/engine/api/workflow_v2/run_search_match_test.go
@@ -1,0 +1,121 @@
+package workflow_v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ovh/cds/sdk"
+)
+
+func runEventPayload() sdk.EventWorkflowRunPayload {
+	return sdk.EventWorkflowRunPayload{
+		ProjectKey:   "KEY",
+		VCSServer:    "github",
+		Repository:   "ovh/cds",
+		WorkflowName: "my-workflow",
+		WorkflowRef:  "refs/heads/master",
+		Status:       sdk.V2WorkflowRunStatusSuccess,
+		RunNumber:    42,
+		UserID:       "user-1",
+		Username:     "jdoe",
+		Annotations:  sdk.WorkflowRunAnnotations{"release": "1.2.3"},
+		Contexts: sdk.EventWorkflowRunPayloadContexts{
+			Git: sdk.GitContext{
+				Server:        "github",
+				Repository:    "ovh/cds",
+				Ref:           "refs/heads/main",
+				Sha:           "abcdef123456",
+				Author:        "asmith",
+				CommitMessage: "fix the thing that was broken",
+			},
+			CDS: sdk.CDSContext{
+				Version:                    "1.2.3+cds.1",
+				WorkflowTemplateVCSServer:  "github",
+				WorkflowTemplateRepository: "ovh/templates",
+				WorkflowTemplate:           "tmpl",
+			},
+		},
+	}
+}
+
+func asVCSRun(r *sdk.EventWorkflowRunPayload) {
+	r.UserID = ""
+	r.Username = "github/mybot"
+	r.VCSUsername = "mybot"
+}
+
+func TestSearchRunsFilters_MatchesRun(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		filters SearchRunsFilters
+		mutate  func(*sdk.EventWorkflowRunPayload)
+		want    bool
+	}{
+		{name: "a search without filter takes every run", want: true},
+		{name: "workflow path", filters: SearchRunsFilters{Workflows: []string{"github/ovh/cds/my-workflow"}}, want: true},
+		{name: "another workflow path", filters: SearchRunsFilters{Workflows: []string{"github/ovh/cds/other"}}},
+		{name: "any of the values of a filter", filters: SearchRunsFilters{Workflows: []string{"github/ovh/cds/other", "github/ovh/cds/my-workflow"}}, want: true},
+		{name: "status", filters: SearchRunsFilters{Status: []string{string(sdk.V2WorkflowRunStatusSuccess)}}, want: true},
+		{name: "another status", filters: SearchRunsFilters{Status: []string{string(sdk.V2WorkflowRunStatusFail)}}},
+		{name: "git ref", filters: SearchRunsFilters{Refs: []string{"refs/heads/main"}}, want: true},
+		{name: "workflow ref", filters: SearchRunsFilters{WorkflowRefs: []string{"refs/heads/master"}}, want: true},
+		{name: "run repository", filters: SearchRunsFilters{Repositories: []string{"github/ovh/cds"}}, want: true},
+		{name: "workflow repository", filters: SearchRunsFilters{WorkflowRepositories: []string{"github/ovh/cds"}}, want: true},
+		{name: "commit author", filters: SearchRunsFilters{Authors: []string{"asmith"}}, want: true},
+		{name: "commit", filters: SearchRunsFilters{Commits: []string{"abcdef123456"}}, want: true},
+		{name: "template path", filters: SearchRunsFilters{Templates: []string{"github/ovh/templates/tmpl"}}, want: true},
+		{name: "annotation", filters: SearchRunsFilters{Annotations: []string{"release:1.2.3"}}, want: true},
+		{name: "every annotation asked for is required", filters: SearchRunsFilters{Annotations: []string{"release:1.2.3", "env:prod"}}},
+		{name: "the actor of a run started by a user", filters: SearchRunsFilters{Actors: []string{"jdoe"}}, want: true},
+		{name: "the actor of a run started from a vcs", filters: SearchRunsFilters{Actors: []string{"mybot"}}, mutate: asVCSRun, want: true},
+		{
+			name:    "the vcs actor is searched on its own name, not on the flattened one",
+			filters: SearchRunsFilters{Actors: []string{"github/mybot"}},
+			mutate:  asVCSRun,
+		},
+		{
+			name:    "the vcs name of a run started by a user is not its actor",
+			filters: SearchRunsFilters{Actors: []string{"mybot"}},
+			mutate:  func(r *sdk.EventWorkflowRunPayload) { r.VCSUsername = "mybot" },
+		},
+		{
+			name:    "filters of different keys are all required",
+			filters: SearchRunsFilters{Status: []string{string(sdk.V2WorkflowRunStatusSuccess)}, Authors: []string{"jdoe"}},
+		},
+		{
+			// The database reads those from the jsonb contexts of a run, where a field that is not
+			// set is absent, and no value is matched against an absent field.
+			name:    "a context field a run does not carry matches nothing",
+			filters: SearchRunsFilters{Commits: []string{""}},
+			mutate:  func(r *sdk.EventWorkflowRunPayload) { r.Contexts.Git.Sha = "" },
+		},
+		{
+			name:    "a template path missing one of its parts matches nothing",
+			filters: SearchRunsFilters{Templates: []string{"github/ovh/templates/"}},
+			mutate:  func(r *sdk.EventWorkflowRunPayload) { r.Contexts.CDS.WorkflowTemplate = "" },
+		},
+
+		// Free text
+		{name: "a word of the workflow name", filters: SearchRunsFilters{Query: "workflow"}, want: true},
+		{name: "free text is case insensitive", filters: SearchRunsFilters{Query: "MY-WORKFLOW"}, want: true},
+		{name: "the run number", filters: SearchRunsFilters{Query: "my-workflow#42"}, want: true},
+		{name: "a word of the commit message", filters: SearchRunsFilters{Query: "broken"}, want: true},
+		{name: "the version", filters: SearchRunsFilters{Query: "1.2.3+cds.1"}, want: true},
+		{name: "an annotation value", filters: SearchRunsFilters{Query: "1.2.3"}, want: true},
+		{name: "the initiator", filters: SearchRunsFilters{Query: "jdoe"}, want: true},
+		{name: "every word must be found", filters: SearchRunsFilters{Query: "workflow broken"}, want: true},
+		{name: "words can be given in any order", filters: SearchRunsFilters{Query: "broken workflow"}, want: true},
+		{name: "one word not found excludes the run", filters: SearchRunsFilters{Query: "workflow nowhere"}},
+		{name: "like wildcards are matched literally", filters: SearchRunsFilters{Query: "%"}},
+		{name: "free text is required next to a filter", filters: SearchRunsFilters{Status: []string{string(sdk.V2WorkflowRunStatusSuccess)}, Query: "nowhere"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run := runEventPayload()
+			if tc.mutate != nil {
+				tc.mutate(&run)
+			}
+			require.Equal(t, tc.want, tc.filters.MatchesRun(run))
+		})
+	}
+}

--- a/sdk/event_v2.go
+++ b/sdk/event_v2.go
@@ -406,6 +406,7 @@ func NewEventWorkflowRunPayload(wr V2WorkflowRun, rjs map[string]V2WorkflowRunJo
 		WorkflowData: wr.WorkflowData,
 		UserID:       wr.Initiator.UserID,
 		Username:     wr.Initiator.Username(),
+		VCSUsername:  wr.Initiator.VCSUsername,
 		AdminMFA:     wr.Initiator.IsAdminWithMFA,
 		RunEvent:     wr.RunEvent,
 		RunJobEvent:  wr.RunJobEvent,
@@ -467,6 +468,9 @@ type EventWorkflowRunPayload struct {
 	RunEvent     V2WorkflowRunEvent     `json:"event,omitempty"`
 	RunJobEvent  V2WorkflowRunJobEvents `json:"job_events,omitempty"`
 	Annotations  WorkflowRunAnnotations `json:"annotations,omitempty"`
+	// VCSUsername is the VCS user that started the run, as the run holds it. Username flattens it
+	// into "vcs/username", which is not the form the runs are searched on.
+	VCSUsername string `json:"vcs_username,omitempty"`
 
 	Contexts EventWorkflowRunPayloadContexts `json:"contexts" db:"contexts"`
 }

--- a/sdk/search.go
+++ b/sdk/search.go
@@ -56,21 +56,33 @@ var searchQueryLikeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`
 // of a search. Extra words are dropped.
 const SearchQueryMaxWords = 20
 
-// SearchQueryLikePatterns turns a free text search into one lowered SQL LIKE pattern per word.
-// All the returned patterns have to match, so words can be given in any order, and the LIKE
-// wildcards are escaped to be matched literally. An empty query returns no pattern at all.
-func SearchQueryLikePatterns(query string) []string {
-	patterns := make([]string, 0, SearchQueryMaxWords)
+// SearchQueryWords are the words a free text search is made of, lowered, without duplicates and
+// bounded. They are what has to be matched, whether by a database or in memory, so both read them
+// from here.
+func SearchQueryWords(query string) []string {
+	words := make([]string, 0, SearchQueryMaxWords)
 	seen := make(map[string]struct{})
 	for _, w := range strings.Fields(strings.ToLower(query)) {
 		if _, ok := seen[w]; ok {
 			continue
 		}
 		seen[w] = struct{}{}
-		patterns = append(patterns, "%"+searchQueryLikeEscaper.Replace(w)+"%")
-		if len(patterns) == SearchQueryMaxWords {
+		words = append(words, w)
+		if len(words) == SearchQueryMaxWords {
 			break
 		}
+	}
+	return words
+}
+
+// SearchQueryLikePatterns turns a free text search into one lowered SQL LIKE pattern per word.
+// All the returned patterns have to match, so words can be given in any order, and the LIKE
+// wildcards are escaped to be matched literally. An empty query returns no pattern at all.
+func SearchQueryLikePatterns(query string) []string {
+	words := SearchQueryWords(query)
+	patterns := make([]string, 0, len(words))
+	for _, w := range words {
+		patterns = append(patterns, "%"+searchQueryLikeEscaper.Replace(w)+"%")
 	}
 	return patterns
 }

--- a/ui/specs/workflow-run-search.md
+++ b/ui/specs/workflow-run-search.md
@@ -116,9 +116,17 @@ query params.
 
 ## 5 — Live Updates
 
-The run list subscribes to run events over the websocket. The current search — filters and free text
-alike — is sent along with the subscription, and the API re-evaluates it for every incoming event so
-that only runs matching the search are pushed into the list.
+The run list subscribes to the run events of the project over the websocket, and the search it shows
+is sent along with the subscription: an event is pushed only for a run that search matches, which the
+API reads from the run the event carries.
+
+Where such a run goes is the list's own decision, taken from the sort in effect. A run it already
+displays is replaced where it stands; a run arriving is inserted at the position the sort gives it,
+and dropped when that position falls past the page, since it then belongs to a later one. The result
+count only moves for a run that is new to the search.
+
+Only the first page follows the events. Further pages are left as they were read: a list showing one
+of them has nowhere to put a run arriving, and coming back to the first page reads it again.
 
 ---
 

--- a/ui/src/app/service/workflowv2/workflow.service.ts
+++ b/ui/src/app/service/workflowv2/workflow.service.ts
@@ -11,6 +11,31 @@ import { CDNLogLink, CDNLogLinks } from "app/model/cdn.model";
  */
 export const RUN_SUMMARY_HEADERS = new HttpHeaders({ Accept: 'application/vnd.cds.workflow-run-summary+json' });
 
+/**
+ * Where a run pushed by the websocket goes in a list showing one page of a search. The API answers
+ * whether the run matches the search, not where it sits in it: sort and paging are the list's
+ * business, and it has everything to decide - the sort in effect, what it displays, and the dates
+ * the run carries.
+ *
+ * Returns the index to insert the run at, or -1 when this page does not reach it: under a descending
+ * sort a run older than the last one shown is on a later page, and under an ascending sort a run
+ * that has just started is at the far end of the result.
+ */
+export function runInsertIndex(runs: Array<V2WorkflowRun>, run: V2WorkflowRun, sort: string, pageSize: number): number {
+	const [field, direction] = (sort ?? '').split(':');
+	// Compared as instants: the same one can be written with any offset.
+	const at = (r: V2WorkflowRun) => new Date(field === 'last_modified' ? r.last_modified : r.started).getTime();
+
+	const value = at(run);
+	for (let i = 0; i < runs.length; i++) {
+		if (direction === 'asc' ? value <= at(runs[i]) : value >= at(runs[i])) {
+			return i;
+		}
+	}
+	// Past the last run shown, so it only belongs to this page while the page has room for it.
+	return runs.length < pageSize ? runs.length : -1;
+}
+
 @Injectable()
 export class V2WorkflowRunService {
     private _http = inject(HttpClient);

--- a/ui/src/app/views/projectv2/run-list/run-list.component.ts
+++ b/ui/src/app/views/projectv2/run-list/run-list.component.ts
@@ -22,7 +22,7 @@ import { ProjectV2State } from "app/store/project-v2.state";
 import { Filter, FilterText } from "../../../shared/input/input-filter.component";
 import { Clipboard } from '@angular/cdk/clipboard';
 import { SearchService } from "app/service/search.service";
-import { RUN_SUMMARY_HEADERS } from "app/service/workflowv2/workflow.service";
+import { RUN_SUMMARY_HEADERS, runInsertIndex } from "app/service/workflowv2/workflow.service";
 import { SearchResultType } from "app/model/search.model";
 import { DisplaySearchResult } from "app/views/search/search.component";
 import { WorkflowNameComponent } from "app/shared/workflow-name/workflow-name.component";
@@ -108,13 +108,25 @@ export class ProjectV2RunListComponent implements OnInit, OnDestroy {
 			if (idx !== -1) {
 				this.runs[idx] = event.payload;
 			} else {
-				this.runs = [event.payload].concat(...this.runs);
+				const at = runInsertIndex(this.runs, event.payload, this.sort, ProjectV2RunListComponent.DEFAULT_PAGESIZE);
+				if (at === -1) {
+					// A run of a later page: this one has no room for it, and it is already counted
+					// in the total.
+					return;
+				}
+				// A page that was not full held every run the search matches, so one arriving that
+				// is not in it is one more. A crafted run is new whatever the page holds.
+				const isNewMatch = this.runs.length < ProjectV2RunListComponent.DEFAULT_PAGESIZE
+					|| event.type === EventV2Type.EventRunCrafted;
+				this.runs = this.runs.slice(0, at).concat(event.payload, this.runs.slice(at));
 				if (this.runs.length > ProjectV2RunListComponent.DEFAULT_PAGESIZE) {
 					this.runs.pop();
 				}
+				if (isNewMatch) {
+					this.totalCount++;
+				}
 				// The run pushed by the websocket matches the current search, so the empty result
 				// state and the workflows it was suggesting do not stand anymore.
-				this.totalCount++;
 				this.matchingWorkflows = [];
 			}
 			this.animatedRuns[event.payload.id] = true;

--- a/ui/src/app/views/projectv2/run/run.component.ts
+++ b/ui/src/app/views/projectv2/run/run.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, inject, OnDestroy, TemplateRef, ViewChild } from "@angular/core";
 import { AutoUnsubscribe } from "app/shared/decorator/autoUnsubscribe";
 import { from, interval, lastValueFrom, Subscription } from "rxjs";
-import { RUN_SUMMARY_HEADERS, V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
+import { RUN_SUMMARY_HEADERS, runInsertIndex, V2WorkflowRunService } from "app/service/workflowv2/workflow.service";
 import { PreferencesState } from "app/store/preferences.state";
 import { Store } from "@ngxs/store";
 import * as actionPreferences from "app/store/preferences.action";
@@ -137,6 +137,9 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
 
     static INFO_PANEL_KEY = 'workflow-run-info';
     static JOB_PANEL_KEY = 'workflow-run-job';
+    /** The strip of runs of the same workflow: the last of them, as the search returns them. */
+    static RUNS_PAGESIZE = 50;
+    static RUNS_SORT = 'started:desc';
     /**
      * The view is driven by the events of the run. This refresh is only a safety net for what events
      * cannot carry (run infos written without any status change) and for what a disconnection may have
@@ -300,8 +303,12 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         if (idx !== -1) {
             this.runs[idx] = event.payload;
         } else {
-            this.runs = [event.payload].concat(...this.runs);
-            if (this.runs.length > 50) {
+            const at = runInsertIndex(this.runs, event.payload, ProjectV2RunComponent.RUNS_SORT, ProjectV2RunComponent.RUNS_PAGESIZE);
+            if (at === -1) {
+                return;
+            }
+            this.runs = this.runs.slice(0, at).concat(event.payload, this.runs.slice(at));
+            if (this.runs.length > ProjectV2RunComponent.RUNS_PAGESIZE) {
                 this.runs.pop();
             }
         }
@@ -599,7 +606,7 @@ export class ProjectV2RunComponent implements AfterViewInit, OnDestroy {
         params = params.appendAll({
             workflow: `${this.workflowRun.vcs_server}/${this.workflowRun.repository}/${this.workflowRun.workflow_name}`,
             offset: 0,
-            limit: 50
+            limit: ProjectV2RunComponent.RUNS_PAGESIZE
         });
 
         this._eventV2Service.updateFilter(<WebsocketV2Filter>{


### PR DESCRIPTION
Every event is offered to every client, and the ones whose filter needs a post
check paid a read of the database for it. A job produces eight events and a run as
many as it has jobs, so the reads followed the traffic of the instance multiplied
by the clients watching it.

Job events: the projects a client may read and the regions it may run on are now
read once and held for half a minute, instead of three tables per event and per
client. A right taken away reaches an open connection within that delay.

Run events: whether the run an event carries is one the client asked to see is a
question about a filter, not about a permission, since read access on the project
is checked when the filter is registered. The event carries the whole run, so it
is answered from the event and nothing is read at all. The match is the in-memory
twin of runQueryFilters, held to it by a test running every filter through both
against a database. Free text is matched too, and what a word is comes from one
place in the sdk so the two cannot drift. The actor filter needed the vcs user
name on the payload, which only carried it flattened into "vcs/username".

The page is no longer part of the answer: a client reading further down the list
is pushed nothing, and on the first page the list places what it receives from the
sort in effect, dropping a run that falls past the page. It used to put every run
at the top and count it as one more result, which is wrong for an older run
changing state.

@ovh/cds