### PR TITLE
perf(api): index the filters a run search is aimed at

### DIFF
--- a/engine/api/v2_workflow_run_test.go
+++ b/engine/api/v2_workflow_run_test.go
@@ -171,6 +171,9 @@ func TestSearchWorkflowRunsFreeTextQuery(t *testing.T) {
 		{"unmatched word excludes the run", "query=" + url.QueryEscape("awesome dev"), []string{}},
 		{"like wildcards are escaped", "query=" + url.QueryEscape("%"), []string{}},
 		{"query combines with filters", "query=workflow&status=Success&ref=" + url.QueryEscape("refs/heads/main"), []string{runAwesome.ID}},
+		{"workflow filter", "workflow=" + url.QueryEscape(vcsServer.Name+"/"+repo.Name+"/my-awesome-workflow"), []string{runAwesome.ID}},
+		{"commit filter", "commit=abcdef123456", []string{runOther.ID, runAwesome.ID}},
+		{"unmatched commit filter", "commit=999999999999", []string{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.ElementsMatch(t, tc.expected, search(t, tc.query))

--- a/engine/sql/api/324_v2_workflow_run_filter_index.sql
+++ b/engine/sql/api/324_v2_workflow_run_filter_index.sql
@@ -1,0 +1,16 @@
+-- The commit and workflow filters of a run search are matched against expressions, which only an
+-- index describes and only its statistics measure.
+
+-- +migrate Up notransaction
+
+-- CONCURRENTLY, since runs are written to this table constantly. It cannot go through
+-- create_index(): a function always runs inside a transaction, which the concurrent build refuses.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_v2_workflow_run_git_sha
+	ON v2_workflow_run ((contexts -> 'git' ->> 'sha'));
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_v2_workflow_run_project_workflow_started
+	ON v2_workflow_run (project_key, ((vcs_server || '/' || repository || '/' || workflow_name)), started);
+
+-- +migrate Down
+DROP INDEX IF EXISTS idx_v2_workflow_run_git_sha;
+DROP INDEX IF EXISTS idx_v2_workflow_run_project_workflow_started;


### PR DESCRIPTION
Listing the runs of a project is the query the slow log shows the most, at some four hundred milliseconds. #7826 gave the search an index per sort column, so an unfiltered listing walks the runs in the order it returns them and stops once the page is full. The searches that filter were left out, and two of the filters the run list offers are matched against something no index describes.

A commit is matched on the sha read from the contexts of a run, which nothing indexes. A workflow is matched on its path, the concatenation of the vcs server, the repository and the name: the index on the name alone cannot be matched against it, which is why one exists and the search is slow all the same. An expression with no index has no statistics either, so the planner values those filters at its default guess: it reads the runs of the project backwards from the most recent one and discards what does not match, and the count, which no LIMIT bounds, reads all of them whatever page was asked for.

The sha index is not bounded to a project: a sha names one repository, so it is selective on its own, and left unbounded it serves the search across projects too. The workflow index leads with the project and carries started behind its two equality columns, which keeps the count of a filtered search inside the index. It does not spare the sort before PostgreSQL 17, where a value list on a column that is not the first of an index leaves the scan unordered; what it spares is the runs of every other workflow.

The builds are CONCURRENTLY, since runs are written to this table constantly, and so cannot go through create_index(): a function always runs inside a transaction, which a concurrent build refuses.

The commit and workflow filters had no test of their own. They have one now.

@ovh/cds
