### PR TITLE
perf(api,sdk): report what an instance costs, count what CDS hold once

### DIFF
--- a/engine/api/status.go
+++ b/engine/api/status.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/rockbears/log"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -18,6 +19,7 @@ import (
 	"github.com/ovh/cds/engine/api/migrate"
 	"github.com/ovh/cds/engine/api/services"
 	"github.com/ovh/cds/engine/api/workermodel"
+	"github.com/ovh/cds/engine/cache"
 	"github.com/ovh/cds/engine/service"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/telemetry"
@@ -33,6 +35,10 @@ const (
 	// inventoryMetricsQueryTimeout caps a single count. A count that cannot complete within it is
 	// worth losing rather than holding a connection for the next tick to pile onto.
 	inventoryMetricsQueryTimeout = 2 * time.Minute
+	// inventoryMetricsCacheKey holds the counts one instance read for all of them. Reading them once
+	// per instance multiplies over the replicas a full scan of the largest tables CDS has, for
+	// numbers that cannot differ from one instance to the next.
+	inventoryMetricsCacheKey = "api:metrics:inventory"
 )
 
 // Status returns status, implements interface service.Service
@@ -298,6 +304,16 @@ func (api *API) initMetrics(ctx context.Context) error {
 		telemetry.NewViewLast("cds/run_results_to_synchronized_error", api.Metrics.RunResultSynchronizedError, tagsService),
 	)
 
+	// The pool of the database describes itself: the connections in use, and above all how long the
+	// callers waited for one. cds/database_conn only counts the connections that are open, which says
+	// that the pool is full but nothing of the queue behind it, and a queue is what a saturated pool
+	// is read from.
+	if db := api.DBConnectionFactory.DB(); db != nil {
+		if err := telemetry.RegisterCollector(ctx, collectors.NewDBStatsCollector(db, api.DBConnectionFactory.DBName)); err != nil {
+			log.Error(ctx, "unable to expose the metrics of the database pool: %v", err)
+		}
+	}
+
 	api.computeMetrics(ctx)
 
 	return err
@@ -395,45 +411,109 @@ func (api *API) computeInventoryMetrics(ctx context.Context) {
 					return
 				}
 			case <-tick:
-				// Common metrics
-				api.countMetric(ctx, api.Metrics.nbUsers, "SELECT COUNT(1) FROM \"authentified_user\"")
-				api.countMetric(ctx, api.Metrics.nbProjects, "SELECT COUNT(1) FROM project")
-				api.countMetric(ctx, api.Metrics.nbGroups, "SELECT COUNT(1) FROM \"group\"")
-
-				// V1 metrics
-				api.countMetric(ctx, api.Metrics.nbApplications, "SELECT COUNT(1) FROM application")
-				api.countMetric(ctx, api.Metrics.nbPipelines, "SELECT COUNT(1) FROM pipeline")
-				api.countMetric(ctx, api.Metrics.nbWorkflows, "SELECT COUNT(1) FROM workflow")
-				api.countMetric(ctx, api.Metrics.nbArtifacts, "SELECT COUNT(1) FROM workflow_node_run_artifacts")
-				api.countMetric(ctx, api.Metrics.nbWorkerModels, "SELECT COUNT(1) FROM worker_model")
-				api.countMetric(ctx, api.Metrics.nbWorkflowRuns, "SELECT COUNT(1) FROM workflow_run")
-				api.countMetric(ctx, api.Metrics.nbWorkflowNodeRuns, "SELECT COUNT(1) FROM workflow_node_run")
-				api.countMetric(ctx, api.Metrics.nbMaxWorkersBuilding, "SELECT COUNT(1) FROM worker where status = 'Building'")
-				api.countMetric(ctx, api.Metrics.RunResultSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NOT NULL")
-				api.countMetric(ctx, api.Metrics.RunResultToSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NULL")
-				api.countMetric(ctx, api.Metrics.RunResultSynchronizedError, "SELECT COUNT(1) FROM workflow_run_result where sync ? 'error'")
-
-				// V2 metrics
-				api.countMetric(ctx, api.Metrics.nbWorkflowsAsCodeV2, "select count(distinct(project_repository_id,name)) from entity where type = 'Workflow'")
+				api.refreshInventoryMetrics(ctx)
 			}
 		}
 	})
 }
 
-func (api *API) countMetric(ctx context.Context, v *stats.Int64Measure, query string) {
+// inventoryCount is one of the counts of what CDS holds, with the measure it feeds. The key is what
+// the value is shared under, so it stays the same while a mix of versions runs.
+type inventoryCount struct {
+	key     string
+	measure *stats.Int64Measure
+	query   string
+}
+
+func (api *API) inventoryCounts() []inventoryCount {
+	return []inventoryCount{
+		// Common
+		{"users", api.Metrics.nbUsers, `SELECT COUNT(1) FROM "authentified_user"`},
+		{"projects", api.Metrics.nbProjects, "SELECT COUNT(1) FROM project"},
+		{"groups", api.Metrics.nbGroups, `SELECT COUNT(1) FROM "group"`},
+
+		// V1
+		{"applications", api.Metrics.nbApplications, "SELECT COUNT(1) FROM application"},
+		{"pipelines", api.Metrics.nbPipelines, "SELECT COUNT(1) FROM pipeline"},
+		{"workflows", api.Metrics.nbWorkflows, "SELECT COUNT(1) FROM workflow"},
+		{"artifacts", api.Metrics.nbArtifacts, "SELECT COUNT(1) FROM workflow_node_run_artifacts"},
+		{"worker_models", api.Metrics.nbWorkerModels, "SELECT COUNT(1) FROM worker_model"},
+		{"workflow_runs", api.Metrics.nbWorkflowRuns, "SELECT COUNT(1) FROM workflow_run"},
+		{"workflow_node_runs", api.Metrics.nbWorkflowNodeRuns, "SELECT COUNT(1) FROM workflow_node_run"},
+		{"max_workers_building", api.Metrics.nbMaxWorkersBuilding, "SELECT COUNT(1) FROM worker where status = 'Building'"},
+		{"run_results_synchronized", api.Metrics.RunResultSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NOT NULL"},
+		{"run_results_to_synchronize", api.Metrics.RunResultToSynchronized, "SELECT COUNT(1) FROM workflow_run_result where sync is NULL"},
+		{"run_results_synchronized_error", api.Metrics.RunResultSynchronizedError, "SELECT COUNT(1) FROM workflow_run_result where sync ? 'error'"},
+
+		// V2
+		{"workflows_as_code_v2", api.Metrics.nbWorkflowsAsCodeV2, "select count(distinct(project_repository_id,name)) from entity where type = 'Workflow'"},
+	}
+}
+
+// refreshInventoryMetrics records the counts of what CDS holds. They describe the database, so they
+// are the same read from any instance, and each of them is a full table scan: one instance reads
+// them and shares them, the others record what it read.
+//
+// Every instance records them rather than only the one that read them: a measure only exists where
+// it was recorded, so leaving the others silent would spread one number over as many series as there
+// are instances, each holding whatever it last saw. Aggregating those is only right for a count that
+// never goes down, and several of these do.
+func (api *API) refreshInventoryMetrics(ctx context.Context) {
+	counts := api.inventoryCounts()
+
+	// Held for the interval and not released: the instance that reads them is whichever one ticks
+	// first once the last read has aged out.
+	locked, err := api.Cache.Lock(cache.Key(inventoryMetricsCacheKey, "lock"), inventoryMetricsInterval, 0, 1)
+	if err != nil {
+		log.Warn(ctx, "metrics> unable to take the inventory counts lock: %v", err)
+	}
+
+	if !locked {
+		var shared map[string]int64
+		found, err := api.Cache.Get(inventoryMetricsCacheKey, &shared)
+		if err != nil {
+			log.Warn(ctx, "metrics> unable to read the shared inventory counts: %v", err)
+		}
+		if found {
+			for _, c := range counts {
+				if n, ok := shared[c.key]; ok {
+					telemetry.Record(ctx, c.measure, n)
+				}
+			}
+			return
+		}
+		// Nothing has been shared yet, which is the first pass of a cluster starting: reading them
+		// here costs a duplicated pass, reporting nothing costs the metrics until the next tick.
+	}
+
+	shared := make(map[string]int64, len(counts))
+	for _, c := range counts {
+		n, err := api.count(ctx, c.query)
+		if err != nil {
+			// Reporting nothing leaves the last count in place. Reporting the zero of a count that
+			// did not happen reads as the disappearance of everything it counts.
+			log.Warn(ctx, "metrics> unable to count %s: %v", c.key, err)
+			continue
+		}
+		shared[c.key] = n
+		telemetry.Record(ctx, c.measure, n)
+	}
+
+	// Kept longer than the interval so that an instance ticking while no read is in progress still
+	// finds them.
+	if err := api.Cache.SetWithDuration(inventoryMetricsCacheKey, shared, 3*inventoryMetricsInterval); err != nil {
+		log.Warn(ctx, "metrics> unable to share the inventory counts: %v", err)
+	}
+}
+
+func (api *API) count(ctx context.Context, query string) (int64, error) {
 	// Bounded so that a scan that outgrew the instance releases its connection instead of holding one
 	// of the few the pool has until it completes.
 	ctxQuery, cancel := context.WithTimeout(ctx, inventoryMetricsQueryTimeout)
 	defer cancel()
 
 	n, err := api.mustDBWithCtx(ctxQuery).SelectInt(query)
-	if err != nil {
-		// Reporting nothing leaves the last count in place. Reporting the zero of a count that did
-		// not happen reads as the disappearance of everything it counts.
-		log.Warn(ctx, "metrics>Errors while fetching count %s: %v", query, err)
-		return
-	}
-	telemetry.Record(ctx, v, n)
+	return n, sdk.WithStack(err)
 }
 
 func (api *API) countMetricRange(ctx context.Context, status string, timerange string, v *stats.Int64Measure, query string, args ...interface{}) {

--- a/engine/api/status_metrics_test.go
+++ b/engine/api/status_metrics_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+
+	"github.com/ovh/cds/engine/cache"
+)
+
+// sharedCountsCache stands for the cache of a cluster where another instance has already read the
+// counts. Only what refreshInventoryMetrics is allowed to use is implemented: anything else it
+// reached for would panic on the embedded nil.
+type sharedCountsCache struct {
+	cache.Store
+	locked bool
+	found  bool
+	shared map[string]int64
+	stored map[string]int64
+}
+
+func (c *sharedCountsCache) Lock(string, time.Duration, int, int) (bool, error) {
+	return c.locked, nil
+}
+
+func (c *sharedCountsCache) Get(_ string, value interface{}) (bool, error) {
+	if m, ok := value.(*map[string]int64); ok {
+		*m = c.shared
+	}
+	return c.found, nil
+}
+
+func (c *sharedCountsCache) SetWithDuration(_ string, value interface{}, _ time.Duration) error {
+	c.stored, _ = value.(map[string]int64)
+	return nil
+}
+
+// The counts describe the database, so an instance that did not read them reports what the instance
+// that did has shared. The API here holds no database at all: reaching for one would be reading them
+// again, which is what this is about.
+func TestRefreshInventoryMetrics_RecordsWhatAnotherInstanceRead(t *testing.T) {
+	api := &API{}
+	api.Metrics.nbProjects = stats.Int64("test/nb_projects_shared", "", stats.UnitDimensionless)
+
+	v := &view.View{
+		Name:        "test/nb_projects_shared",
+		Measure:     api.Metrics.nbProjects,
+		Aggregation: view.LastValue(),
+	}
+	require.NoError(t, view.Register(v))
+	defer view.Unregister(v)
+
+	api.Cache = &sharedCountsCache{found: true, shared: map[string]int64{"projects": 42}}
+
+	api.refreshInventoryMetrics(context.Background())
+
+	rows, err := view.RetrieveData(v.Name)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 42, rows[0].Data.(*view.LastValueData).Value)
+}
+
+// The key a count is shared under is what pairs it with its measure from one instance to the next,
+// and from one version to the next while they run side by side. Two counts sharing a key would
+// report one another's value.
+func TestInventoryCounts_KeysAreDistinct(t *testing.T) {
+	counts := (&API{}).inventoryCounts()
+	require.NotEmpty(t, counts)
+
+	seen := make(map[string]bool, len(counts))
+	for _, c := range counts {
+		require.NotEmpty(t, c.key)
+		require.NotEmpty(t, c.query, "the count %q has no query", c.key)
+		require.False(t, seen[c.key], "the key %q is used by two counts", c.key)
+		seen[c.key] = true
+	}
+}

--- a/engine/api/v2_websocket.go
+++ b/engine/api/v2_websocket.go
@@ -215,9 +215,11 @@ func (a *API) initWebsocketV2(pubSubKey string) error {
 		server:     websocket.NewServer(),
 		clientData: make(map[string]*websocketV2ClientData),
 	}
-	tickerMetrics := time.NewTicker(10 * time.Second)
-	defer tickerMetrics.Stop()
+	// The ticker belongs to the goroutine reading it: created here, the deferred stop would run when
+	// this function returns, which is before the first tick, and the count would never be recorded.
 	a.GoRoutines.Run(a.Router.Background, "api.initWebsocketV2.WSV2Server", func(ctx context.Context) {
+		tickerMetrics := time.NewTicker(10 * time.Second)
+		defer tickerMetrics.Stop()
 		for {
 			select {
 			case <-tickerMetrics.C:

--- a/engine/api/websocket.go
+++ b/engine/api/websocket.go
@@ -211,9 +211,11 @@ func (a *API) initWebsocket(pubSubKey string) error {
 		server:     websocket.NewServer(),
 		clientData: make(map[string]*websocketClientData),
 	}
-	tickerMetrics := time.NewTicker(10 * time.Second)
-	defer tickerMetrics.Stop()
+	// See initWebsocketV2: the ticker is created by the goroutine reading it, so that its stop is not
+	// deferred to the return of this function.
 	a.GoRoutines.Run(a.Router.Background, "api.InitRouter.WSServer", func(ctx context.Context) {
+		tickerMetrics := time.NewTicker(10 * time.Second)
+		defer tickerMetrics.Stop()
 		for {
 			select {
 			case <-tickerMetrics.C:

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/rockbears/log v0.12.0
 	github.com/rockbears/yaml v0.4.0
@@ -269,7 +270,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/sdk/telemetry/telemetry.go
+++ b/sdk/telemetry/telemetry.go
@@ -8,6 +8,8 @@ import (
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/pkg/errors"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/rockbears/log"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -84,17 +86,45 @@ func Init(ctx context.Context, cfg Configuration, s Service) (context.Context, e
 
 	log.Info(ctx, "observability> initializing prometheus exporter for %q", serviceName(s))
 
-	e, err := prometheus.NewExporter(prometheus.Options{})
+	// The registry is built here rather than left to the exporter, which would create an empty one:
+	// the runtime of the process is described by the collectors registered on it, and nothing of it
+	// goes through a view. Without them the metrics say what the service did and nothing about what
+	// it costs, which is what a goroutine leak or a heap growing out of hand is read from.
+	registry := prom.NewRegistry()
+	if err := registry.Register(collectors.NewGoCollector()); err != nil {
+		return ctx, errors.WithStack(err)
+	}
+	if err := registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
+		return ctx, errors.WithStack(err)
+	}
+
+	e, err := prometheus.NewExporter(prometheus.Options{Registry: registry})
 	if err != nil {
 		return ctx, errors.WithStack(err)
 	}
 	view.RegisterExporter(e)
 	he := new(HTTPExporter)
 	he.Exporter = e
+	he.Registry = registry
 	view.RegisterExporter(he)
 	ctx = context.WithValue(ctx, contextStatsExporter, he)
 
 	return ctx, nil
+}
+
+// RegisterCollector exposes a prometheus collector on the metrics of the service. It is for what the
+// service knows and this package does not, such as the pool of its database.
+func RegisterCollector(ctx context.Context, cs ...prom.Collector) error {
+	e := StatsExporter(ctx)
+	if e == nil || e.Registry == nil {
+		return errors.New("telemetry: no stats exporter to register a collector on")
+	}
+	for _, c := range cs {
+		if err := e.Registry.Register(c); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
 }
 
 // Tags contants

--- a/sdk/telemetry/telemetry_test.go
+++ b/sdk/telemetry/telemetry_test.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/stretchr/testify/require"
+)
+
+type testService struct{}
+
+func (testService) Name() string { return "test" }
+func (testService) Type() string { return "api" }
+
+// unreachableConnector stands for a pool without a database: the statistics of a pool are held by
+// the pool itself, so they can be read from one that never connected.
+type unreachableConnector struct{}
+
+func (unreachableConnector) Connect(context.Context) (driver.Conn, error) {
+	return nil, errors.New("no database")
+}
+func (unreachableConnector) Driver() driver.Driver { return nil }
+
+func scrape(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	StatsExporter(ctx).ServeHTTP(w, httptest.NewRequest("GET", "/mon/metrics", nil))
+	require.Equal(t, 200, w.Code)
+	return w.Body.String()
+}
+
+// The metrics of a service say what it did; what it costs is described by the collectors of the
+// runtime, which report nothing through a view and have to be registered on the registry the
+// exporter serves.
+func TestInit_ExposesTheRuntimeOfTheProcess(t *testing.T) {
+	ctx, err := Init(context.Background(), Configuration{}, testService{})
+	require.NoError(t, err)
+
+	body := scrape(t, ctx)
+	require.Contains(t, body, "go_goroutines", "the goroutine count is what a fan-out or a leak is read from")
+	require.Contains(t, body, "go_memstats_heap_inuse_bytes")
+	require.Contains(t, body, "process_resident_memory_bytes")
+}
+
+// A pool reports the connections in use and the time its callers spent waiting for one, which is
+// what a saturated pool is read from and what counting the open connections cannot tell.
+func TestRegisterCollector_ExposesADatabasePool(t *testing.T) {
+	ctx, err := Init(context.Background(), Configuration{}, testService{})
+	require.NoError(t, err)
+
+	// Never connected: the collector reads the statistics of the pool, not the database behind it.
+	db := sql.OpenDB(unreachableConnector{})
+	defer db.Close()
+
+	require.NoError(t, RegisterCollector(ctx, collectors.NewDBStatsCollector(db, "cds")))
+
+	body := scrape(t, ctx)
+	require.Contains(t, body, "go_sql_in_use_connections")
+	require.Contains(t, body, "go_sql_wait_count_total")
+	require.Contains(t, body, "go_sql_wait_duration_seconds_total")
+	require.Contains(t, body, `db_name="cds"`)
+}
+
+func TestRegisterCollector_WithoutAnExporter(t *testing.T) {
+	require.Error(t, RegisterCollector(context.Background(), collectors.NewGoCollector()))
+}

--- a/sdk/telemetry/types.go
+++ b/sdk/telemetry/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
+	prom "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace/propagation"
@@ -63,9 +64,12 @@ type ExposedView struct {
 
 type HTTPExporter struct {
 	*prometheus.Exporter `json:"-"`
-	ExposedViews         []ExposedView `json:"-"`
-	exposedViewMutex     sync.Mutex    `json:"-"`
-	Views                []HTTPExporterView
+	// Registry is the one the exporter serves, held so that a service can add the collectors of what
+	// only it knows. See RegisterCollector.
+	Registry         *prom.Registry `json:"-"`
+	ExposedViews     []ExposedView  `json:"-"`
+	exposedViewMutex sync.Mutex     `json:"-"`
+	Views            []HTTPExporterView
 }
 
 type HTTPExporterView struct {


### PR DESCRIPTION
The metrics of a service said what it did and nothing about what it costs, which is what the growth of a process is read from, and the one number that described the load of an instance was never recorded at all.

The count of websocket clients has never been exported, in either version of the websocket. Both build their ticker with time.NewTicker followed by a deferred Stop and then return: the stop runs before the first tick, and the goroutine waits on a channel that will never fire. The ticker now belongs to the goroutine reading it, so websocket_clients and websocket_v2_clients report for the first time since the servers they count for were written. Without them the fan-out of an event, which starts a goroutine per client, cannot be measured.

The prometheus exporter was built with an empty option struct, which leaves it a registry of its own carrying nothing but the views. The runtime of a process is described by collectors rather than by views, so nothing said how many goroutines it holds or how large its heap is, and those are what tell a fan-out apart from a leak. The registry is now built with the go and process collectors on it, for every service and not only the API, and a service adds what only it knows through RegisterCollector.

The pool of the database is the first of those. database_conn counts the connections that are open, which says that the pool is full and nothing of the queue behind it, and a queue is what a saturated pool is read from: the statement timeout of a caller waiting for a connection has nowhere to appear. The DBStats collector reports the connections in use and, above all, how many callers waited and for how long.

Last, the counts of what CDS holds were read by every instance: the users, the projects, the workflows and the runs of the whole installation, every five minutes, each of them a full scan of the largest tables there are. Those numbers describe the database, so they cannot differ from one instance to the next, and the scans were multiplied by the number of replicas for one answer. One instance now reads them and shares them; the lock is held for the length of the interval and not released, so the reader is whichever instance ticks first once the last read has aged out, and one that finds nothing shared - a cluster starting - reads them rather than leaving the metrics empty until the next tick.

Every instance still records them. A measure only exists in the process that recorded it, so leaving the others silent would spread one number over as many series as there are instances, each holding whatever it last saw. Aggregating those is only right for a count that never goes down, and several of these do.

The queue metrics are left as they are: they are read every nine seconds because alerting and the scheduling dashboards follow them, and they are indexed counts rather than scans.

All of this is per instance, so a scrape that drops the pod label collapses the replicas into one series, where the difference between two of them reads as a counter reset.

@ovh/cds
