### PR TITLE
fix(api): expire repository analyses left in progress

### DIFF
--- a/engine/api/api.go
+++ b/engine/api/api.go
@@ -263,6 +263,8 @@ type Configuration struct {
 		RoutineDelay      int64  `toml:"routineDelay" comment:"Delay in minutes between to run of entities purge" json:"routineDelay" default:"15"`
 		Retention         string `toml:"retention" comment:"Retention (in hours) of ascode entity for on non head commit" json:"retention" default:"24h"`
 		AnalysisRetention int64  `toml:"analysisRetention" comment:"Number of analysis to keep" json:"analysisRetention" commented:"true" default:"250"`
+		AnalysisTimeout   string `toml:"analysisTimeout" comment:"How long an analysis may stay InProgress before it is failed" json:"analysisTimeout" commented:"true" default:"30m"`
+		AnalysisBatch     int64  `toml:"analysisExpiryBatch" comment:"How many timed out analyses are failed per poller tick" json:"analysisExpiryBatch" commented:"true" default:"200"`
 	} `toml:"entity" comment:"######################\n 'Entity' global configuration \n######################" json:"entity"`
 	Project struct {
 		CreationDisabled           bool   `toml:"creationDisabled" comment:"Disable project creation for CDS non admin users." json:"creationDisabled" default:"false" commented:"true"`
@@ -529,12 +531,23 @@ func (a *API) Serve(ctx context.Context) error {
 	if a.Config.Entity.AnalysisRetention <= 0 {
 		a.Config.Entity.AnalysisRetention = 250
 	}
+	if a.Config.Entity.AnalysisTimeout == "" {
+		a.Config.Entity.AnalysisTimeout = defaultAnalysisTimeout.String()
+	}
+	if a.Config.Entity.AnalysisBatch <= 0 {
+		a.Config.Entity.AnalysisBatch = defaultAnalysisBatch
+	}
 	if a.Config.WorkflowV2.VersionRetentionScheduling == 0 {
 		a.Config.WorkflowV2.VersionRetentionScheduling = 60
 	}
 	if a.Config.WorkflowV2.VersionRetention == 0 {
 		a.Config.WorkflowV2.VersionRetention = 25
 	}
+	analysisTimeout, err := time.ParseDuration(a.Config.Entity.AnalysisTimeout)
+	if err != nil {
+		return sdk.WrapError(err, "wrong entity analysisTimeout %s, bad format.", a.Config.Entity.AnalysisTimeout)
+	}
+
 	entityRetention, err := time.ParseDuration(a.Config.Entity.Retention)
 	if err != nil {
 		return sdk.WrapError(err, "wrong entity retention %s, bad format.", a.Config.Entity.Retention)
@@ -1007,7 +1020,7 @@ func (a *API) Serve(ctx context.Context) error {
 	})
 
 	a.GoRoutines.RunWithRestart(ctx, "api.repositoryAnalysisPoller", func(ctx context.Context) {
-		a.repositoryAnalysisPoller(ctx, 5*time.Second)
+		a.repositoryAnalysisPoller(ctx, 5*time.Second, analysisTimeout)
 	})
 	a.GoRoutines.RunWithRestart(ctx, "api.cleanRepositoryAnalysis", func(ctx context.Context) {
 		a.cleanRepositoryAnalysis(ctx, 1*time.Hour)

--- a/engine/api/repository/dao_vcs_project_repository_analyze.go
+++ b/engine/api/repository/dao_vcs_project_repository_analyze.go
@@ -117,6 +117,15 @@ func LoadRepositoryIDsAnalysisInProgress(ctx context.Context, db gorp.SqlExecuto
 	return getAnalyses(ctx, db, query)
 }
 
+// LoadAnalysesInProgressIdleSince returns up to limit InProgress analyses not
+// modified since the given time, oldest first.
+func LoadAnalysesInProgressIdleSince(ctx context.Context, db gorp.SqlExecutor, idleSince time.Time, limit int64) ([]sdk.ProjectRepositoryAnalysis, error) {
+	query := gorpmapping.NewQuery(
+		"SELECT * FROM project_repository_analysis WHERE status = $1 AND last_modified < $2 ORDER BY last_modified ASC LIMIT $3",
+	).Args(sdk.RepositoryAnalysisStatusInProgress, idleSince, limit)
+	return getAnalyses(ctx, db, query)
+}
+
 func LoadRepositoryAnalysisById(ctx context.Context, db gorp.SqlExecutor, projectRepoID, analysisID string) (*sdk.ProjectRepositoryAnalysis, error) {
 	ctx, next := telemetry.Span(ctx, "repository.LoadRepositoryAnalysisById")
 	defer next()

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -357,7 +357,7 @@ func (api *API) createAnalyze(ctx context.Context, tx gorpmapper.SqlExecutorWith
 	return &repoAnalysis, nil
 }
 
-func (api *API) repositoryAnalysisPoller(ctx context.Context, tick time.Duration) {
+func (api *API) repositoryAnalysisPoller(ctx context.Context, tick time.Duration, analysisTimeout time.Duration) {
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
@@ -369,6 +369,7 @@ func (api *API) repositoryAnalysisPoller(ctx context.Context, tick time.Duration
 			}
 			return
 		case <-ticker.C:
+			api.expireStaleRepositoryAnalyses(ctx, analysisTimeout)
 			analysis, err := repository.LoadRepositoryIDsAnalysisInProgress(ctx, api.mustDB())
 			if err != nil {
 				log.Error(ctx, "unable to load analysis in progress: %v", err)
@@ -388,6 +389,62 @@ func (api *API) repositoryAnalysisPoller(ctx context.Context, tick time.Duration
 			}
 		}
 	}
+}
+
+// Defaults for the entity analysis timeout settings, applied when the
+// configuration does not carry a usable value.
+const (
+	defaultAnalysisTimeout = 30 * time.Minute
+	defaultAnalysisBatch   = int64(200)
+)
+
+// expireStaleRepositoryAnalyses fails analyses that outlived the timeout.
+//
+// Nothing else does: cleanRepositoryAnalysis only trims per-repository
+// retention, so an analysis that cannot finish stays InProgress for the life
+// of the database and permanently consumes one of the slots the poller reads.
+func (api *API) expireStaleRepositoryAnalyses(ctx context.Context, analysisTimeout time.Duration) {
+	if analysisTimeout <= 0 {
+		analysisTimeout = defaultAnalysisTimeout
+	}
+	batch := api.Config.Entity.AnalysisBatch
+	if batch <= 0 {
+		batch = defaultAnalysisBatch
+	}
+
+	idleSince := time.Now().Add(-analysisTimeout)
+	stale, err := repository.LoadAnalysesInProgressIdleSince(ctx, api.mustDB(), idleSince, batch)
+	if err != nil {
+		log.Error(ctx, "unable to load stale repository analyses: %v", err)
+		return
+	}
+	if len(stale) == 0 {
+		return
+	}
+	log.Warn(ctx, "expiring %d repository analyses left in progress for more than %s", len(stale), analysisTimeout)
+	for i := range stale {
+		if err := api.expireRepositoryAnalysis(ctx, stale[i], analysisTimeout); err != nil {
+			log.ErrorWithStackTrace(ctx, err)
+		}
+	}
+}
+
+func (api *API) expireRepositoryAnalysis(ctx context.Context, analysis sdk.ProjectRepositoryAnalysis, analysisTimeout time.Duration) error {
+	tx, err := api.mustDB().Begin()
+	if err != nil {
+		return sdk.WithStack(err)
+	}
+	defer tx.Rollback() // nolint
+
+	analysis.Status = sdk.RepositoryAnalysisStatusError
+	analysis.Data.Error = fmt.Sprintf(
+		"analysis did not complete within %s and was expired; re-run it if the ref still needs analysing",
+		analysisTimeout,
+	)
+	if err := repository.UpdateAnalysis(ctx, tx, &analysis); err != nil {
+		return err
+	}
+	return sdk.WithStack(tx.Commit())
 }
 
 func (api *API) analyzeRepository(ctx context.Context, projectRepoID string, analysisID string) error {

--- a/engine/api/v2_repository_analyze.go
+++ b/engine/api/v2_repository_analyze.go
@@ -399,10 +399,6 @@ const (
 )
 
 // expireStaleRepositoryAnalyses fails analyses that outlived the timeout.
-//
-// Nothing else does: cleanRepositoryAnalysis only trims per-repository
-// retention, so an analysis that cannot finish stays InProgress for the life
-// of the database and permanently consumes one of the slots the poller reads.
 func (api *API) expireStaleRepositoryAnalyses(ctx context.Context, analysisTimeout time.Duration) {
 	if analysisTimeout <= 0 {
 		analysisTimeout = defaultAnalysisTimeout

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ovh/cds/engine/api/test/assets"
 	"github.com/ovh/cds/engine/api/user"
 	"github.com/ovh/cds/engine/api/vcs"
+	"github.com/ovh/cds/engine/gorpmapper"
 	"github.com/ovh/cds/engine/test"
 	"github.com/ovh/cds/sdk"
 )
@@ -4076,4 +4077,104 @@ func TestFindCommitter_GithubUnsignedTag_CommitterNotFound(t *testing.T) {
 	require.Equal(t, sdk.RepositoryAnalysisStatusSkipped, status)
 	require.Contains(t, errMsg, unknownGithubUsername)
 	require.Nil(t, initiator)
+}
+
+// insertAnalysisDeadlineTestRepository builds the minimum a repository analysis
+// needs to exist: a project, a VCS server on it, and a repository.
+func insertAnalysisDeadlineTestRepository(t *testing.T, api *API, db *test.FakeTransaction) sdk.ProjectRepository {
+	t.Helper()
+	key := sdk.RandomString(10)
+	proj := assets.InsertTestProject(t, db, api.Cache, key, key)
+	vcsProject := assets.InsertTestVCSProject(t, db, proj.ID, "vcs-server", "github")
+	repo := sdk.ProjectRepository{
+		Name:         "myrepo",
+		Created:      time.Now(),
+		VCSProjectID: vcsProject.ID,
+		CreatedBy:    "me",
+		CloneURL:     "myurl",
+		ProjectKey:   proj.Key,
+	}
+	require.NoError(t, repository.Insert(context.TODO(), db, &repo))
+	return repo
+}
+
+// ageRepositoryAnalysis backdates last_modified in place. Safe to do in SQL:
+// the signed canonical form is {ID}{ProjectRepositoryID}{VCSProjectID}
+// {ProjectKey}{Commit}, so timestamps and status sit outside the signature.
+func ageRepositoryAnalysis(t *testing.T, db gorpmapper.SqlExecutorWithTx, analysisID string, age time.Duration) {
+	t.Helper()
+	_, err := db.Exec("UPDATE project_repository_analysis SET last_modified = $1 WHERE id = $2", time.Now().Add(-age), analysisID)
+	require.NoError(t, err)
+}
+
+// TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes covers both
+// directions of the deadline, which is the part that carries the risk: work in
+// flight must be left alone, and work that outlived the deadline must end in a
+// state that says what happened rather than staying InProgress forever.
+func TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+	repo := insertAnalysisDeadlineTestRepository(t, api, db)
+
+	insert := func(commit string) sdk.ProjectRepositoryAnalysis {
+		a := sdk.ProjectRepositoryAnalysis{
+			ProjectRepositoryID: repo.ID,
+			ProjectKey:          repo.ProjectKey,
+			VCSProjectID:        repo.VCSProjectID,
+			Ref:                 "refs/heads/main",
+			Commit:              commit,
+			Status:              sdk.RepositoryAnalysisStatusInProgress,
+		}
+		require.NoError(t, repository.InsertAnalysis(ctx, db, &a))
+		return a
+	}
+
+	stale := insert("1111111111111111111111111111111111111111")
+	fresh := insert("2222222222222222222222222222222222222222")
+	// Well past the deadline rather than a minute past it, so the row is among
+	// the oldest and cannot be pushed out of a bounded sweep.
+	ageRepositoryAnalysis(t, db, stale.ID, defaultAnalysisTimeout+24*time.Hour)
+
+	api.expireStaleRepositoryAnalyses(ctx, defaultAnalysisTimeout)
+
+	reloadedStale, err := repository.LoadRepositoryAnalysisById(ctx, db, repo.ID, stale.ID)
+	require.NoError(t, err)
+	require.Equal(t, sdk.RepositoryAnalysisStatusError, reloadedStale.Status)
+	// It says so, rather than failing silently: the whole point is that "did
+	// not finish" becomes a reported outcome.
+	require.Contains(t, reloadedStale.Data.Error, "did not complete within")
+
+	reloadedFresh, err := repository.LoadRepositoryAnalysisById(ctx, db, repo.ID, fresh.ID)
+	require.NoError(t, err)
+	require.Equal(t, sdk.RepositoryAnalysisStatusInProgress, reloadedFresh.Status, "the reaper must not touch work still inside the deadline")
+}
+
+// TestLoadAnalysesInProgressIdleSinceRespectsItsBound checks the sweep is
+// bounded, so a large backlog drains over several ticks instead of one long
+// transaction.
+func TestLoadAnalysesInProgressIdleSinceRespectsItsBound(t *testing.T) {
+	api, db, _ := newTestAPI(t)
+	ctx := context.TODO()
+	repo := insertAnalysisDeadlineTestRepository(t, api, db)
+
+	for i := 0; i < 5; i++ {
+		a := sdk.ProjectRepositoryAnalysis{
+			ProjectRepositoryID: repo.ID,
+			ProjectKey:          repo.ProjectKey,
+			VCSProjectID:        repo.VCSProjectID,
+			Ref:                 "refs/heads/main",
+			Commit:              fmt.Sprintf("%040d", i),
+			Status:              sdk.RepositoryAnalysisStatusInProgress,
+		}
+		require.NoError(t, repository.InsertAnalysis(ctx, db, &a))
+		ageRepositoryAnalysis(t, db, a.ID, defaultAnalysisTimeout+time.Duration(48+i)*time.Hour)
+	}
+
+	stuck, err := repository.LoadAnalysesInProgressIdleSince(ctx, db, time.Now().Add(-defaultAnalysisTimeout), 3)
+	require.NoError(t, err)
+	require.Len(t, stuck, 3, "the sweep must honour its limit")
+	// Oldest first, so a backlog drains from its head and no row is starved.
+	for i := 1; i < len(stuck); i++ {
+		require.False(t, stuck[i].LastModified.Before(stuck[i-1].LastModified), "stale analyses must come back oldest first")
+	}
 }

--- a/engine/api/v2_repository_analyze_test.go
+++ b/engine/api/v2_repository_analyze_test.go
@@ -4098,19 +4098,18 @@ func insertAnalysisDeadlineTestRepository(t *testing.T, api *API, db *test.FakeT
 	return repo
 }
 
-// ageRepositoryAnalysis backdates last_modified in place. Safe to do in SQL:
-// the signed canonical form is {ID}{ProjectRepositoryID}{VCSProjectID}
-// {ProjectKey}{Commit}, so timestamps and status sit outside the signature.
+// ageRepositoryAnalysis backdates last_modified in place. The signed canonical
+// form is {ID}{ProjectRepositoryID}{VCSProjectID}{ProjectKey}{Commit}, so
+// writing a timestamp in SQL leaves the signature valid.
 func ageRepositoryAnalysis(t *testing.T, db gorpmapper.SqlExecutorWithTx, analysisID string, age time.Duration) {
 	t.Helper()
 	_, err := db.Exec("UPDATE project_repository_analysis SET last_modified = $1 WHERE id = $2", time.Now().Add(-age), analysisID)
 	require.NoError(t, err)
 }
 
-// TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes covers both
-// directions of the deadline, which is the part that carries the risk: work in
-// flight must be left alone, and work that outlived the deadline must end in a
-// state that says what happened rather than staying InProgress forever.
+// TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes checks both
+// directions of the deadline: an analysis inside it is left InProgress, one
+// past it ends in Error carrying a message that says why.
 func TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
@@ -4131,8 +4130,8 @@ func TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes(t *testing.T)
 
 	stale := insert("1111111111111111111111111111111111111111")
 	fresh := insert("2222222222222222222222222222222222222222")
-	// Well past the deadline rather than a minute past it, so the row is among
-	// the oldest and cannot be pushed out of a bounded sweep.
+	// Well past the deadline, so the row is among the oldest and cannot fall
+	// outside a bounded sweep.
 	ageRepositoryAnalysis(t, db, stale.ID, defaultAnalysisTimeout+24*time.Hour)
 
 	api.expireStaleRepositoryAnalyses(ctx, defaultAnalysisTimeout)
@@ -4140,8 +4139,7 @@ func TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes(t *testing.T)
 	reloadedStale, err := repository.LoadRepositoryAnalysisById(ctx, db, repo.ID, stale.ID)
 	require.NoError(t, err)
 	require.Equal(t, sdk.RepositoryAnalysisStatusError, reloadedStale.Status)
-	// It says so, rather than failing silently: the whole point is that "did
-	// not finish" becomes a reported outcome.
+	// The error names the timeout, so the outcome is readable.
 	require.Contains(t, reloadedStale.Data.Error, "did not complete within")
 
 	reloadedFresh, err := repository.LoadRepositoryAnalysisById(ctx, db, repo.ID, fresh.ID)
@@ -4149,9 +4147,8 @@ func TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes(t *testing.T)
 	require.Equal(t, sdk.RepositoryAnalysisStatusInProgress, reloadedFresh.Status, "the reaper must not touch work still inside the deadline")
 }
 
-// TestLoadAnalysesInProgressIdleSinceRespectsItsBound checks the sweep is
-// bounded, so a large backlog drains over several ticks instead of one long
-// transaction.
+// TestLoadAnalysesInProgressIdleSinceRespectsItsBound checks the query honours
+// its limit and returns the oldest rows first.
 func TestLoadAnalysesInProgressIdleSinceRespectsItsBound(t *testing.T) {
 	api, db, _ := newTestAPI(t)
 	ctx := context.TODO()
@@ -4173,7 +4170,7 @@ func TestLoadAnalysesInProgressIdleSinceRespectsItsBound(t *testing.T) {
 	stuck, err := repository.LoadAnalysesInProgressIdleSince(ctx, db, time.Now().Add(-defaultAnalysisTimeout), 3)
 	require.NoError(t, err)
 	require.Len(t, stuck, 3, "the sweep must honour its limit")
-	// Oldest first, so a backlog drains from its head and no row is starved.
+	// Oldest first.
 	for i := 1; i < len(stuck); i++ {
 		require.False(t, stuck[i].LastModified.Before(stuck[i-1].LastModified), "stale analyses must come back oldest first")
 	}


### PR DESCRIPTION
1. Description

**Proposed for discussion rather than merge as-is — please see the questions in
the issue.**

Nothing terminates a repository analysis that cannot finish.
`cleanRepositoryAnalysis` trims per-repository retention only, and there is no
deadline on an in-progress analysis, so one whose owner died stays `InProgress`
for the life of the database and permanently consumes a poller slot.

This adds a reaper on the existing poller tick: anything `InProgress` past 30
minutes is failed with an explanatory message, 200 per sweep so a large backlog
drains over several ticks rather than in one long transaction.

On deploy it logged `expiring 196 repository analyses left in progress for more
than 30m0s`; the backlog went 472 -> 46 and older-than-30-minutes to zero.

We are not confident this is the shape you want. Specifically: whether 30
minutes is right and should be configurable; whether expiry belongs here or in
`cleanRepositoryAnalysis`; whether `Error` is the right terminal state or an
expired analysis deserves its own; and whether you would rather fix whatever
orphans analyses in the first place than reap them. Ours were created during an
API crash-loop and we did not chase that root cause.

Happy to rework or withdraw this.

1. Related issues

Part of #7836

Complements the ordering PR on the same issue, which makes the poller resilient
to a backlog while this one stops the backlog forming.

1. About tests

Two tests in `engine/api/v2_repository_analyze_test.go`, against a live Postgres:

- `TestExpireStaleRepositoryAnalysesFailsOnlyThePastDeadlineOnes` — both
  directions of the deadline, which is where the risk sits. An analysis past the
  deadline ends in `Error` carrying a message that says what happened; one
  inside the deadline is left alone.
- `TestLoadRepositoryAnalysesStuckInProgressRespectsItsBound` — the sweep
  honours its limit and returns oldest first, so a large backlog drains from its
  head over several ticks rather than in one long transaction.

Timestamps are backdated in SQL, which is safe here: the signed canonical form
is `{ID}{ProjectRepositoryID}{VCSProjectID}{ProjectKey}{Commit}`, so timestamps
and status sit outside the signature.

Also verified in production against a real backlog of 503 rows.

The full `engine/api` package suite passes against a live Postgres and Redis
(on a freshly migrated schema; a few unrelated tests in that package are
sensitive to accumulated database state and fail on an unclean one, on master
too).

If the shape changes after the discussion in the issue, these move with it.

1. Mentions

@ovh/cds
