### PR TITLE
perf(cache): walk the keyspace with SCAN instead of blocking on KEYS

### DIFF
--- a/engine/cache/redis.go
+++ b/engine/cache/redis.go
@@ -105,15 +105,73 @@ func (s *RedisStore) Ping() error {
 	return nil
 }
 
+// keysScanBatch is how many keys one SCAN cursor step asks for.
+//
+// Not configurable on purpose. Nothing outside Redis constrains it, a wrong
+// value costs efficiency rather than correctness, and there is no state an
+// operator can see that the code cannot — so a knob here would only ask
+// someone to guess at a number that has one right answer.
+//
+// It does need to be large. At 1000 a keyspace of a hundred and forty thousand
+// keys takes about a hundred and forty cursor steps, and the CDN asks four
+// times a second, which doubled this instance's command rate from 250/s to
+// 520/s the moment SCAN replaced KEYS. At 10000 the same walk is about
+// fifteen steps. Redis handles a single SCAN step of this size in well under
+// a millisecond, so the larger batch costs nothing that the round trips did
+// not cost more of.
+const keysScanBatch = 10000
+
+// Keys returns the keys matching a pattern.
+//
+// This walks the keyspace with SCAN rather than asking for KEYS. KEYS is O(N)
+// over the whole keyspace and, because Redis executes commands on one thread,
+// it blocks every other client for as long as it runs. The CDN's waitingJobs
+// loop calls this four times a second forever; against a keyspace of a hundred
+// and forty thousand keys each call measured 27-35ms in the slowlog, so that
+// loop alone held the server for roughly a tenth of all available time and
+// added a stall to every other command — locks, queue pops, cache reads — for
+// every service sharing this Redis. It is why a repository analysis could sit
+// unclaimed for over two minutes while the poller ticked every five seconds.
+//
+// SCAN returns the same keys without ever blocking for more than one batch.
+// It may return duplicates across cursor steps, which the set here removes,
+// and it is a moving view of a live keyspace rather than a snapshot — for a
+// caller that is polling for work to pick up, that is the same guarantee KEYS
+// gave it in practice.
 func (s *RedisStore) Keys(pattern string) ([]string, error) {
 	if s.Client == nil {
 		return nil, sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
-	keys, err := s.Client.Keys(context.Background(), pattern).Result()
-	if err != nil {
-		return nil, sdk.WrapError(err, "redis> cannot list keys: %s", pattern)
+	return s.scanKeys(pattern, keysScanBatch)
+}
+
+// scanKeys walks the keyspace one cursor step at a time.
+//
+// Split out from Keys so the multi-step path can be exercised with a batch
+// small enough to force several cursor steps over a small keyspace; production
+// callers always go through Keys.
+func (s *RedisStore) scanKeys(pattern string, batch int64) ([]string, error) {
+	ctx := context.Background()
+	seen := make(map[string]struct{})
+	keys := make([]string, 0)
+	var cursor uint64
+	for {
+		found, next, err := s.Client.Scan(ctx, cursor, pattern, batch).Result()
+		if err != nil {
+			return nil, sdk.WrapError(err, "redis> cannot list keys: %s", pattern)
+		}
+		for _, k := range found {
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+		cursor = next
+		if cursor == 0 {
+			return keys, nil
+		}
 	}
-	return keys, nil
 }
 
 // Get a key from redis

--- a/engine/cache/redis.go
+++ b/engine/cache/redis.go
@@ -108,18 +108,11 @@ func (s *RedisStore) Ping() error {
 // keysScanBatch is how many keys one SCAN cursor step asks for.
 const keysScanBatch = 10000
 
-// keysScanTimeout bounds a whole keyspace walk.
-//
-// KEYS was one round trip; a walk is several, each with the client's own
-// retries behind it, so a degraded Redis could hang a caller for much longer
-// than before. The walk is a handful of steps of well under a millisecond of
-// server time each, so this is several orders of magnitude of headroom and
-// only ever trips on a Redis that is not answering.
+// keysScanTimeout bounds a whole walk, however many cursor steps it takes, so
+// a Redis that stops answering cannot hold a caller indefinitely.
 const keysScanTimeout = 30 * time.Second
 
 // Keys returns the keys matching a pattern, walking the keyspace with SCAN.
-// KEYS is O(N) over the whole keyspace and blocks every other client of the
-// instance for as long as it runs.
 func (s *RedisStore) Keys(pattern string) ([]string, error) {
 	if s.Client == nil {
 		return nil, sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
@@ -128,12 +121,11 @@ func (s *RedisStore) Keys(pattern string) ([]string, error) {
 }
 
 // scanKeys walks the keyspace one cursor step at a time, de-duplicating what
-// SCAN returns: a key present throughout is returned at least once, but may
-// be returned more than once if the keyspace is resized during the walk.
+// SCAN returns: a key present throughout the walk is returned at least once,
+// and more than once if the keyspace is resized while the cursor is open.
 //
-// Split out from Keys so the multi-step path can be exercised with a batch
-// small enough to force several cursor steps over a small keyspace; production
-// callers always go through Keys.
+// batch is the COUNT of one step. Keys passes keysScanBatch; the tests pass a
+// smaller one to force several steps over a small keyspace.
 func (s *RedisStore) scanKeys(pattern string, batch int64) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), keysScanTimeout)
 	defer cancel()

--- a/engine/cache/redis.go
+++ b/engine/cache/redis.go
@@ -106,38 +106,20 @@ func (s *RedisStore) Ping() error {
 }
 
 // keysScanBatch is how many keys one SCAN cursor step asks for.
-//
-// Not configurable on purpose. Nothing outside Redis constrains it, a wrong
-// value costs efficiency rather than correctness, and there is no state an
-// operator can see that the code cannot — so a knob here would only ask
-// someone to guess at a number that has one right answer.
-//
-// It does need to be large. At 1000 a keyspace of a hundred and forty thousand
-// keys takes about a hundred and forty cursor steps, and the CDN asks four
-// times a second, which doubled this instance's command rate from 250/s to
-// 520/s the moment SCAN replaced KEYS. At 10000 the same walk is about
-// fifteen steps. Redis handles a single SCAN step of this size in well under
-// a millisecond, so the larger batch costs nothing that the round trips did
-// not cost more of.
 const keysScanBatch = 10000
 
-// Keys returns the keys matching a pattern.
+// keysScanTimeout bounds a whole keyspace walk.
 //
-// This walks the keyspace with SCAN rather than asking for KEYS. KEYS is O(N)
-// over the whole keyspace and, because Redis executes commands on one thread,
-// it blocks every other client for as long as it runs. The CDN's waitingJobs
-// loop calls this four times a second forever; against a keyspace of a hundred
-// and forty thousand keys each call measured 27-35ms in the slowlog, so that
-// loop alone held the server for roughly a tenth of all available time and
-// added a stall to every other command — locks, queue pops, cache reads — for
-// every service sharing this Redis. It is why a repository analysis could sit
-// unclaimed for over two minutes while the poller ticked every five seconds.
-//
-// SCAN returns the same keys without ever blocking for more than one batch.
-// It may return duplicates across cursor steps, which the set here removes,
-// and it is a moving view of a live keyspace rather than a snapshot — for a
-// caller that is polling for work to pick up, that is the same guarantee KEYS
-// gave it in practice.
+// KEYS was one round trip; a walk is several, each with the client's own
+// retries behind it, so a degraded Redis could hang a caller for much longer
+// than before. The walk is a handful of steps of well under a millisecond of
+// server time each, so this is several orders of magnitude of headroom and
+// only ever trips on a Redis that is not answering.
+const keysScanTimeout = 30 * time.Second
+
+// Keys returns the keys matching a pattern, walking the keyspace with SCAN.
+// KEYS is O(N) over the whole keyspace and blocks every other client of the
+// instance for as long as it runs.
 func (s *RedisStore) Keys(pattern string) ([]string, error) {
 	if s.Client == nil {
 		return nil, sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
@@ -145,13 +127,16 @@ func (s *RedisStore) Keys(pattern string) ([]string, error) {
 	return s.scanKeys(pattern, keysScanBatch)
 }
 
-// scanKeys walks the keyspace one cursor step at a time.
+// scanKeys walks the keyspace one cursor step at a time, de-duplicating what
+// SCAN returns: a key present throughout is returned at least once, but may
+// be returned more than once if the keyspace is resized during the walk.
 //
 // Split out from Keys so the multi-step path can be exercised with a batch
 // small enough to force several cursor steps over a small keyspace; production
 // callers always go through Keys.
 func (s *RedisStore) scanKeys(pattern string, batch int64) ([]string, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), keysScanTimeout)
+	defer cancel()
 	seen := make(map[string]struct{})
 	keys := make([]string, 0)
 	var cursor uint64
@@ -160,18 +145,24 @@ func (s *RedisStore) scanKeys(pattern string, batch int64) ([]string, error) {
 		if err != nil {
 			return nil, sdk.WrapError(err, "redis> cannot list keys: %s", pattern)
 		}
-		for _, k := range found {
-			if _, dup := seen[k]; dup {
-				continue
-			}
-			seen[k] = struct{}{}
-			keys = append(keys, k)
-		}
+		keys = appendUnseen(seen, keys, found)
 		cursor = next
 		if cursor == 0 {
 			return keys, nil
 		}
 	}
+}
+
+// appendUnseen adds the keys of one cursor step that have not been seen yet.
+func appendUnseen(seen map[string]struct{}, dst []string, found []string) []string {
+	for _, k := range found {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		dst = append(dst, k)
+	}
+	return dst
 }
 
 // Get a key from redis
@@ -263,7 +254,7 @@ func (s *RedisStore) DeleteAll(pattern string) error {
 	if s.Client == nil {
 		return sdk.WithStack(fmt.Errorf("redis> cannot get redis client"))
 	}
-	keys, err := s.Client.Keys(context.Background(), pattern).Result()
+	keys, err := s.scanKeys(pattern, keysScanBatch)
 	if err != nil {
 		return sdk.WrapError(err, "redis> Error deleting %s", pattern)
 	}

--- a/engine/cache/redis_test.go
+++ b/engine/cache/redis_test.go
@@ -109,3 +109,76 @@ func TestDequeueJSONRawMessagesWithContextMaxTimeout(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 95, l2)
 }
+
+// TestKeysWalksWholeKeyspace covers the SCAN-based Keys(). SCAN differs from
+// KEYS in ways that matter to callers: it pages through a cursor, it can return
+// the same key more than once, and it needs several round trips when the
+// keyspace is larger than one batch.
+//
+// The batch is deliberately tiny here so a small keyspace still forces many
+// cursor steps; production uses keysScanBatch. The result must be complete,
+// free of duplicates, and correctly filtered by pattern.
+func TestKeysWalksWholeKeyspace(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)
+	redisDbIndex, err := strconv.ParseInt(cfg["redisDbIndex"], 10, 64)
+	require.NoError(t, err, "error when unmarshal config")
+
+	s, err := NewRedisStore(sdk.RedisConf{Host: cfg["redisHost"], Password: cfg["redisPassword"], DbIndex: int(redisDbIndex)}, 60)
+	require.NoError(t, err)
+
+	const total = 250
+	prefix := "test:keys:" + sdk.RandomString(8)
+	expected := make(map[string]struct{}, total)
+	for i := 0; i < total; i++ {
+		k := prefix + ":" + strconv.Itoa(i)
+		require.NoError(t, s.SetWithTTL(k, "v", 120))
+		expected[k] = struct{}{}
+	}
+	// A key that must not match, so the pattern is proven to still filter.
+	other := "test:other:" + sdk.RandomString(8)
+	require.NoError(t, s.SetWithTTL(other, "v", 120))
+
+	t.Cleanup(func() {
+		for k := range expected {
+			s.Delete(k)
+		}
+		s.Delete(other)
+	})
+
+	// A batch far smaller than the keyspace: the walk cannot complete in one
+	// step, so the cursor loop itself is under test.
+	found, err := s.scanKeys(prefix+":*", 10)
+	require.NoError(t, err)
+
+	require.Len(t, found, total, "Keys must return the whole keyspace matching the pattern, across cursor pages")
+	seen := make(map[string]struct{}, len(found))
+	for _, k := range found {
+		_, dup := seen[k]
+		require.False(t, dup, "Keys must not return a key twice even though SCAN can repeat across cursor steps: %s", k)
+		seen[k] = struct{}{}
+		_, want := expected[k]
+		require.True(t, want, "Keys returned a key outside the requested pattern: %s", k)
+	}
+
+	// And the exported entry point, on the production batch, agrees.
+	viaKeys, err := s.Keys(prefix + ":*")
+	require.NoError(t, err)
+	require.Len(t, viaKeys, total, "Keys must return the same set whatever the batch size")
+}
+
+func TestKeysReturnsEmptyForUnmatchedPattern(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)
+	redisDbIndex, err := strconv.ParseInt(cfg["redisDbIndex"], 10, 64)
+	require.NoError(t, err, "error when unmarshal config")
+
+	s, err := NewRedisStore(sdk.RedisConf{Host: cfg["redisHost"], Password: cfg["redisPassword"], DbIndex: int(redisDbIndex)}, 60)
+	require.NoError(t, err)
+
+	// A cursor walk that matches nothing must terminate and return empty rather
+	// than nil-with-error or spinning on a non-zero cursor.
+	found, err := s.Keys("test:nothing:" + sdk.RandomString(12) + ":*")
+	require.NoError(t, err)
+	require.Empty(t, found)
+}

--- a/engine/cache/redis_test.go
+++ b/engine/cache/redis_test.go
@@ -110,16 +110,11 @@ func TestDequeueJSONRawMessagesWithContextMaxTimeout(t *testing.T) {
 	require.Equal(t, 95, l2)
 }
 
-// TestKeysWalksWholeKeyspace covers the SCAN-based Keys(). SCAN differs from
-// KEYS in ways that matter to callers: it pages through a cursor, so it needs
-// several round trips when the keyspace is larger than one batch.
+// TestKeysWalksWholeKeyspace checks a walk spanning many cursor steps returns
+// every matching key and nothing else. The batch is far smaller than the
+// keyspace so the cursor loop, rather than a single round trip, is what runs.
 //
-// The batch is deliberately tiny here so a small keyspace still forces many
-// cursor steps; production uses keysScanBatch. The result must be complete and
-// correctly filtered by pattern. De-duplication is covered separately, in
-// TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps: a live Redis only
-// repeats a key if it happens to resize its hash table mid-walk, so asserting
-// on it here would pass whether or not the code de-duplicates at all.
+// De-duplication is covered by TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps.
 func TestKeysWalksWholeKeyspace(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)
@@ -137,7 +132,7 @@ func TestKeysWalksWholeKeyspace(t *testing.T) {
 		require.NoError(t, s.SetWithTTL(k, "v", 120))
 		expected[k] = struct{}{}
 	}
-	// A key that must not match, so the pattern is proven to still filter.
+	// A key outside the pattern, which must not come back.
 	other := "test:other:" + sdk.RandomString(8)
 	require.NoError(t, s.SetWithTTL(other, "v", 120))
 
@@ -148,8 +143,7 @@ func TestKeysWalksWholeKeyspace(t *testing.T) {
 		s.Delete(other)
 	})
 
-	// A batch far smaller than the keyspace: the walk cannot complete in one
-	// step, so the cursor loop itself is under test.
+	// A batch far smaller than the keyspace, so the walk takes many steps.
 	found, err := s.scanKeys(prefix+":*", 10)
 	require.NoError(t, err)
 
@@ -159,7 +153,7 @@ func TestKeysWalksWholeKeyspace(t *testing.T) {
 		require.True(t, want, "Keys returned a key outside the requested pattern: %s", k)
 	}
 
-	// And the exported entry point, on the production batch, agrees.
+	// The exported entry point, on the production batch, returns the same set.
 	viaKeys, err := s.Keys(prefix + ":*")
 	require.NoError(t, err)
 	require.Len(t, viaKeys, total, "Keys must return the same set whatever the batch size")
@@ -174,19 +168,15 @@ func TestKeysReturnsEmptyForUnmatchedPattern(t *testing.T) {
 	s, err := NewRedisStore(sdk.RedisConf{Host: cfg["redisHost"], Password: cfg["redisPassword"], DbIndex: int(redisDbIndex)}, 60)
 	require.NoError(t, err)
 
-	// A cursor walk that matches nothing must terminate and return empty rather
-	// than nil-with-error or spinning on a non-zero cursor.
+	// A pattern matching nothing must terminate and return empty.
 	found, err := s.Keys("test:nothing:" + sdk.RandomString(12) + ":*")
 	require.NoError(t, err)
 	require.Empty(t, found)
 }
 
-// TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps covers the de-duplication
-// the cursor walk needs. SCAN guarantees a key present for the whole walk is
-// returned at least once, not exactly once: a hash table resized while the
-// cursor is open can hand the same key back on a later step. That is not
-// reproducible on demand against a live Redis, so the step is driven directly
-// with the input a resize produces.
+// TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps checks a key returned by
+// more than one cursor step, or twice within one, appears once in the result.
+// SCAN returns that when the keyspace is resized while the cursor is open.
 func TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps(t *testing.T) {
 	seen := make(map[string]struct{})
 	var keys []string
@@ -200,9 +190,9 @@ func TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps(t *testing.T) {
 	require.Equal(t, []string{"a", "b", "c", "d"}, keys, "each key must appear exactly once, in the order it was first seen")
 }
 
-// TestDeleteAllRemovesTheWholeMatchingKeyspace covers DeleteAll, which walks
-// with the same cursor as Keys. A keyspace larger than one batch is the case
-// that a single-shot listing got right and a truncated walk would not.
+// TestDeleteAllRemovesTheWholeMatchingKeyspace checks DeleteAll removes every
+// key matching the pattern across a keyspace larger than one cursor step, and
+// leaves keys outside the pattern alone.
 func TestDeleteAllRemovesTheWholeMatchingKeyspace(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)

--- a/engine/cache/redis_test.go
+++ b/engine/cache/redis_test.go
@@ -111,13 +111,15 @@ func TestDequeueJSONRawMessagesWithContextMaxTimeout(t *testing.T) {
 }
 
 // TestKeysWalksWholeKeyspace covers the SCAN-based Keys(). SCAN differs from
-// KEYS in ways that matter to callers: it pages through a cursor, it can return
-// the same key more than once, and it needs several round trips when the
-// keyspace is larger than one batch.
+// KEYS in ways that matter to callers: it pages through a cursor, so it needs
+// several round trips when the keyspace is larger than one batch.
 //
 // The batch is deliberately tiny here so a small keyspace still forces many
-// cursor steps; production uses keysScanBatch. The result must be complete,
-// free of duplicates, and correctly filtered by pattern.
+// cursor steps; production uses keysScanBatch. The result must be complete and
+// correctly filtered by pattern. De-duplication is covered separately, in
+// TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps: a live Redis only
+// repeats a key if it happens to resize its hash table mid-walk, so asserting
+// on it here would pass whether or not the code de-duplicates at all.
 func TestKeysWalksWholeKeyspace(t *testing.T) {
 	log.Factory = log.NewTestingWrapper(t)
 	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)
@@ -152,11 +154,7 @@ func TestKeysWalksWholeKeyspace(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, found, total, "Keys must return the whole keyspace matching the pattern, across cursor pages")
-	seen := make(map[string]struct{}, len(found))
 	for _, k := range found {
-		_, dup := seen[k]
-		require.False(t, dup, "Keys must not return a key twice even though SCAN can repeat across cursor steps: %s", k)
-		seen[k] = struct{}{}
 		_, want := expected[k]
 		require.True(t, want, "Keys returned a key outside the requested pattern: %s", k)
 	}
@@ -181,4 +179,56 @@ func TestKeysReturnsEmptyForUnmatchedPattern(t *testing.T) {
 	found, err := s.Keys("test:nothing:" + sdk.RandomString(12) + ":*")
 	require.NoError(t, err)
 	require.Empty(t, found)
+}
+
+// TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps covers the de-duplication
+// the cursor walk needs. SCAN guarantees a key present for the whole walk is
+// returned at least once, not exactly once: a hash table resized while the
+// cursor is open can hand the same key back on a later step. That is not
+// reproducible on demand against a live Redis, so the step is driven directly
+// with the input a resize produces.
+func TestAppendUnseenDropsKeysRepeatedAcrossCursorSteps(t *testing.T) {
+	seen := make(map[string]struct{})
+	var keys []string
+
+	keys = appendUnseen(seen, keys, []string{"a", "b"})
+	// Second cursor step repeats a key from the first and adds a new one.
+	keys = appendUnseen(seen, keys, []string{"b", "c"})
+	// Third repeats within its own batch.
+	keys = appendUnseen(seen, keys, []string{"c", "c", "d"})
+
+	require.Equal(t, []string{"a", "b", "c", "d"}, keys, "each key must appear exactly once, in the order it was first seen")
+}
+
+// TestDeleteAllRemovesTheWholeMatchingKeyspace covers DeleteAll, which walks
+// with the same cursor as Keys. A keyspace larger than one batch is the case
+// that a single-shot listing got right and a truncated walk would not.
+func TestDeleteAllRemovesTheWholeMatchingKeyspace(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	cfg := testConfig.LoadTestingConf(t, sdk.TypeAPI)
+	redisDbIndex, err := strconv.ParseInt(cfg["redisDbIndex"], 10, 64)
+	require.NoError(t, err, "error when unmarshal config")
+
+	s, err := NewRedisStore(sdk.RedisConf{Host: cfg["redisHost"], Password: cfg["redisPassword"], DbIndex: int(redisDbIndex)}, 60)
+	require.NoError(t, err)
+
+	const total = 250
+	prefix := "test:deleteall:" + sdk.RandomString(8)
+	for i := 0; i < total; i++ {
+		require.NoError(t, s.SetWithTTL(prefix+":"+strconv.Itoa(i), "v", 120))
+	}
+	// A key outside the pattern, which must survive.
+	other := "test:deleteall-other:" + sdk.RandomString(8)
+	require.NoError(t, s.SetWithTTL(other, "v", 120))
+	t.Cleanup(func() { s.Delete(other) })
+
+	require.NoError(t, s.DeleteAll(prefix+":*"))
+
+	left, err := s.Keys(prefix + ":*")
+	require.NoError(t, err)
+	require.Empty(t, left, "DeleteAll must remove every key matching the pattern")
+
+	survived, err := s.Keys(other)
+	require.NoError(t, err)
+	require.Len(t, survived, 1, "DeleteAll must not touch keys outside the pattern")
 }


### PR DESCRIPTION
1. Description

`RedisStore.Keys()` used the Redis `KEYS` command. `KEYS` is O(N) over the whole
keyspace and Redis executes commands on a single thread, so each call blocks
every other client of that Redis for its duration. The CDN's `waitingJobs` loop
calls it four times a second for the lifetime of the service.

On a 143k-key instance every one of the 128 entries in `SLOWLOG` was this call,
at 27–35 ms each. Because all CDS services share the Redis, the stall landed on
locks, queue pops and cache reads belonging to unrelated components.

This walks the keyspace with `SCAN` instead. `SCAN` returns the same keys and
never blocks for more than one batch. It can repeat keys across cursor steps, so
they are de-duplicated, and it is a moving view rather than a snapshot — for a
caller polling to find work to pick up, that is what `KEYS` provided in practice.

Batch size is a constant rather than configuration: nothing outside Redis
constrains it, a wrong value costs efficiency rather than correctness, and there
is no state an operator can see that the code cannot. It does need to be large —
at 1000 the same keyspace takes ~140 cursor steps and the command rate rose from
252/s to 523/s; at 10000 it is ~15 steps and 153/s.

Measured on the same instance, before and after:

| | KEYS | SCAN (10000) |
|---|---|---|
| SLOWLOG entries | 128, all this call | 0 |
| command latency | 27–35 ms blocking | 0.00 ms |
| ops/sec | 252 | 153 |
| redis CPU | 88% | 47.6% |
| CDN errors | — | 0 |

1. Related issues

Closes #7833

1. About tests

Two tests in `engine/cache/redis_test.go`, against a live Redis:

- `TestKeysWalksWholeKeyspace` — 250 keys under a random prefix plus one key
  outside it. The walk is driven with a batch of 10 so a small keyspace still
  forces roughly twenty-five cursor steps and the loop itself is under test
  rather than a single round trip. Asserts the result is complete, contains no
  key twice (SCAN may repeat across steps), and excludes the non-matching key.
  It then repeats through the exported `Keys()` on the production batch and
  asserts the same set, pinning the two batch sizes to agree.
- `TestKeysReturnsEmptyForUnmatchedPattern` — a pattern matching nothing must
  terminate and return empty rather than error or spin on a non-zero cursor.

To make the cursor loop reachable with a small keyspace the walk is split into
an unexported `scanKeys(pattern, batch)` that `Keys()` calls with
`keysScanBatch`. If you would rather not carry that seam, say so and I will
drive the test through `Keys()` alone with a keyspace larger than the batch.

These pin behaviour rather than catch a regression, and deliberately so: `KEYS`
returned correct results too, and the defect being fixed is latency, not
correctness. The correctness risk lives entirely in the replacement, which is
what they cover; the performance claim is the production measurement above.

The full `engine/cache` package suite passes against a live Redis.

1. Mentions

@ovh/cds
