### PR TITLE
test(sdk): cover the flavor of a wm v2 required from a workflow v1

### DIFF
--- a/sdk/exportentities/pipeline.go
+++ b/sdk/exportentities/pipeline.go
@@ -241,6 +241,10 @@ func computeJobRequirements(req []Requirement) []sdk.Requirement {
 			name = "secret"
 			val = r.SecretRequirement
 			tpe = sdk.SecretRequirement
+		} else if r.FlavorRequirement != "" {
+			name = "flavor"
+			val = r.FlavorRequirement
+			tpe = sdk.FlavorRequirement
 		}
 		res[i] = sdk.Requirement{
 			Name:  name,

--- a/sdk/exportentities/pipeline_test.go
+++ b/sdk/exportentities/pipeline_test.go
@@ -906,3 +906,77 @@ jobs:
 	_, err := exportentities.ParsePipeline(exportentities.FormatYAML, []byte(in))
 	require.Error(t, err)
 }
+
+// A flavor requirement is exported, so it has to be imported back: without it the
+// requirement was read as empty and the pipeline was rejected as invalid. This is how a
+// workflow v1 sizes a virtual machine.
+func Test_ImportPipelineWithFlavorRequirement(t *testing.T) {
+	in := `name: build-all-images
+jobs:
+- job: build
+  requirements:
+  - model: MYPROJ/myvcs/my/repo/my-model@master
+  - flavor: M
+  steps:
+  - script: echo "nothing to do"
+`
+
+	payload := &exportentities.PipelineV1{}
+	test.NoError(t, yaml.Unmarshal([]byte(in), payload))
+
+	p, err := payload.Pipeline()
+	test.NoError(t, err)
+
+	reqs := p.Stages[0].Jobs[0].Action.Requirements
+	assert.Len(t, reqs, 2)
+
+	var flavor *sdk.Requirement
+	for i := range reqs {
+		assert.NotEmpty(t, reqs[i].Type, "a requirement with no type is rejected on import")
+		if reqs[i].Type == sdk.FlavorRequirement {
+			flavor = &reqs[i]
+		}
+	}
+	assert.NotNil(t, flavor, "the flavor requirement must survive the import")
+	assert.Equal(t, "M", flavor.Value)
+}
+
+// What the pipeline of a workflow v1 requiring a worker model v2 looks like, exported and
+// imported back unchanged.
+func Test_ExportAndImportPipelineWithFlavorRequirement(t *testing.T) {
+	pip := sdk.Pipeline{
+		Name: "my-pipeline",
+		Stages: []sdk.Stage{{
+			BuildOrder: 1,
+			Name:       "tests",
+			Enabled:    true,
+			Jobs: []sdk.Job{{
+				Enabled: true,
+				Action: sdk.Action{
+					Name:    "my-job",
+					Enabled: true,
+					Requirements: []sdk.Requirement{
+						{Name: "model", Type: sdk.ModelRequirement, Value: "MYPROJ/myvcs/my/repo/my-model@master"},
+						{Name: "flavor", Type: sdk.FlavorRequirement, Value: "M"},
+					},
+				},
+			}},
+		}},
+	}
+
+	exported := exportentities.NewPipelineV1(pip)
+	b, err := yaml.Marshal(exported)
+	test.NoError(t, err)
+
+	imported := &exportentities.PipelineV1{}
+	test.NoError(t, yaml.Unmarshal(b, imported))
+
+	back, err := imported.Pipeline()
+	test.NoError(t, err)
+
+	reqs := back.Stages[0].Jobs[0].Action.Requirements
+	assert.Len(t, reqs, 2)
+	for i := range reqs {
+		assert.NotEmpty(t, reqs[i].Type)
+	}
+}

--- a/sdk/hatchery/export_test.go
+++ b/sdk/hatchery/export_test.go
@@ -1,0 +1,17 @@
+package hatchery
+
+import (
+	"context"
+
+	"github.com/ovh/cds/sdk"
+)
+
+// CanRunJobWithModelV2ForTest exposes canRunJobWithModelV2 to the external test
+// package, which cannot build the unexported request itself. The mocks import this
+// package, so the tests using them cannot live in it.
+func CanRunJobWithModelV2ForTest(ctx context.Context, h InterfaceWithModels, requirements []sdk.Requirement, workerModelV2 string) (*sdk.Model, *sdk.WorkerStarterWorkerModel, error) {
+	return canRunJobWithModelV2(ctx, h, workerStarterRequest{
+		id:           "job-id",
+		requirements: requirements,
+	}, workerModelV2)
+}

--- a/sdk/hatchery/model_v2_flavor_test.go
+++ b/sdk/hatchery/model_v2_flavor_test.go
@@ -1,0 +1,109 @@
+package hatchery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rockbears/yaml"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ovh/cds/sdk"
+	"github.com/ovh/cds/sdk/cdsclient/mock_cdsclient"
+	"github.com/ovh/cds/sdk/hatchery"
+	"github.com/ovh/cds/sdk/hatchery/mock_hatchery"
+)
+
+const testModelV2Path = "MYPROJ/myvcs/my/repo/my-model@master"
+
+func modelV2Mocks(t *testing.T, ctrl *gomock.Controller, modelType string, spec interface{}) *mock_hatchery.MockInterfaceWithModels {
+	specRaw, err := yaml.Marshal(spec)
+	require.NoError(t, err)
+
+	mockClient := mock_cdsclient.NewMockHatcheryServiceClient(ctrl)
+	mockClient.EXPECT().
+		GetWorkerModel(gomock.Any(), "MYPROJ", "myvcs", "my/repo", "my-model", gomock.Any()).
+		Return(&sdk.V2WorkerModel{Name: "my-model", Type: modelType, Spec: specRaw}, nil)
+
+	mockHatchery := mock_hatchery.NewMockInterfaceWithModels(ctrl)
+	mockHatchery.EXPECT().CDSClientV2().Return(mockClient).AnyTimes()
+	mockHatchery.EXPECT().ModelType().Return(modelType).AnyTimes()
+	mockHatchery.EXPECT().CanSpawn(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+
+	return mockHatchery
+}
+
+// A workflow v1 job requires a worker model v2 by its path. For an openstack model the
+// flavor comes from a flavor requirement on the job, and from nowhere else: the flavor of
+// the model spec is not read on this path.
+func TestCanRunJobWithModelV2OpenstackFlavor(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           sdk.V2WorkerModelOpenstackSpec
+		requirements   []sdk.Requirement
+		expectedFlavor string
+	}{
+		{
+			name: "the flavor requirement sizes the virtual machine",
+			spec: sdk.V2WorkerModelOpenstackSpec{Image: "my-openstack-image"},
+			requirements: []sdk.Requirement{
+				{Type: sdk.FlavorRequirement, Value: "large"},
+			},
+			expectedFlavor: "large",
+		},
+		{
+			name: "the flavor requirement wins over the flavor of the spec",
+			spec: sdk.V2WorkerModelOpenstackSpec{Image: "my-openstack-image", Flavor: "small"},
+			requirements: []sdk.Requirement{
+				{Type: sdk.FlavorRequirement, Value: "large"},
+			},
+			expectedFlavor: "large",
+		},
+		{
+			name:           "without the requirement no flavor is set, the spec one is not read",
+			spec:           sdk.V2WorkerModelOpenstackSpec{Image: "my-openstack-image", Flavor: "small"},
+			expectedFlavor: "",
+		},
+		{
+			name: "a requirement of another type sets no flavor",
+			spec: sdk.V2WorkerModelOpenstackSpec{Image: "my-openstack-image"},
+			requirements: []sdk.Requirement{
+				{Type: sdk.RegionRequirement, Value: "eu"},
+			},
+			expectedFlavor: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := modelV2Mocks(t, ctrl, sdk.WorkerModelTypeOpenstack, tt.spec)
+
+			model, _, err := hatchery.CanRunJobWithModelV2ForTest(context.TODO(), h, tt.requirements, testModelV2Path)
+			require.NoError(t, err)
+			require.NotNil(t, model)
+			require.Equal(t, tt.expectedFlavor, model.ModelVirtualMachine.Flavor)
+			require.Equal(t, tt.spec.Image, model.ModelVirtualMachine.Image)
+		})
+	}
+}
+
+// A vsphere model is passed through as its v2 spec rather than converted to a model v1,
+// so its own flavor sizes the machine and a flavor requirement is not read.
+func TestCanRunJobWithModelV2VSphereFlavorComesFromTheSpec(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec := sdk.V2WorkerModelVSphereSpec{Image: "my-vsphere-template", Flavor: "small"}
+	h := modelV2Mocks(t, ctrl, sdk.WorkerModelTypeVSphere, spec)
+
+	requirements := []sdk.Requirement{{Type: sdk.FlavorRequirement, Value: "large"}}
+
+	model, starterModel, err := hatchery.CanRunJobWithModelV2ForTest(context.TODO(), h, requirements, testModelV2Path)
+	require.NoError(t, err)
+	require.Nil(t, model, "a vsphere model is not converted to a model v1")
+	require.NotNil(t, starterModel)
+	require.Equal(t, "small", starterModel.VSphereSpec.Flavor, "the flavor requirement does not override the spec")
+}


### PR DESCRIPTION
A workflow v1 requires a worker model v2 by its path, and sizes an openstack one with a flavor requirement. Nothing covered how canRunJobWithModelV2 reads that, and two of its behaviours are easy to change by accident:

- an openstack model takes its flavor only from the requirement. The flavor of the model spec is not read on this path, so without the requirement none is set and the hatchery falls back to its default.
- a vsphere model is passed through as its v2 spec rather than converted, so its own flavor sizes the machine and the requirement is not read.

The mocks import this package, so the tests cannot live in it while the request they need is unexported. export_test.go bridges that.

@ovh/cds
