### PR TITLE
fix(api): keep the newest analyses visible to the poller

### DIFF
--- a/engine/api/repository/dao_vcs_project_repository_analyze.go
+++ b/engine/api/repository/dao_vcs_project_repository_analyze.go
@@ -112,8 +112,16 @@ func LoadAnalysesByRepo(ctx context.Context, db gorp.SqlExecutor, projectReposit
 	return getAnalyses(ctx, db, query)
 }
 
+// LoadRepositoryIDsAnalysisInProgress returns the analyses the poller should
+// pick up next.
+//
+// The ordering matters. This is a fixed-size window over every row sitting in
+// InProgress, and an analysis whose owner died stays in that state, so without
+// an order the window fills with whichever hundred rows the table happens to
+// return and newly created analyses may never be seen at all. Newest first
+// keeps fresh work reachable however large the backlog grows.
 func LoadRepositoryIDsAnalysisInProgress(ctx context.Context, db gorp.SqlExecutor) ([]sdk.ProjectRepositoryAnalysis, error) {
-	query := gorpmapping.NewQuery("SELECT * FROM project_repository_analysis WHERE status = $1 LIMIT 100").Args(sdk.RepositoryAnalysisStatusInProgress)
+	query := gorpmapping.NewQuery("SELECT * FROM project_repository_analysis WHERE status = $1 ORDER BY created DESC LIMIT 100").Args(sdk.RepositoryAnalysisStatusInProgress)
 	return getAnalyses(ctx, db, query)
 }
 

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ovh/cds/engine/api/test/assets"
 	"github.com/ovh/cds/engine/api/user"
 	"github.com/ovh/cds/engine/api/vcs"
+	"github.com/ovh/cds/engine/gorpmapper"
 	"github.com/ovh/cds/engine/test"
 	"github.com/ovh/cds/sdk"
 )
@@ -4076,4 +4077,79 @@ func TestFindCommitter_GithubUnsignedTag_CommitterNotFound(t *testing.T) {
 	require.Equal(t, sdk.RepositoryAnalysisStatusSkipped, status)
 	require.Contains(t, errMsg, unknownGithubUsername)
 	require.Nil(t, initiator)
+}
+
+// insertAnalysisPollerTestRepository builds the minimum a repository analysis
+// needs to exist: a project, a VCS server on it, and a repository.
+func insertAnalysisPollerTestRepository(t *testing.T, api *API, db *test.FakeTransaction) sdk.ProjectRepository {
+	t.Helper()
+	key := sdk.RandomString(10)
+	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
+	vcsProject := assets.InsertTestVCSProject(t, db, proj.ID, "vcs-server", "github")
+	repo := sdk.ProjectRepository{
+		Name:         "myrepo",
+		Created:      time.Now(),
+		VCSProjectID: vcsProject.ID,
+		CreatedBy:    "me",
+		CloneURL:     "myurl",
+		ProjectKey:   proj.Key,
+	}
+	require.NoError(t, repository.Insert(context.TODO(), db, &repo))
+	return repo
+}
+
+// backdateAnalysisCreation moves created into the past in place. Safe to do in
+// SQL: the signed canonical form is {ID}{ProjectRepositoryID}{VCSProjectID}
+// {ProjectKey}{Commit}, so timestamps sit outside the signature.
+func backdateAnalysisCreation(t *testing.T, db gorpmapper.SqlExecutorWithTx, analysisID string, age time.Duration) {
+	t.Helper()
+	_, err := db.Exec("UPDATE project_repository_analysis SET created = $1 WHERE id = $2", time.Now().Add(-age), analysisID)
+	require.NoError(t, err)
+}
+
+// TestAnalysisInProgressPollerSeesNewestWorkPastABacklog builds a backlog
+// larger than the poller's window and checks that a freshly created analysis is
+// still returned.
+//
+// This is the failure the ordering exists to prevent: an analysis whose owner
+// died stays InProgress forever, and with an unordered LIMIT the window filled
+// with whichever rows the table happened to return, so new work could sit
+// behind a wall of stuck rows and never be looked at — no error, no timeout,
+// nothing in the logs.
+func TestAnalysisInProgressPollerSeesNewestWorkPastABacklog(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+	repo := insertAnalysisPollerTestRepository(t, api, db)
+
+	insert := func(i int) sdk.ProjectRepositoryAnalysis {
+		a := sdk.ProjectRepositoryAnalysis{
+			ProjectRepositoryID: repo.ID,
+			ProjectKey:          repo.ProjectKey,
+			VCSProjectID:        repo.VCSProjectID,
+			Ref:                 "refs/heads/main",
+			Commit:              fmt.Sprintf("%040d", i),
+			Status:              sdk.RepositoryAnalysisStatusInProgress,
+		}
+		require.NoError(t, repository.InsertAnalysis(ctx, db, &a))
+		return a
+	}
+
+	// A backlog wider than the window, explicitly aged so the ordering under
+	// test is the only thing deciding what comes back.
+	const backlog = 120
+	for i := 0; i < backlog; i++ {
+		stuck := insert(i)
+		backdateAnalysisCreation(t, db, stuck.ID, time.Duration(backlog-i)*time.Hour)
+	}
+	newest := insert(backlog)
+
+	found, err := repository.LoadRepositoryIDsAnalysisInProgress(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, found, 100, "the poller reads a fixed-size window")
+
+	ids := make(map[string]struct{}, len(found))
+	for i := range found {
+		ids[found[i].ID] = struct{}{}
+	}
+	require.Contains(t, ids, newest.ID, "the most recently created analysis must be visible to the poller even behind a backlog")
 }


### PR DESCRIPTION
1. Description

The analysis poller selects its work with `LIMIT 100` and no `ORDER BY`. An
analysis whose owner died stays `InProgress` indefinitely, so those rows can
occupy the hundred the poller reads and analyses created afterwards are never
returned — with no error, no timeout and nothing in the logs.

On our instance the table reached 503 `InProgress` rows, 483 of them beyond half
an hour old. While that was true, manually triggered analyses on a repository
stopped completing entirely while webhook-driven analyses on the same repository
minutes apart still succeeded — the only difference being which side of the
window they fell on.

`ORDER BY created DESC` keeps fresh work reachable however large the backlog
grows. No behaviour change on a healthy instance.

1. Related issues

Part of #7836

Related: the second PR on that issue — this keeps the system usable when a
backlog exists but does not stop one forming. That change is more opinionated and is proposed
separately so this one can be judged on its own.

1. About tests

`TestAnalysisInProgressPollerSeesNewestWorkPastABacklog` in
`engine/api/v2_repository_analyze_test.go`, against a live Postgres. It builds a
backlog of 120 InProgress analyses, explicitly aged so the ordering is the only
thing deciding what comes back, then creates one more and asserts the poller's
window still contains it.

It is a real regression test rather than a restatement of the code: reverting
the `ORDER BY` alone turns it red — the newest analysis is absent from the
hundred rows returned — and green again with it.

The full `engine/api` package suite passes against a live Postgres and Redis
(on a freshly migrated schema; a few unrelated tests in that package are
sensitive to accumulated database state and fail on an unclean one, on master
too).

1. Mentions

@ovh/cds
