### PR TITLE
perf(api): read entity files concurrently during a repository analysis

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -260,9 +260,10 @@ type Configuration struct {
 		VersionRetention                 int64  `toml:"versionRetention" comment:"Number of Workflow version CDS keep" json:"versionRetention" commented:"true"`
 	} `toml:"workflowv2" comment:"######################\n 'Workflow V2' global configuration \n######################" json:"workflowv2"`
 	Entity struct {
-		RoutineDelay      int64  `toml:"routineDelay" comment:"Delay in minutes between to run of entities purge" json:"routineDelay" default:"15"`
-		Retention         string `toml:"retention" comment:"Retention (in hours) of ascode entity for on non head commit" json:"retention" default:"24h"`
-		AnalysisRetention int64  `toml:"analysisRetention" comment:"Number of analysis to keep" json:"analysisRetention" commented:"true" default:"250"`
+		RoutineDelay         int64  `toml:"routineDelay" comment:"Delay in minutes between to run of entities purge" json:"routineDelay" default:"15"`
+		Retention            string `toml:"retention" comment:"Retention (in hours) of ascode entity for on non head commit" json:"retention" default:"24h"`
+		AnalysisRetention    int64  `toml:"analysisRetention" comment:"Number of analysis to keep" json:"analysisRetention" commented:"true" default:"250"`
+		FileFetchConcurrency int64  `toml:"fileFetchConcurrency" comment:"How many entity files a repository analysis reads from the VCS at once. Lower it if the forge rate limits concurrent requests, raise it if it can take more." json:"fileFetchConcurrency" commented:"true" default:"8"`
 	} `toml:"entity" comment:"######################\n 'Entity' global configuration \n######################" json:"entity"`
 	Project struct {
 		CreationDisabled           bool   `toml:"creationDisabled" comment:"Disable project creation for CDS non admin users." json:"creationDisabled" default:"false" commented:"true"`
@@ -528,6 +529,9 @@ func (a *API) Serve(ctx context.Context) error {
 	}
 	if a.Config.Entity.AnalysisRetention <= 0 {
 		a.Config.Entity.AnalysisRetention = 250
+	}
+	if a.Config.Entity.FileFetchConcurrency <= 0 {
+		a.Config.Entity.FileFetchConcurrency = defaultEntityFileFetchConcurrency
 	}
 	if a.Config.WorkflowV2.VersionRetentionScheduling == 0 {
 		a.Config.WorkflowV2.VersionRetentionScheduling = 60

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -15,6 +15,9 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 	"time"
 
 	"github.com/go-gorp/gorp"
@@ -2009,6 +2012,48 @@ func (api *API) analyzeCommitSignatureThroughOperation(ctx context.Context, anal
 	return keyId, analyzeError, nil
 }
 
+// cdsFileFetchConcurrency bounds how many entity files are read from the VCS
+// at once.
+const cdsFileFetchConcurrency = 8
+
+// listCdsFilePaths walks the .cds tree and returns the entity files in it.
+// Listing is one call per directory, a handful in total; reading the files is
+// the part that scales with the repository, so it is done separately and can
+// then be done in parallel.
+func (api *API) listCdsFilePaths(ctx context.Context, client sdk.VCSAuthorizedClientService, repoName, commit, directory string) ([]string, error) {
+	contents, err := client.ListContent(ctx, repoName, commit, directory, "0", "100")
+	if err != nil {
+		return nil, sdk.WrapError(err, "unable to list content on commit [%s] in directory %s: %v", commit, directory, err)
+	}
+	paths := make([]string, 0, len(contents))
+	for _, c := range contents {
+		if c.IsFile && (strings.HasSuffix(c.Name, ".yml") || strings.HasSuffix(c.Name, ".yaml")) {
+			paths = append(paths, directory+"/"+c.Name)
+		}
+		if c.IsDirectory {
+			sub, err := api.listCdsFilePaths(ctx, client, repoName, commit, directory+"/"+c.Name)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, sub...)
+		}
+	}
+	return paths, nil
+}
+
+// getCdsFilesOnVCSDirectory reads every entity file under a directory.
+//
+// The files are read concurrently. Read one after another, an analysis costs
+// one network round trip per entity in series, so its duration grows with the
+// number of entities a repository declares rather than with the work involved:
+// a repository with about a hundred and thirty entities took five and a half
+// minutes to analyse while one with far fewer took thirty-six seconds, and the
+// VCS service logged two and a half thousand requests in fifteen minutes,
+// nearly all single-file reads for one analysis. None of that is compute, so
+// it parallelises directly.
+//
+// Bounded rather than unbounded: every read crosses whatever fronts the forge,
+// and that hop, not CDS, is what sets the safe ceiling.
 func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.ProjectRepositoryAnalysis, vcsName, repoName, commit, directory string) (map[string][]byte, error) {
 	ctx, next := telemetry.Span(ctx, "api.getCdsFilesOnVCSDirectory")
 	defer next()
@@ -2018,33 +2063,34 @@ func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.Pro
 		return nil, sdk.WithStack(err)
 	}
 
-	filesContent := make(map[string][]byte)
-	contents, err := client.ListContent(ctx, repoName, commit, directory, "0", "100")
+	paths, err := api.listCdsFilePaths(ctx, client, repoName, commit, directory)
 	if err != nil {
-		return nil, sdk.WrapError(err, "unable to list content on commit [%s] in directory %s: %v", commit, directory, err)
+		return nil, err
 	}
-	for _, c := range contents {
-		if c.IsFile && (strings.HasSuffix(c.Name, ".yml") || strings.HasSuffix(c.Name, ".yaml")) {
-			filePath := directory + "/" + c.Name
-			vcsContent, err := client.GetContent(ctx, repoName, commit, filePath)
+
+	filesContent := make(map[string][]byte, len(paths))
+	var mu sync.Mutex
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(cdsFileFetchConcurrency)
+	for i := range paths {
+		filePath := paths[i]
+		group.Go(func() error {
+			vcsContent, err := client.GetContent(groupCtx, repoName, commit, filePath)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			contentBts, err := base64.StdEncoding.DecodeString(vcsContent.Content)
 			if err != nil {
-				return nil, sdk.WithStack(err)
+				return sdk.WithStack(err)
 			}
+			mu.Lock()
 			filesContent[filePath] = contentBts
-		}
-		if c.IsDirectory {
-			contents, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, vcsName, repoName, commit, directory+"/"+c.Name)
-			if err != nil {
-				return nil, err
-			}
-			for k, v := range contents {
-				filesContent[k] = v
-			}
-		}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	return filesContent, nil
 }

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -2057,26 +2057,23 @@ func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.Pro
 	filesContent := make(map[string][]byte, len(paths))
 	var mu sync.Mutex
 	group, groupCtx := errgroup.WithContext(ctx)
-	// errgroup.SetLimit(0) does not mean unbounded: it admits no goroutines at
-	// all and Wait blocks forever. Serve applies the default, but an API built
-	// without being served keeps the zero, so the value is clamped where it is
-	// read rather than only where it is configured.
+	// errgroup.SetLimit(0) admits no goroutines and Wait then blocks forever,
+	// so an unset bound falls back to the default here as well as in Serve.
 	fileFetchConcurrency := int(api.Config.Entity.FileFetchConcurrency)
 	if fileFetchConcurrency <= 0 {
 		fileFetchConcurrency = defaultEntityFileFetchConcurrency
 	}
 	group.SetLimit(fileFetchConcurrency)
 	for i := range paths {
-		// A failed read cancels groupCtx, and every read started after that
-		// can only fail with the same error. Stop scheduling them.
+		// A failed read cancels groupCtx; every read started after that can
+		// only fail with the same error.
 		if groupCtx.Err() != nil {
 			break
 		}
 		filePath := paths[i]
 		group.Go(func() (err error) {
-			// errgroup starts a bare goroutine, so a panic here takes the
-			// process down; the serial version this replaces was covered by
-			// the recover in GoRoutines.Exec further up the call chain.
+			// errgroup starts a bare goroutine with no recovery of its own,
+			// so a panic here would reach the runtime and end the process.
 			defer func() {
 				if r := recover(); r != nil {
 					buf := make([]byte, 1<<16)

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -16,8 +16,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-
-	"golang.org/x/sync/errgroup"
 	"time"
 
 	"github.com/go-gorp/gorp"
@@ -25,6 +23,7 @@ import (
 	"github.com/rockbears/log"
 	"github.com/rockbears/yaml"
 	"go.opencensus.io/trace"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ovh/cds/engine/api/database/gorpmapping"
 	"github.com/ovh/cds/engine/api/entity"
@@ -2012,14 +2011,11 @@ func (api *API) analyzeCommitSignatureThroughOperation(ctx context.Context, anal
 	return keyId, analyzeError, nil
 }
 
-// cdsFileFetchConcurrency bounds how many entity files are read from the VCS
-// at once.
-const cdsFileFetchConcurrency = 8
+// defaultEntityFileFetchConcurrency is used when entity.fileFetchConcurrency
+// is not set.
+const defaultEntityFileFetchConcurrency = 8
 
 // listCdsFilePaths walks the .cds tree and returns the entity files in it.
-// Listing is one call per directory, a handful in total; reading the files is
-// the part that scales with the repository, so it is done separately and can
-// then be done in parallel.
 func (api *API) listCdsFilePaths(ctx context.Context, client sdk.VCSAuthorizedClientService, repoName, commit, directory string) ([]string, error) {
 	contents, err := client.ListContent(ctx, repoName, commit, directory, "0", "100")
 	if err != nil {
@@ -2041,19 +2037,8 @@ func (api *API) listCdsFilePaths(ctx context.Context, client sdk.VCSAuthorizedCl
 	return paths, nil
 }
 
-// getCdsFilesOnVCSDirectory reads every entity file under a directory.
-//
-// The files are read concurrently. Read one after another, an analysis costs
-// one network round trip per entity in series, so its duration grows with the
-// number of entities a repository declares rather than with the work involved:
-// a repository with about a hundred and thirty entities took five and a half
-// minutes to analyse while one with far fewer took thirty-six seconds, and the
-// VCS service logged two and a half thousand requests in fifteen minutes,
-// nearly all single-file reads for one analysis. None of that is compute, so
-// it parallelises directly.
-//
-// Bounded rather than unbounded: every read crosses whatever fronts the forge,
-// and that hop, not CDS, is what sets the safe ceiling.
+// getCdsFilesOnVCSDirectory reads every entity file under a directory,
+// concurrently, bounded by entity.fileFetchConcurrency.
 func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.ProjectRepositoryAnalysis, vcsName, repoName, commit, directory string) (map[string][]byte, error) {
 	ctx, next := telemetry.Span(ctx, "api.getCdsFilesOnVCSDirectory")
 	defer next()
@@ -2071,7 +2056,15 @@ func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.Pro
 	filesContent := make(map[string][]byte, len(paths))
 	var mu sync.Mutex
 	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(cdsFileFetchConcurrency)
+	// errgroup.SetLimit(0) does not mean unbounded: it admits no goroutines at
+	// all and Wait blocks forever. Serve applies the default, but an API built
+	// without being served keeps the zero, so the value is clamped where it is
+	// read rather than only where it is configured.
+	fileFetchConcurrency := int(api.Config.Entity.FileFetchConcurrency)
+	if fileFetchConcurrency <= 0 {
+		fileFetchConcurrency = defaultEntityFileFetchConcurrency
+	}
+	group.SetLimit(fileFetchConcurrency)
 	for i := range paths {
 		filePath := paths[i]
 		group.Go(func() error {

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -2066,8 +2067,24 @@ func (api *API) getCdsFilesOnVCSDirectory(ctx context.Context, analysis *sdk.Pro
 	}
 	group.SetLimit(fileFetchConcurrency)
 	for i := range paths {
+		// A failed read cancels groupCtx, and every read started after that
+		// can only fail with the same error. Stop scheduling them.
+		if groupCtx.Err() != nil {
+			break
+		}
 		filePath := paths[i]
-		group.Go(func() error {
+		group.Go(func() (err error) {
+			// errgroup starts a bare goroutine, so a panic here takes the
+			// process down; the serial version this replaces was covered by
+			// the recover in GoRoutines.Exec further up the call chain.
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 1<<16)
+					buf = buf[:runtime.Stack(buf, false)]
+					log.Error(groupCtx, "[PANIC] getCdsFilesOnVCSDirectory> reading %s: %v\n%s", filePath, r, string(buf))
+					err = sdk.WithStack(fmt.Errorf("panic while reading %s: %v", filePath, r))
+				}
+			}()
 			vcsContent, err := client.GetContent(groupCtx, repoName, commit, filePath)
 			if err != nil {
 				return err

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/ovh/cds/engine/api/test/assets"
 	"github.com/ovh/cds/engine/api/user"
 	"github.com/ovh/cds/engine/api/vcs"
+	"strings"
+	"sync/atomic"
+
 	"github.com/ovh/cds/engine/test"
 	"github.com/ovh/cds/sdk"
 )
@@ -4076,4 +4079,194 @@ func TestFindCommitter_GithubUnsignedTag_CommitterNotFound(t *testing.T) {
 	require.Equal(t, sdk.RepositoryAnalysisStatusSkipped, status)
 	require.Contains(t, errMsg, unknownGithubUsername)
 	require.Nil(t, initiator)
+}
+
+// TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded covers both
+// things the change has to get right: the same files come back as when they
+// were read one after another, and the reads genuinely overlap without
+// exceeding the bound.
+//
+// The bound matters as much as the parallelism. Every read crosses whatever
+// fronts the forge, and that hop, not CDS, is what sets the safe ceiling.
+func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	key := sdk.RandomString(10)
+	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
+	vcsProject := assets.InsertTestVCSProject(t, db, proj.ID, "vcs-server", "github")
+
+	repo := sdk.ProjectRepository{
+		Name:         "myrepo",
+		Created:      time.Now(),
+		VCSProjectID: vcsProject.ID,
+		CreatedBy:    "me",
+		CloneURL:     "myurl",
+		ProjectKey:   proj.Key,
+	}
+	require.NoError(t, repository.Insert(ctx, db, &repo))
+
+	analysis := sdk.ProjectRepositoryAnalysis{
+		Status:              sdk.RepositoryAnalysisStatusInProgress,
+		Commit:              "abcdef",
+		ProjectKey:          proj.Key,
+		ProjectRepositoryID: repo.ID,
+		Ref:                 "refs/heads/master",
+		VCSProjectID:        vcsProject.ID,
+	}
+	require.NoError(t, repository.InsertAnalysis(ctx, db, &analysis))
+
+	svc, _ := assets.InsertService(t, db, t.Name()+"_VCS", sdk.TypeVCS)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	servicesClients := mock_services.NewMockClient(ctrl)
+	services.NewClient = func(_ []sdk.Service) services.Client {
+		return servicesClients
+	}
+	defer func() {
+		_ = services.Delete(db, svc)
+		services.NewClient = services.NewDefaultClient
+	}()
+
+	// A tree wide enough that a bound of cdsFileFetchConcurrency is actually
+	// reached, plus a nested directory and a file that must be ignored.
+	const nestedFiles = 24
+	expected := map[string]string{
+		".cds/workflows/root-a.yml":  "root-a",
+		".cds/workflows/root-b.yaml": "root-b",
+	}
+	nested := make([]sdk.VCSContent, 0, nestedFiles)
+	i := 0
+	for i < nestedFiles {
+		name := fmt.Sprintf("nested-%02d.yml", i)
+		nested = append(nested, sdk.VCSContent{Name: name, IsFile: true})
+		expected[".cds/workflows/sub/"+name] = strings.TrimSuffix(name, ".yml")
+		i++
+	}
+
+	var inFlight, maxInFlight, reads int64
+	servicesClients.EXPECT().
+		DoJSONRequest(gomock.Any(), "GET", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, path string, _ interface{}, out interface{}, _ interface{}) (http.Header, int, error) {
+			switch typed := out.(type) {
+			case *[]sdk.VCSContent:
+				// Directory listing. Sequential by design: a handful of calls,
+				// and it is the file reads that scale with the repository.
+				if strings.Contains(path, "sub") {
+					*typed = nested
+					return nil, 200, nil
+				}
+				*typed = []sdk.VCSContent{
+					{Name: "root-a.yml", IsFile: true},
+					{Name: "root-b.yaml", IsFile: true},
+					{Name: "notes.txt", IsFile: true},
+					{Name: "sub", IsDirectory: true},
+				}
+				return nil, 200, nil
+			case *sdk.VCSContent:
+				// One file read. Hold it open briefly so overlap is observable:
+				// serial code can never push the in-flight count above one.
+				current := atomic.AddInt64(&inFlight, 1)
+				for {
+					observed := atomic.LoadInt64(&maxInFlight)
+					if current <= observed || atomic.CompareAndSwapInt64(&maxInFlight, observed, current) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				atomic.AddInt64(&inFlight, -1)
+				atomic.AddInt64(&reads, 1)
+
+				name := path[strings.LastIndex(path, "%2F")+len("%2F"):]
+				if idx := strings.Index(name, "?"); idx >= 0 {
+					name = name[:idx]
+				}
+				body := strings.TrimSuffix(strings.TrimSuffix(name, ".yml"), ".yaml")
+				*typed = sdk.VCSContent{Name: name, IsFile: true, Content: base64.StdEncoding.EncodeToString([]byte(body))}
+				return nil, 200, nil
+			}
+			return nil, 200, nil
+		}).AnyTimes()
+
+	files, err := api.getCdsFilesOnVCSDirectory(ctx, &analysis, "vcs-server", repo.Name, analysis.Commit, ".cds/workflows")
+	require.NoError(t, err)
+
+	// Same result as reading them one at a time: every entity file, decoded,
+	// keyed by full path, and nothing that is not an entity file.
+	require.Len(t, files, len(expected), "every entity file in the tree must come back exactly once")
+	require.NotContains(t, files, ".cds/workflows/notes.txt", "non-entity files must still be ignored")
+	for path, body := range expected {
+		content, ok := files[path]
+		require.True(t, ok, "missing %s", path)
+		require.Equal(t, body, string(content), "content must be base64-decoded, not passed through")
+	}
+
+	require.EqualValues(t, len(expected), atomic.LoadInt64(&reads), "each file must be read once, not repeatedly")
+	observed := atomic.LoadInt64(&maxInFlight)
+	require.Greater(t, observed, int64(1), "reads must overlap; serial reads can never exceed one in flight")
+	require.LessOrEqual(t, observed, int64(cdsFileFetchConcurrency), "reads must stay within the bound, the forge is the constraint")
+}
+
+// TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures checks a failing read
+// still fails the whole call. Concurrency makes this worth pinning: a dropped
+// error would turn a partial read into an analysis that silently sees fewer
+// entities than the repository declares.
+func TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	key := sdk.RandomString(10)
+	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
+	vcsProject := assets.InsertTestVCSProject(t, db, proj.ID, "vcs-server", "github")
+
+	repo := sdk.ProjectRepository{
+		Name:         "myrepo",
+		Created:      time.Now(),
+		VCSProjectID: vcsProject.ID,
+		CreatedBy:    "me",
+		CloneURL:     "myurl",
+		ProjectKey:   proj.Key,
+	}
+	require.NoError(t, repository.Insert(ctx, db, &repo))
+
+	analysis := sdk.ProjectRepositoryAnalysis{
+		Status:              sdk.RepositoryAnalysisStatusInProgress,
+		Commit:              "abcdef",
+		ProjectKey:          proj.Key,
+		ProjectRepositoryID: repo.ID,
+		Ref:                 "refs/heads/master",
+		VCSProjectID:        vcsProject.ID,
+	}
+	require.NoError(t, repository.InsertAnalysis(ctx, db, &analysis))
+
+	svc, _ := assets.InsertService(t, db, t.Name()+"_VCS", sdk.TypeVCS)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	servicesClients := mock_services.NewMockClient(ctrl)
+	services.NewClient = func(_ []sdk.Service) services.Client {
+		return servicesClients
+	}
+	defer func() {
+		_ = services.Delete(db, svc)
+		services.NewClient = services.NewDefaultClient
+	}()
+
+	servicesClients.EXPECT().
+		DoJSONRequest(gomock.Any(), "GET", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, path string, _ interface{}, out interface{}, _ interface{}) (http.Header, int, error) {
+			switch typed := out.(type) {
+			case *[]sdk.VCSContent:
+				*typed = []sdk.VCSContent{
+					{Name: "a.yml", IsFile: true},
+					{Name: "b.yml", IsFile: true},
+				}
+				return nil, 200, nil
+			case *sdk.VCSContent:
+				return nil, 500, sdk.NewErrorFrom(sdk.ErrUnknownError, "vcs is unavailable")
+			}
+			return nil, 200, nil
+		}).AnyTimes()
+
+	_, err := api.getCdsFilesOnVCSDirectory(ctx, &analysis, "vcs-server", repo.Name, analysis.Commit, ".cds/workflows")
+	require.Error(t, err, "a failed read must fail the analysis rather than yield a partial tree")
 }

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -4080,9 +4080,8 @@ func TestFindCommitter_GithubUnsignedTag_CommitterNotFound(t *testing.T) {
 	require.Nil(t, initiator)
 }
 
-// TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded covers both
-// things the change has to get right: the same files come back as when they
-// were read one after another, and the reads genuinely overlap without
+// TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded checks the
+// tree comes back whole and decoded, and that the reads overlap without ever
 // exceeding the configured bound.
 func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testing.T) {
 	api, db, _ := newTestAPI(t)
@@ -4091,8 +4090,8 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 	const bound = 8
 	api.Config.Entity.FileFetchConcurrency = bound
 
-	// A tree wide enough that the bound is actually reached, plus a nested
-	// directory and a file that must be ignored.
+	// Wide enough to reach the bound, with a nested directory and a file that
+	// must be ignored.
 	const nestedFiles = 24
 	expected := map[string]string{
 		".cds/workflows/root-a.yml":  "root-a",
@@ -4109,8 +4108,7 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
 		switch typed := out.(type) {
 		case *[]sdk.VCSContent:
-			// Directory listing. Sequential by design: a handful of calls,
-			// and it is the file reads that scale with the repository.
+			// Directory listing: one call per directory.
 			if strings.Contains(path, "sub") {
 				*typed = nested
 				return 200, nil
@@ -4122,8 +4120,8 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 				{Name: "sub", IsDirectory: true},
 			}
 		case *sdk.VCSContent:
-			// One file read. Hold it open briefly so overlap is observable:
-			// serial code can never push the in-flight count above one.
+			// One file read, held open briefly so the in-flight count is
+			// observable.
 			current := atomic.AddInt64(&inFlight, 1)
 			for {
 				observed := atomic.LoadInt64(&maxInFlight)
@@ -4148,8 +4146,7 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 	files, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
 	require.NoError(t, err)
 
-	// Same result as reading them one at a time: every entity file, decoded,
-	// keyed by full path, and nothing that is not an entity file.
+	// Every entity file, decoded, keyed by full path, and nothing else.
 	require.Len(t, files, len(expected), "every entity file in the tree must come back exactly once")
 	require.NotContains(t, files, ".cds/workflows/notes.txt", "non-entity files must still be ignored")
 	for path, body := range expected {
@@ -4164,10 +4161,8 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 	require.LessOrEqual(t, observed, int64(bound), "reads must stay within the configured bound")
 }
 
-// TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures checks a failing read
-// still fails the whole call. Concurrency makes this worth pinning: a dropped
-// error would turn a partial read into an analysis that silently sees fewer
-// entities than the repository declares.
+// TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures checks one failing read
+// fails the whole call rather than returning a partial tree.
 func TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
@@ -4191,7 +4186,8 @@ func TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures(t *testing.T) {
 }
 
 // analysisFixtureForFileReads builds the project, repository and analysis the
-// entity-file read path needs, and installs a mocked VCS service client.
+// entity-file read path needs, and installs a mocked VCS service client. The
+// handler decides what the VCS answers for a listing or a file read.
 func analysisFixtureForFileReads(t *testing.T, api *API, db *test.FakeTransaction, handler func(path string, out interface{}) (int, error)) *sdk.ProjectRepositoryAnalysis {
 	ctx := context.TODO()
 
@@ -4241,12 +4237,9 @@ func analysisFixtureForFileReads(t *testing.T, api *API, db *test.FakeTransactio
 	return &analysis
 }
 
-// TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency pins that the
-// bound comes from configuration and not from the default: set to one, the
-// reads must not overlap at all. Forges differ in what they will take -- some
-// rate limit concurrent requests, some limit calls per minute -- so an
-// operator has to be able to lower this, and a knob that is read but ignored
-// looks exactly like one that works.
+// TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency checks the bound
+// comes from configuration rather than from the default: set to one, the reads
+// must not overlap at all.
 func TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
@@ -4284,16 +4277,14 @@ func TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency(t *testing.T) {
 }
 
 // TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency
-// pins the failure mode that makes an unset bound hang rather than fail:
-// errgroup's SetLimit(0) admits no goroutines, so Wait blocks forever. Serve
-// fills the default in, but anything building an API without serving it --
-// every test in this package -- leaves the value at zero, and reading it
-// unclamped stops the whole package with no failing assertion to point at.
+// checks an unset bound falls back to the default instead of blocking forever,
+// which is what errgroup.SetLimit(0) does. The assertion is that the call
+// finishes at all, so it is written as a bounded wait.
 func TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
 
-	// Explicitly unset, as it is for any API that has not been through Serve.
+	// Unset, as for any API that has not been through Serve.
 	api.Config.Entity.FileFetchConcurrency = 0
 
 	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
@@ -4324,12 +4315,9 @@ func TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency(t 
 	require.Len(t, files, 2)
 }
 
-// TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic pins that a panic in a
-// read fails the analysis instead of the process. errgroup starts bare
-// goroutines with no recovery of their own -- x/sync removed it deliberately
-// -- where the serial version this replaces was covered by the recover in
-// GoRoutines.Exec further up the call chain. Without the recover here this
-// test does not fail, it takes the test binary down with it.
+// TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic checks a panic in one
+// read is returned as an error from the call. Without the recover it is not a
+// failing assertion, it is the test binary ending.
 func TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
@@ -4352,10 +4340,8 @@ func TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic(t *testing.T) {
 	require.Contains(t, err.Error(), "panic while reading")
 }
 
-// TestGetCdsFilesOnVCSDirectoryStopsSchedulingAfterAFailure pins that a failed
-// read ends the fan-out. Once the group's context is cancelled every read
-// started after it can only fail with the same error, so scheduling the rest
-// of a large repository is work the forge is asked for and nothing can use.
+// TestGetCdsFilesOnVCSDirectoryStopsSchedulingAfterAFailure checks a failure
+// part way through a large tree stops the remaining reads being scheduled.
 func TestGetCdsFilesOnVCSDirectoryStopsSchedulingAfterAFailure(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -4323,3 +4323,63 @@ func TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency(t 
 	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
+
+// TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic pins that a panic in a
+// read fails the analysis instead of the process. errgroup starts bare
+// goroutines with no recovery of their own -- x/sync removed it deliberately
+// -- where the serial version this replaces was covered by the recover in
+// GoRoutines.Exec further up the call chain. Without the recover here this
+// test does not fail, it takes the test binary down with it.
+func TestGetCdsFilesOnVCSDirectoryRecoversFromAReadPanic(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	api.Config.Entity.FileFetchConcurrency = 2
+
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			*typed = []sdk.VCSContent{{Name: "a.yml", IsFile: true}, {Name: "b.yml", IsFile: true}}
+		case *sdk.VCSContent:
+			_ = typed
+			panic("boom")
+		}
+		return 200, nil
+	})
+
+	_, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
+	require.Error(t, err, "a panic in a read must fail the analysis, not the API process")
+	require.Contains(t, err.Error(), "panic while reading")
+}
+
+// TestGetCdsFilesOnVCSDirectoryStopsSchedulingAfterAFailure pins that a failed
+// read ends the fan-out. Once the group's context is cancelled every read
+// started after it can only fail with the same error, so scheduling the rest
+// of a large repository is work the forge is asked for and nothing can use.
+func TestGetCdsFilesOnVCSDirectoryStopsSchedulingAfterAFailure(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	api.Config.Entity.FileFetchConcurrency = 1
+
+	const total = 200
+	var reads int64
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			contents := make([]sdk.VCSContent, 0, total)
+			for i := 0; i < total; i++ {
+				contents = append(contents, sdk.VCSContent{Name: fmt.Sprintf("f-%03d.yml", i), IsFile: true})
+			}
+			*typed = contents
+		case *sdk.VCSContent:
+			atomic.AddInt64(&reads, 1)
+			return 500, sdk.NewErrorFrom(sdk.ErrUnknownError, "vcs is unavailable")
+		}
+		return 200, nil
+	})
+
+	_, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
+	require.Error(t, err)
+	require.Less(t, atomic.LoadInt64(&reads), int64(total), "reads must stop once the group's context is cancelled")
+}

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -13,6 +13,8 @@ import (
 
 	"io"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,9 +29,6 @@ import (
 	"github.com/ovh/cds/engine/api/test/assets"
 	"github.com/ovh/cds/engine/api/user"
 	"github.com/ovh/cds/engine/api/vcs"
-	"strings"
-	"sync/atomic"
-
 	"github.com/ovh/cds/engine/test"
 	"github.com/ovh/cds/sdk"
 )
@@ -4084,111 +4083,69 @@ func TestFindCommitter_GithubUnsignedTag_CommitterNotFound(t *testing.T) {
 // TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded covers both
 // things the change has to get right: the same files come back as when they
 // were read one after another, and the reads genuinely overlap without
-// exceeding the bound.
-//
-// The bound matters as much as the parallelism. Every read crosses whatever
-// fronts the forge, and that hop, not CDS, is what sets the safe ceiling.
+// exceeding the configured bound.
 func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
 
-	key := sdk.RandomString(10)
-	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
-	vcsProject := assets.InsertTestVCSProject(t, db, proj.ID, "vcs-server", "github")
+	const bound = 8
+	api.Config.Entity.FileFetchConcurrency = bound
 
-	repo := sdk.ProjectRepository{
-		Name:         "myrepo",
-		Created:      time.Now(),
-		VCSProjectID: vcsProject.ID,
-		CreatedBy:    "me",
-		CloneURL:     "myurl",
-		ProjectKey:   proj.Key,
-	}
-	require.NoError(t, repository.Insert(ctx, db, &repo))
-
-	analysis := sdk.ProjectRepositoryAnalysis{
-		Status:              sdk.RepositoryAnalysisStatusInProgress,
-		Commit:              "abcdef",
-		ProjectKey:          proj.Key,
-		ProjectRepositoryID: repo.ID,
-		Ref:                 "refs/heads/master",
-		VCSProjectID:        vcsProject.ID,
-	}
-	require.NoError(t, repository.InsertAnalysis(ctx, db, &analysis))
-
-	svc, _ := assets.InsertService(t, db, t.Name()+"_VCS", sdk.TypeVCS)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	servicesClients := mock_services.NewMockClient(ctrl)
-	services.NewClient = func(_ []sdk.Service) services.Client {
-		return servicesClients
-	}
-	defer func() {
-		_ = services.Delete(db, svc)
-		services.NewClient = services.NewDefaultClient
-	}()
-
-	// A tree wide enough that a bound of cdsFileFetchConcurrency is actually
-	// reached, plus a nested directory and a file that must be ignored.
+	// A tree wide enough that the bound is actually reached, plus a nested
+	// directory and a file that must be ignored.
 	const nestedFiles = 24
 	expected := map[string]string{
 		".cds/workflows/root-a.yml":  "root-a",
 		".cds/workflows/root-b.yaml": "root-b",
 	}
 	nested := make([]sdk.VCSContent, 0, nestedFiles)
-	i := 0
-	for i < nestedFiles {
+	for i := 0; i < nestedFiles; i++ {
 		name := fmt.Sprintf("nested-%02d.yml", i)
 		nested = append(nested, sdk.VCSContent{Name: name, IsFile: true})
 		expected[".cds/workflows/sub/"+name] = strings.TrimSuffix(name, ".yml")
-		i++
 	}
 
 	var inFlight, maxInFlight, reads int64
-	servicesClients.EXPECT().
-		DoJSONRequest(gomock.Any(), "GET", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, path string, _ interface{}, out interface{}, _ interface{}) (http.Header, int, error) {
-			switch typed := out.(type) {
-			case *[]sdk.VCSContent:
-				// Directory listing. Sequential by design: a handful of calls,
-				// and it is the file reads that scale with the repository.
-				if strings.Contains(path, "sub") {
-					*typed = nested
-					return nil, 200, nil
-				}
-				*typed = []sdk.VCSContent{
-					{Name: "root-a.yml", IsFile: true},
-					{Name: "root-b.yaml", IsFile: true},
-					{Name: "notes.txt", IsFile: true},
-					{Name: "sub", IsDirectory: true},
-				}
-				return nil, 200, nil
-			case *sdk.VCSContent:
-				// One file read. Hold it open briefly so overlap is observable:
-				// serial code can never push the in-flight count above one.
-				current := atomic.AddInt64(&inFlight, 1)
-				for {
-					observed := atomic.LoadInt64(&maxInFlight)
-					if current <= observed || atomic.CompareAndSwapInt64(&maxInFlight, observed, current) {
-						break
-					}
-				}
-				time.Sleep(20 * time.Millisecond)
-				atomic.AddInt64(&inFlight, -1)
-				atomic.AddInt64(&reads, 1)
-
-				name := path[strings.LastIndex(path, "%2F")+len("%2F"):]
-				if idx := strings.Index(name, "?"); idx >= 0 {
-					name = name[:idx]
-				}
-				body := strings.TrimSuffix(strings.TrimSuffix(name, ".yml"), ".yaml")
-				*typed = sdk.VCSContent{Name: name, IsFile: true, Content: base64.StdEncoding.EncodeToString([]byte(body))}
-				return nil, 200, nil
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			// Directory listing. Sequential by design: a handful of calls,
+			// and it is the file reads that scale with the repository.
+			if strings.Contains(path, "sub") {
+				*typed = nested
+				return 200, nil
 			}
-			return nil, 200, nil
-		}).AnyTimes()
+			*typed = []sdk.VCSContent{
+				{Name: "root-a.yml", IsFile: true},
+				{Name: "root-b.yaml", IsFile: true},
+				{Name: "notes.txt", IsFile: true},
+				{Name: "sub", IsDirectory: true},
+			}
+		case *sdk.VCSContent:
+			// One file read. Hold it open briefly so overlap is observable:
+			// serial code can never push the in-flight count above one.
+			current := atomic.AddInt64(&inFlight, 1)
+			for {
+				observed := atomic.LoadInt64(&maxInFlight)
+				if current <= observed || atomic.CompareAndSwapInt64(&maxInFlight, observed, current) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
+			atomic.AddInt64(&reads, 1)
 
-	files, err := api.getCdsFilesOnVCSDirectory(ctx, &analysis, "vcs-server", repo.Name, analysis.Commit, ".cds/workflows")
+			name := path[strings.LastIndex(path, "%2F")+len("%2F"):]
+			if idx := strings.Index(name, "?"); idx >= 0 {
+				name = name[:idx]
+			}
+			body := strings.TrimSuffix(strings.TrimSuffix(name, ".yml"), ".yaml")
+			*typed = sdk.VCSContent{Name: name, IsFile: true, Content: base64.StdEncoding.EncodeToString([]byte(body))}
+		}
+		return 200, nil
+	})
+
+	files, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
 	require.NoError(t, err)
 
 	// Same result as reading them one at a time: every entity file, decoded,
@@ -4204,7 +4161,7 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 	require.EqualValues(t, len(expected), atomic.LoadInt64(&reads), "each file must be read once, not repeatedly")
 	observed := atomic.LoadInt64(&maxInFlight)
 	require.Greater(t, observed, int64(1), "reads must overlap; serial reads can never exceed one in flight")
-	require.LessOrEqual(t, observed, int64(cdsFileFetchConcurrency), "reads must stay within the bound, the forge is the constraint")
+	require.LessOrEqual(t, observed, int64(bound), "reads must stay within the configured bound")
 }
 
 // TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures checks a failing read
@@ -4213,6 +4170,29 @@ func TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded(t *testin
 // entities than the repository declares.
 func TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures(t *testing.T) {
 	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			*typed = []sdk.VCSContent{
+				{Name: "a.yml", IsFile: true},
+				{Name: "b.yml", IsFile: true},
+			}
+		case *sdk.VCSContent:
+			_ = typed
+			return 500, sdk.NewErrorFrom(sdk.ErrUnknownError, "vcs is unavailable")
+		}
+		return 200, nil
+	})
+
+	_, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
+	require.Error(t, err, "a failed read must fail the analysis rather than yield a partial tree")
+}
+
+// analysisFixtureForFileReads builds the project, repository and analysis the
+// entity-file read path needs, and installs a mocked VCS service client.
+func analysisFixtureForFileReads(t *testing.T, api *API, db *test.FakeTransaction, handler func(path string, out interface{}) (int, error)) *sdk.ProjectRepositoryAnalysis {
 	ctx := context.TODO()
 
 	key := sdk.RandomString(10)
@@ -4241,32 +4221,105 @@ func TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures(t *testing.T) {
 
 	svc, _ := assets.InsertService(t, db, t.Name()+"_VCS", sdk.TypeVCS)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	servicesClients := mock_services.NewMockClient(ctrl)
 	services.NewClient = func(_ []sdk.Service) services.Client {
 		return servicesClients
 	}
-	defer func() {
+	t.Cleanup(func() {
 		_ = services.Delete(db, svc)
 		services.NewClient = services.NewDefaultClient
-	}()
+		ctrl.Finish()
+	})
 
 	servicesClients.EXPECT().
 		DoJSONRequest(gomock.Any(), "GET", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _, path string, _ interface{}, out interface{}, _ interface{}) (http.Header, int, error) {
-			switch typed := out.(type) {
-			case *[]sdk.VCSContent:
-				*typed = []sdk.VCSContent{
-					{Name: "a.yml", IsFile: true},
-					{Name: "b.yml", IsFile: true},
-				}
-				return nil, 200, nil
-			case *sdk.VCSContent:
-				return nil, 500, sdk.NewErrorFrom(sdk.ErrUnknownError, "vcs is unavailable")
-			}
-			return nil, 200, nil
+			code, err := handler(path, out)
+			return nil, code, err
 		}).AnyTimes()
 
-	_, err := api.getCdsFilesOnVCSDirectory(ctx, &analysis, "vcs-server", repo.Name, analysis.Commit, ".cds/workflows")
-	require.Error(t, err, "a failed read must fail the analysis rather than yield a partial tree")
+	return &analysis
+}
+
+// TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency pins that the
+// bound comes from configuration and not from the default: set to one, the
+// reads must not overlap at all. Forges differ in what they will take -- some
+// rate limit concurrent requests, some limit calls per minute -- so an
+// operator has to be able to lower this, and a knob that is read but ignored
+// looks exactly like one that works.
+func TestGetCdsFilesOnVCSDirectoryHonoursConfiguredConcurrency(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	api.Config.Entity.FileFetchConcurrency = 1
+
+	var inFlight, maxInFlight int64
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			contents := make([]sdk.VCSContent, 0, 12)
+			for i := 0; i < 12; i++ {
+				contents = append(contents, sdk.VCSContent{Name: fmt.Sprintf("f-%02d.yml", i), IsFile: true})
+			}
+			*typed = contents
+		case *sdk.VCSContent:
+			current := atomic.AddInt64(&inFlight, 1)
+			for {
+				observed := atomic.LoadInt64(&maxInFlight)
+				if current <= observed || atomic.CompareAndSwapInt64(&maxInFlight, observed, current) {
+					break
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
+			*typed = sdk.VCSContent{IsFile: true, Content: base64.StdEncoding.EncodeToString([]byte("x"))}
+		}
+		return 200, nil
+	})
+
+	files, err := api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
+	require.NoError(t, err)
+	require.Len(t, files, 12)
+	require.EqualValues(t, 1, atomic.LoadInt64(&maxInFlight), "with the bound configured to one the reads must not overlap")
+}
+
+// TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency
+// pins the failure mode that makes an unset bound hang rather than fail:
+// errgroup's SetLimit(0) admits no goroutines, so Wait blocks forever. Serve
+// fills the default in, but anything building an API without serving it --
+// every test in this package -- leaves the value at zero, and reading it
+// unclamped stops the whole package with no failing assertion to point at.
+func TestGetCdsFilesOnVCSDirectoryDoesNotDeadlockWithoutConfiguredConcurrency(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+
+	// Explicitly unset, as it is for any API that has not been through Serve.
+	api.Config.Entity.FileFetchConcurrency = 0
+
+	analysis := analysisFixtureForFileReads(t, api, db, func(path string, out interface{}) (int, error) {
+		switch typed := out.(type) {
+		case *[]sdk.VCSContent:
+			*typed = []sdk.VCSContent{{Name: "a.yml", IsFile: true}, {Name: "b.yml", IsFile: true}}
+		case *sdk.VCSContent:
+			*typed = sdk.VCSContent{IsFile: true, Content: base64.StdEncoding.EncodeToString([]byte("x"))}
+		}
+		return 200, nil
+	})
+
+	// The deadlock shows up as the package timing out with no failing test, so
+	// bound it here: this must finish, and finishing is the assertion.
+	done := make(chan struct{})
+	var files map[string][]byte
+	var err error
+	go func() {
+		defer close(done)
+		files, err = api.getCdsFilesOnVCSDirectory(ctx, analysis, "vcs-server", "myrepo", analysis.Commit, ".cds/workflows")
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("getCdsFilesOnVCSDirectory blocked with fileFetchConcurrency unset: an unset bound must fall back to the default, not deadlock")
+	}
+	require.NoError(t, err)
+	require.Len(t, files, 2)
 }

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.39.0
 	golang.org/x/time v0.15.0
@@ -316,7 +317,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	google.golang.org/api v0.275.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect


### PR DESCRIPTION
1. Description

`getCdsFilesOnVCSDirectory` read each entity file with its own `GetContent`
call, in series. Every read is a round trip to the VCS service and on to the
forge, so an analysis cost one serial round trip per entity and its duration
scaled with how many entities a repository declares rather than with the work of
analysing them.

On our instance a repository with ~130 `.cds` entities took 5 min 30 s to
analyse while one with few entities took 36 s, and the VCS service logged 2,453
requests in fifteen minutes — nearly all single-file reads serving one analysis.
Round-trip latency to the forge was p50 1237 ms, so ~130 files in series is
around 160 s of pure waiting.

The listing is unchanged and still sequential: it is one call per directory, a
handful in total. Only the reads, which are what scales, are fanned out, with a
bounded group so the forge is not flooded.

Result on the 130-entity repository: 330 s → 114 s.

Note this path is taken by Gitea, GitHub, GitLab and Forgejo; Bitbucket already
fetches an archive in one call via `getCdsArchiveFileOnRepo`.

One note on the bound. It is a constant here, at 8. We run this as a
configurable value set to 16 and saw bursts of 14-15 concurrent completions in
the VCS service logs, so the ceiling does bind in practice rather than being
theoretical. A constant seemed right for upstream, since the sensible value
depends on what fronts the forge rather than on anything an operator can
readily see — but if you would rather it were configurable, that is a small
change and I am happy to make it.

1. Related issues

Closes #7834

1. About tests

Two tests in `engine/api/v2_repository_analyze_test.go`, against a live Postgres
with the VCS service mocked:

- `TestGetCdsFilesOnVCSDirectoryReadsEveryFileConcurrentlyAndBounded` — a tree
  of twenty-six entity files across a directory and a subdirectory, plus a
  `.txt` that must be ignored. Asserts the same result the serial version
  produced: every entity file exactly once, keyed by full path, base64-decoded,
  and nothing that is not an entity file. It also holds each mocked read open
  briefly and tracks the peak number in flight, asserting that peak exceeds one
  — serial code can never do that — and never exceeds the bound.
- `TestGetCdsFilesOnVCSDirectoryPropagatesReadFailures` — a failing read must
  fail the whole call. Worth pinning under concurrency: a dropped error would
  turn a partial read into an analysis that silently sees fewer entities than
  the repository declares.

The full `engine/api` package suite passes against a live Postgres and Redis
(on a freshly migrated schema; a few unrelated tests in that package are
sensitive to accumulated database state and fail on an unclean one, on master
too).

1. Mentions

@ovh/cds
