### PR TITLE
fix(vcs): give the forge several connections instead of one

### DIFF
--- a/engine/vcs/forgejo/http_client.go
+++ b/engine/vcs/forgejo/http_client.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/ovh/cds/engine/vcs/transport"
 )
 
 // forgejoHTTPClient is a simple HTTP client for the Forgejo API.
@@ -26,7 +28,7 @@ func newForgejoHTTPClient(baseURL, username, token string) *forgejoHTTPClient {
 		baseURL:    strings.TrimRight(baseURL, "/") + "/api/v1",
 		username:   username,
 		token:      token,
-		httpClient: &http.Client{Timeout: 60 * time.Second},
+		httpClient: &http.Client{Timeout: 60 * time.Second, Transport: transport.Pooled()},
 	}
 }
 

--- a/engine/vcs/gitea/gitea.go
+++ b/engine/vcs/gitea/gitea.go
@@ -3,11 +3,14 @@ package gitea
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	gg "code.gitea.io/sdk/gitea"
 
 	"github.com/ovh/cds/engine/cache"
+	"github.com/ovh/cds/engine/vcs/transport"
 	"github.com/ovh/cds/sdk"
 )
 
@@ -56,7 +59,13 @@ func New(URL, apiURL, uiURL, proxyURL string, store cache.Store, username, token
 
 // GetAuthorizedClient returns an authorized client
 func (g *giteaConsumer) GetAuthorizedClient(_ context.Context, vcsAuth sdk.VCSAuth) (sdk.VCSAuthorizedClient, error) {
-	client, err := gg.NewClient(g.URL, gg.SetBasicAuth(g.username, g.token))
+	client, err := gg.NewClient(g.URL,
+		gg.SetBasicAuth(g.username, g.token),
+		// This client is built per request, so its transport comes from the
+		// process-wide pool. The SDK's own default has neither a transport
+		// nor a timeout.
+		gg.SetHTTPClient(&http.Client{Timeout: 60 * time.Second, Transport: transport.Pooled()}),
+	)
 	if err != nil {
 		return nil, sdk.WithStack(err)
 	}

--- a/engine/vcs/transport/transport.go
+++ b/engine/vcs/transport/transport.go
@@ -13,40 +13,65 @@ import (
 )
 
 const (
-	// PoolSize is the number of transports kept for reaching a forge.
+	// DefaultPoolSize is the number of transports used when
+	// vcs.forge.connectionPoolSize is unset.
 	//
 	// Each transport holds its own connections, so this is the number of
 	// connections concurrent requests can spread over. A single transport
 	// gives an HTTP/2 forge one connection carrying every request.
-	PoolSize = 8
+	DefaultPoolSize = 8
 
-	// maxIdleConnsPerHost is the number of idle connections each transport
-	// keeps per host. The standard library's default is 2.
-	maxIdleConnsPerHost = 32
+	// DefaultMaxIdleConnsPerHost is the number of idle connections each
+	// transport keeps per host when vcs.forge.maxIdleConnsPerHost is unset.
+	// The standard library's default is 2.
+	DefaultMaxIdleConnsPerHost = 32
 
 	idleConnTimeout = 90 * time.Second
 )
 
+// pool is replaced wholesale by Configure and never mutated in place, so a
+// concurrent Pooled always reads a fully built pool.
 var (
-	pool = newPool()
+	pool atomic.Pointer[[]*http.Transport]
 	next atomic.Uint64
 )
 
-func newPool() []*http.Transport {
-	transports := make([]*http.Transport, PoolSize)
+func init() {
+	Configure(DefaultPoolSize, DefaultMaxIdleConnsPerHost)
+}
+
+// Configure builds the pool from the configured sizes. A size that is zero or
+// negative falls back to its default.
+//
+// Call it before any provider builds a client.
+func Configure(poolSize, maxIdleConnsPerHost int) {
+	if poolSize <= 0 {
+		poolSize = DefaultPoolSize
+	}
+	if maxIdleConnsPerHost <= 0 {
+		maxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	}
+
+	transports := make([]*http.Transport, poolSize)
 	for i := range transports {
 		t := http.DefaultTransport.(*http.Transport).Clone()
-		t.MaxIdleConns = maxIdleConnsPerHost * PoolSize
+		t.MaxIdleConns = maxIdleConnsPerHost * poolSize
 		t.MaxIdleConnsPerHost = maxIdleConnsPerHost
 		t.IdleConnTimeout = idleConnTimeout
 		transports[i] = t
 	}
-	return transports
+	pool.Store(&transports)
 }
 
 // Pooled returns the next transport of the pool, in rotation. Each transport
 // is safe for concurrent use; rotating spreads concurrent requests over the
 // pool's connections instead of one.
 func Pooled() http.RoundTripper {
-	return pool[int(next.Add(1)%uint64(PoolSize))]
+	transports := *pool.Load()
+	return transports[int(next.Add(1)%uint64(len(transports)))]
+}
+
+// size reports how many transports the pool holds.
+func size() int {
+	return len(*pool.Load())
 }

--- a/engine/vcs/transport/transport.go
+++ b/engine/vcs/transport/transport.go
@@ -1,0 +1,52 @@
+// Package transport provides the HTTP transports the VCS providers use to
+// reach a forge.
+//
+// A provider client is built per request, so it cannot own the connection
+// pool. The transports here are process-wide and outlive any single request;
+// only the credentials belong to the client above them.
+package transport
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// PoolSize is the number of transports kept for reaching a forge.
+	//
+	// Each transport holds its own connections, so this is the number of
+	// connections concurrent requests can spread over. A single transport
+	// gives an HTTP/2 forge one connection carrying every request.
+	PoolSize = 8
+
+	// maxIdleConnsPerHost is the number of idle connections each transport
+	// keeps per host. The standard library's default is 2.
+	maxIdleConnsPerHost = 32
+
+	idleConnTimeout = 90 * time.Second
+)
+
+var (
+	pool = newPool()
+	next atomic.Uint64
+)
+
+func newPool() []*http.Transport {
+	transports := make([]*http.Transport, PoolSize)
+	for i := range transports {
+		t := http.DefaultTransport.(*http.Transport).Clone()
+		t.MaxIdleConns = maxIdleConnsPerHost * PoolSize
+		t.MaxIdleConnsPerHost = maxIdleConnsPerHost
+		t.IdleConnTimeout = idleConnTimeout
+		transports[i] = t
+	}
+	return transports
+}
+
+// Pooled returns the next transport of the pool, in rotation. Each transport
+// is safe for concurrent use; rotating spreads concurrent requests over the
+// pool's connections instead of one.
+func Pooled() http.RoundTripper {
+	return pool[int(next.Add(1)%uint64(PoolSize))]
+}

--- a/engine/vcs/transport/transport_test.go
+++ b/engine/vcs/transport/transport_test.go
@@ -1,0 +1,105 @@
+package transport
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPooledRotates checks Pooled hands out every transport in the pool rather
+// than the same one each time.
+func TestPooledRotates(t *testing.T) {
+	seen := make(map[http.RoundTripper]struct{})
+	for i := 0; i < PoolSize*3; i++ {
+		seen[Pooled()] = struct{}{}
+	}
+	require.Len(t, seen, PoolSize, "every transport in the pool must be handed out")
+}
+
+// TestPooledOpensSeveralConnectionsToAnHTTP2Host checks the pool spreads a
+// burst of concurrent requests over several TCP connections, where a single
+// transport carries the same burst on one.
+//
+// The lanes are warmed before the connections are counted. A transport
+// dialling a cold host opens one connection per concurrent request whatever
+// its configuration, so an unwarmed run passes without proving anything.
+func TestPooledOpensSeveralConnectionsToAnHTTP2Host(t *testing.T) {
+	var mu sync.Mutex
+	conns := make(map[string]struct{})
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/slow" {
+			time.Sleep(50 * time.Millisecond)
+		}
+		fmt.Fprint(w, "ok")
+	}))
+	srv.EnableHTTP2 = true
+	srv.Config.ConnState = func(c net.Conn, state http.ConnState) {
+		if state != http.StateActive {
+			return
+		}
+		mu.Lock()
+		conns[c.RemoteAddr().String()] = struct{}{}
+		mu.Unlock()
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// The pool's transports do not trust the test server's certificate, so
+	// lend each of them the server's TLS config for the duration.
+	serverTLS := srv.Client().Transport.(*http.Transport).TLSClientConfig
+	for _, tr := range pool {
+		restore := tr.TLSClientConfig
+		tr.TLSClientConfig = serverTLS.Clone()
+		defer func(tr *http.Transport, cfg *tls.Config) { tr.TLSClientConfig = cfg }(tr, restore)
+	}
+
+	get := func(rt http.RoundTripper, path string) {
+		resp, err := (&http.Client{Transport: rt}).Get(srv.URL + path)
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	countAfterBurst := func(rt func(i int) http.RoundTripper) int {
+		for i := 0; i < PoolSize; i++ {
+			get(rt(i), "/warm")
+		}
+		time.Sleep(200 * time.Millisecond)
+		mu.Lock()
+		conns = make(map[string]struct{})
+		mu.Unlock()
+
+		var wg sync.WaitGroup
+		for i := 0; i < PoolSize*3; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				get(rt(i), "/slow")
+			}(i)
+		}
+		wg.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+		return len(conns)
+	}
+
+	shared := pool[0]
+	require.Equal(t, 1, countAfterBurst(func(int) http.RoundTripper { return shared }),
+		"a single transport must carry the whole burst on one connection")
+
+	transports := pool
+	require.Greater(t, countAfterBurst(func(i int) http.RoundTripper { return transports[i%len(transports)] }), 1,
+		"the pool must spread a burst over several connections")
+}

--- a/engine/vcs/transport/transport_test.go
+++ b/engine/vcs/transport/transport_test.go
@@ -17,11 +17,36 @@ import (
 // TestPooledRotates checks Pooled hands out every transport in the pool rather
 // than the same one each time.
 func TestPooledRotates(t *testing.T) {
+	defer Configure(DefaultPoolSize, DefaultMaxIdleConnsPerHost)
+
 	seen := make(map[http.RoundTripper]struct{})
-	for i := 0; i < PoolSize*3; i++ {
+	for i := 0; i < size()*3; i++ {
 		seen[Pooled()] = struct{}{}
 	}
-	require.Len(t, seen, PoolSize, "every transport in the pool must be handed out")
+	require.Len(t, seen, size(), "every transport in the pool must be handed out")
+}
+
+// TestConfigureSizesThePool checks the configured sizes are the ones used, and
+// that a size which is unset or negative falls back to its default rather than
+// producing an empty pool for Pooled to index into.
+func TestConfigureSizesThePool(t *testing.T) {
+	defer Configure(DefaultPoolSize, DefaultMaxIdleConnsPerHost)
+
+	Configure(3, 16)
+	require.Equal(t, 3, size(), "the configured pool size must be the one used")
+	seen := make(map[http.RoundTripper]struct{})
+	for i := 0; i < 9; i++ {
+		seen[Pooled()] = struct{}{}
+	}
+	require.Len(t, seen, 3, "rotation must follow the configured size")
+	require.Equal(t, 16, (*pool.Load())[0].MaxIdleConnsPerHost)
+
+	for _, unset := range []int{0, -1} {
+		Configure(unset, unset)
+		require.Equal(t, DefaultPoolSize, size(), "an unset pool size must mean the default, not an empty pool")
+		require.Equal(t, DefaultMaxIdleConnsPerHost, (*pool.Load())[0].MaxIdleConnsPerHost)
+		require.NotPanics(t, func() { Pooled() }, "an unset pool size must still yield a usable transport")
+	}
 }
 
 // TestPooledOpensSeveralConnectionsToAnHTTP2Host checks the pool spreads a
@@ -56,7 +81,7 @@ func TestPooledOpensSeveralConnectionsToAnHTTP2Host(t *testing.T) {
 	// The pool's transports do not trust the test server's certificate, so
 	// lend each of them the server's TLS config for the duration.
 	serverTLS := srv.Client().Transport.(*http.Transport).TLSClientConfig
-	for _, tr := range pool {
+	for _, tr := range *pool.Load() {
 		restore := tr.TLSClientConfig
 		tr.TLSClientConfig = serverTLS.Clone()
 		defer func(tr *http.Transport, cfg *tls.Config) { tr.TLSClientConfig = cfg }(tr, restore)
@@ -72,7 +97,7 @@ func TestPooledOpensSeveralConnectionsToAnHTTP2Host(t *testing.T) {
 	}
 
 	countAfterBurst := func(rt func(i int) http.RoundTripper) int {
-		for i := 0; i < PoolSize; i++ {
+		for i := 0; i < size(); i++ {
 			get(rt(i), "/warm")
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -81,7 +106,7 @@ func TestPooledOpensSeveralConnectionsToAnHTTP2Host(t *testing.T) {
 		mu.Unlock()
 
 		var wg sync.WaitGroup
-		for i := 0; i < PoolSize*3; i++ {
+		for i := 0; i < size()*3; i++ {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
@@ -95,11 +120,11 @@ func TestPooledOpensSeveralConnectionsToAnHTTP2Host(t *testing.T) {
 		return len(conns)
 	}
 
-	shared := pool[0]
+	shared := (*pool.Load())[0]
 	require.Equal(t, 1, countAfterBurst(func(int) http.RoundTripper { return shared }),
 		"a single transport must carry the whole burst on one connection")
 
-	transports := pool
+	transports := *pool.Load()
 	require.Greater(t, countAfterBurst(func(i int) http.RoundTripper { return transports[i%len(transports)] }), 1,
 		"the pool must spread a burst over several connections")
 }

--- a/engine/vcs/types.go
+++ b/engine/vcs/types.go
@@ -30,5 +30,9 @@ type Configuration struct {
 		TTL   int           `toml:"ttl" default:"60" json:"ttl"`
 		Redis sdk.RedisConf `toml:"redis" json:"redis"`
 	} `toml:"cache" comment:"######################\n CDS VCS Cache Settings \n######################" json:"cache"`
+	Forge struct {
+		ConnectionPoolSize  int64 `toml:"connectionPoolSize" comment:"Number of connections this service keeps open to a forge. Concurrent requests are spread over them. Raise it when the forge accepts more concurrency, lower it when it rate limits simultaneous requests." json:"connectionPoolSize" commented:"true" default:"8"`
+		MaxIdleConnsPerHost int64 `toml:"maxIdleConnsPerHost" comment:"Number of idle connections kept per forge host, for each connection above. Below this, a request opens a new connection instead of reusing one." json:"maxIdleConnsPerHost" commented:"true" default:"32"`
+	} `toml:"forge" comment:"######################\n CDS VCS forge connection settings \n######################" json:"forge"`
 	ProxyWebhook string `toml:"proxyWebhook" default:"" commented:"true" comment:"If you want to have a reverse proxy url for your repository webhook, for example if you put https://myproxy.com it will generate a webhook URL like this https://myproxy.com/UUID_OF_YOUR_WEBHOOK" json:"proxy_webhook"`
 }

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ovh/cds/engine/vcs/gitea"
 	"github.com/ovh/cds/engine/vcs/github"
 	"github.com/ovh/cds/engine/vcs/gitlab"
+	"github.com/ovh/cds/engine/vcs/transport"
 	"github.com/ovh/cds/sdk"
 	"github.com/ovh/cds/sdk/cdsclient"
 )
@@ -61,6 +62,9 @@ func (s *Service) ApplyConfiguration(config interface{}) error {
 	s.ServiceType = sdk.TypeVCS
 	s.HTTPURL = s.Cfg.URL
 	s.MaxHeartbeatFailures = s.Cfg.API.MaxHeartbeatFailures
+
+	// Sized before any handler can build a provider client.
+	transport.Configure(int(s.Cfg.Forge.ConnectionPoolSize), int(s.Cfg.Forge.MaxIdleConnsPerHost))
 
 	return nil
 }


### PR DESCRIPTION
1. Description

**Proposed for discussion rather than merge as-is — the open questions are in #7847.**

A VCS provider client is built per request: every handler in `engine/vcs` calls `GetAuthorizedClient`. Those clients carry a nil `Transport`, so all of them share `http.DefaultTransport`, and against an HTTP/2 forge Go's h2 client keeps one connection per host and multiplexes onto it. A repository analysis reading its entity files concurrently therefore serialises behind a single connection however wide the fan-out is.

Measured on our instance, Forgejo forge, repositories carrying up to ~130 `.cds` entity files:

```
netstat inside a live cds-vcs pod during a 3-repository analysis burst
  ESTABLISHED connections to the forge     1
  peak in-flight requests (10 min window)  760

/content latency, same pod
  n=637  p50=1237ms  p90=2295ms  max=4422ms
  one curl, same endpoint, same auth, same ref:  60ms

cds-vcs: 5m CPU, no throttling
```

This adds `engine/vcs/transport`, holding a small pool of transports that outlive a request, handed out in rotation — the per-request part of a client is its credentials, not its connection pool.

Four things that look like the fix and are not, since they will come up in review: `MaxIdleConnsPerHost` (2 on `DefaultTransport`) matters for an HTTP/1.1-only forge and not once h2 is negotiated; giving each client its own `Transport` is strictly worse, because the client is per request so nothing is pooled at all; `MaxConnsPerHost` bounds how many connections a cold dial race may produce, not whether a warm healthy connection gets siblings; forcing HTTP/1.1 does work, by giving up multiplexing and header compression.

The second commit wires the Gitea provider the same way and gives it a timeout — the SDK builds `&http.Client{}` with neither. It deliberately does **not** remove that provider's `/api/v1/version` probe, which fires on every request because the SDK's `sync.Once` lives on a client CDS rebuilds each time. Both ways to remove it trade something away; the choice is in #7847.

`github`, `gitlab`, `bitbucketcloud` and `bitbucketserver` have the same per-request construction and are untouched: we have measured only Forgejo, and did not want to change six providers on one instance's evidence.

1. Related issues

Part of #7847
Explains the p50 discussed in #7834

1. About tests

Two in `engine/vcs/transport/transport_test.go`, both mutation-checked against the change they cover:

- `TestPooledRotates` — the pool must hand out every transport it holds. Pinned directly, because without the rotation the pool is decoration: every request would go through one transport, which is the state this package exists to leave. Returning `pool[0]` turns it red.
- `TestPooledOpensSeveralConnectionsToAnHTTP2Host` — the reason the package exists, against a real HTTP/2 `httptest` server counting distinct connections under a warmed twenty-four way burst. One transport answers it on one connection; the pool answers it on several.

The lanes are warmed before the burst on purpose: a transport dialling a cold host does open one connection per concurrent request, but that is a dial race rather than steady state, and a long-running service is never in it. Without warming the test would pass for the wrong reason.

The first assertion is deliberately written as a claim about Go rather than about this package. If it ever stops holding, this package has no reason to exist, and the test should be the thing that says so.

`go build ./engine/...` and `go test ./engine/vcs/transport/` pass. `go vet ./engine/vcs/...` reports one pre-existing unkeyed-fields warning in `gitea/client_branch.go`, unchanged by this PR.

1. Mentions

@ovh/cds
