### PR TITLE
perf(hooks): run the next state of a hook event without waiting for the sweep

### DIFF
--- a/engine/hooks/scheduler_repository_event.go
+++ b/engine/hooks/scheduler_repository_event.go
@@ -163,6 +163,10 @@ func (s *Service) manageRepositoryEvent(ctx context.Context, eventKey string) er
 }
 
 func (s *Service) executeEvent(ctx context.Context, hre *sdk.HookRepositoryEvent) error {
+	// One pass advances the event by at most one state. Whether the next state
+	// runs now or waits for the sweep is decided at the end of this function.
+	statusOnEntry := hre.Status
+
 	ctx, next := telemetry.Span(ctx, "s.executeEvent")
 	defer next()
 	defer func() {
@@ -230,5 +234,33 @@ func (s *Service) executeEvent(ctx context.Context, hre *sdk.HookRepositoryEvent
 			log.Error(ctx, "executeEvent >unable to remove event %s from inprogress list: %v", hre.UUID, err)
 		}
 	}
+
+	// Run the next state now rather than waiting to be swept up.
+	//
+	// A push walks Scheduled -> Analysis -> WorkflowHooks -> GitInfo ->
+	// Workflow, and each pass through this function handles exactly one of
+	// them. Nothing re-queued the event in between, so every transition waited
+	// for manageOldRepositoryEvent, which ticks once per
+	// OldRepositoryEventRetry minute: four or five states meant minutes between
+	// a push and its run while the work itself took seconds.
+	//
+	// Only re-queue when this pass actually moved the event. A trigger that
+	// returns without advancing is waiting on something it does not own — an
+	// analysis still running, an operation outstanding — and re-queueing that
+	// would spin the worker instead of waiting for the callback that resolves
+	// it. The periodic sweep stays as the backstop for exactly those.
+	if hre.Status != statusOnEntry && !isTerminalHookEventStatus(hre.Status) {
+		if err := s.Dao.EnqueueRepositoryEvent(ctx, hre); err != nil {
+			return sdk.WrapError(err, "unable to enqueue repository event %s for its next state", hre.GetFullName())
+		}
+	}
 	return nil
+}
+
+func isTerminalHookEventStatus(status string) bool {
+	switch status {
+	case sdk.HookEventStatusDone, sdk.HookEventStatusSkipped, sdk.HookEventStatusError:
+		return true
+	}
+	return false
 }

--- a/engine/hooks/scheduler_repository_event_test.go
+++ b/engine/hooks/scheduler_repository_event_test.go
@@ -184,3 +184,161 @@ func TestManageRepositoryEvent_NonPushEventWorkflowToTrigger(t *testing.T) {
 	k := cache.Key(repositoryEventRootKey, s.Dao.GetRepositoryMemberKey(hr.VCSServerName, hr.RepositoryName), hr.UUID)
 	require.NoError(t, s.manageRepositoryEvent(context.TODO(), k))
 }
+
+// TestExecuteEventRequeuesItselfWhenItAdvances covers the reason the re-queue
+// exists. One pass moves the event by a single state, and before this nothing
+// put it back on the queue, so every transition waited for the periodic sweep —
+// minutes per state for work that takes seconds.
+func TestExecuteEventRequeuesItselfWhenItAdvances(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	s, cancel := setupTestHookService(t)
+	defer cancel()
+
+	event := GiteaEventPayload{}
+	event.Repository.FullName = "ovh/cds"
+	event.Ref = "master"
+	event.After = "123456"
+	bts, _ := json.Marshal(event)
+
+	hr := sdk.HookRepositoryEvent{
+		UUID:           sdk.UUID(),
+		VCSServerName:  "private-github",
+		RepositoryName: "ovh/cds",
+		Status:         sdk.HookEventStatusScheduled,
+		EventName:      sdk.WorkflowHookEventNamePush,
+		Created:        time.Now().UnixNano(),
+		Body:           bts,
+		ExtractData: sdk.HookRepositoryEventExtractData{
+			Ref:    "refs/heads/master",
+			Commit: "123456",
+		},
+	}
+	require.NoError(t, s.Dao.SaveRepositoryEvent(context.TODO(), &hr))
+	_, err := s.Dao.CreateRepository(context.TODO(), hr.VCSServerName, hr.RepositoryName)
+	require.NoError(t, err)
+
+	s.Client.(*mock_cdsclient.MockInterface).EXPECT().CreateInsightReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	s.Client.(*mock_cdsclient.MockInterface).EXPECT().HookRepositoriesList(gomock.Any(), hr.VCSServerName, hr.RepositoryName).Return([]sdk.ProjectRepository{
+		{Name: hr.RepositoryName, ProjectKey: "TEST"},
+	}, nil).Times(1)
+	s.Client.(*mock_cdsclient.MockInterface).EXPECT().ProjectRepositoryAnalysis(gomock.Any(), gomock.Any()).Times(1)
+
+	// Relative, not absolute: the queue is shared and other work may sit in it.
+	before, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+
+	require.NoError(t, s.executeEvent(context.TODO(), &hr))
+
+	require.Equal(t, sdk.HookEventStatusAnalysis, hr.Status, "the pass must have advanced the event")
+	after, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+	require.Equal(t, before+1, after, "an event that advanced must be queued again so its next state runs now rather than at the next sweep")
+}
+
+// TestExecuteEventDoesNotRequeueWhileWaiting covers the other half of the
+// condition, which is the half that carries the risk. An event that did not
+// advance is waiting on something it does not own — here an analysis still
+// running — and re-queueing it would spin the worker instead of waiting for the
+// callback that resolves it. Measured worse when we tried the unconditional
+// form: the dequeue loop is serial, so parked events crowd out real work.
+func TestExecuteEventDoesNotRequeueWhileWaiting(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	s, cancel := setupTestHookService(t)
+	defer cancel()
+
+	event := GiteaEventPayload{}
+	event.Repository.FullName = "ovh/cds"
+	event.Ref = "master"
+	event.After = "123456"
+	bts, _ := json.Marshal(event)
+
+	hr := sdk.HookRepositoryEvent{
+		UUID:           sdk.UUID(),
+		VCSServerName:  "private-github",
+		RepositoryName: "ovh/cds",
+		Status:         sdk.HookEventStatusAnalysis,
+		EventName:      sdk.WorkflowHookEventNamePush,
+		Created:        time.Now().UnixNano(),
+		// Recent, so the analysis is genuinely considered still in flight
+		// rather than due for a status re-check.
+		LastUpdate: time.Now().UnixMilli(),
+		Body:       bts,
+		Analyses: []sdk.HookRepositoryEventAnalysis{
+			{
+				ProjectKey: "TEST",
+				Status:     sdk.RepositoryAnalysisStatusInProgress,
+				AnalyzeID:  sdk.UUID(),
+			},
+		},
+	}
+	require.NoError(t, s.Dao.SaveRepositoryEvent(context.TODO(), &hr))
+	_, err := s.Dao.CreateRepository(context.TODO(), hr.VCSServerName, hr.RepositoryName)
+	require.NoError(t, err)
+
+	s.Client.(*mock_cdsclient.MockInterface).EXPECT().CreateInsightReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	before, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+
+	require.NoError(t, s.executeEvent(context.TODO(), &hr))
+
+	require.Equal(t, sdk.HookEventStatusAnalysis, hr.Status, "the event must not have advanced")
+	after, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+	require.Equal(t, before, after, "an event still waiting must be left to the periodic sweep, not re-queued into a spin")
+}
+
+// TestExecuteEventDoesNotRequeueTerminalEvents guards the other exit: a
+// finished event must leave the queue rather than be put back on it.
+func TestExecuteEventDoesNotRequeueTerminalEvents(t *testing.T) {
+	log.Factory = log.NewTestingWrapper(t)
+	s, cancel := setupTestHookService(t)
+	defer cancel()
+
+	event := GiteaEventPayload{}
+	event.Repository.FullName = "ovh/cds"
+	event.Ref = "master"
+	event.After = "123456"
+	bts, _ := json.Marshal(event)
+
+	hr := sdk.HookRepositoryEvent{
+		UUID:           sdk.UUID(),
+		VCSServerName:  "private-github",
+		RepositoryName: "ovh/cds",
+		Status:         sdk.HookEventStatusDone,
+		EventName:      sdk.WorkflowHookEventNamePush,
+		Created:        time.Now().UnixNano(),
+		Body:           bts,
+	}
+	require.NoError(t, s.Dao.SaveRepositoryEvent(context.TODO(), &hr))
+	_, err := s.Dao.CreateRepository(context.TODO(), hr.VCSServerName, hr.RepositoryName)
+	require.NoError(t, err)
+
+	s.Client.(*mock_cdsclient.MockInterface).EXPECT().CreateInsightReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	before, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+
+	require.NoError(t, s.executeEvent(context.TODO(), &hr))
+
+	after, err := s.Dao.RepositoryEventQueueLen()
+	require.NoError(t, err)
+	require.Equal(t, before, after, "a finished event must not be put back on the queue")
+}
+
+// TestIsTerminalHookEventStatus pins which states end an event. Getting this
+// wrong in either direction is silent: a terminal state treated as
+// intermediate is re-queued forever, an intermediate state treated as terminal
+// stalls exactly like the bug this change fixes.
+func TestIsTerminalHookEventStatus(t *testing.T) {
+	require.True(t, isTerminalHookEventStatus(sdk.HookEventStatusDone))
+	require.True(t, isTerminalHookEventStatus(sdk.HookEventStatusSkipped))
+	require.True(t, isTerminalHookEventStatus(sdk.HookEventStatusError))
+
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusScheduled))
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusAnalysis))
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusCheckAnalysis))
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusWorkflowHooks))
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusGitInfo))
+	require.False(t, isTerminalHookEventStatus(sdk.HookEventStatusWorkflow))
+}


### PR DESCRIPTION
1. Description

`executeEvent` advances a hook event by at most one state per dequeue and
nothing re-queued it afterwards, so each transition waited for
`manageOldRepositoryEvent` — a ticker of `OldRepositoryEventRetry` minutes,
default 1. A push walks Scheduled -> Analysis -> WorkflowHooks -> GitInfo ->
Workflow, so it paid that interval four or five times over while the work in
each state took seconds.

This was not congestion. The queue was empty throughout (`Queue 0`, dequeue
goroutines running, more events out than in). On one measured push the analysis
completed 2 seconds after the event was created, and the run appeared 2 minutes
49 seconds later.

The event is now re-queued as soon as a pass advances it, so the states chain.

Only when the status actually changed. A trigger that returns without advancing
is waiting on something it does not own — an analysis still running, an
operation outstanding — and re-queueing that spins the worker rather than
waiting for the callback that resolves it. We tried the unconditional form and
measured it worse (94s -> 141s and 182s): the dequeue loop is serial, so parked
events crowd out real work. The periodic sweep remains the backstop for states
that are genuinely waiting.

Traced per transition after the change: +6s Analyzing, +31s GitInfo, +36s Done.

1. Related issues

Closes #7835

1. About tests

Four tests in `engine/hooks/scheduler_repository_event_test.go`, against a live
Redis. Both sides of the condition are covered, and each side fails if removed:

- `TestExecuteEventRequeuesItselfWhenItAdvances` — a push event at Scheduled
  advances to Analysis and must be back on the queue. Red without the re-queue.
- `TestExecuteEventDoesNotRequeueWhileWaiting` — an event at Analysis whose
  analysis is still running does not advance and must not be re-queued. Red
  against the unconditional form described above, which is the variant we tried
  first and measured worse.
- `TestExecuteEventDoesNotRequeueTerminalEvents` — a finished event must leave
  the queue rather than be put back on it.
- `TestIsTerminalHookEventStatus` — pins which states end an event. Getting this
  wrong is silent in either direction: a terminal state treated as intermediate
  is re-queued forever, an intermediate state treated as terminal stalls exactly
  like the bug this fixes.

Queue assertions are relative rather than absolute, since the queue is shared.

The full `engine/hooks` package suite passes (29 tests) against a live Redis,
which is also where a re-queue loop or goroutine leak would surface.

Verified in production for several hours: no growth in the event queue, no
repeated processing of the same event, and push-to-run latency reduced as above.

1. Mentions

@ovh/cds
